### PR TITLE
Fix up + bump main: Kotlin 2.4.0, ksrpc 1.1.1, v0.2.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.2.2
+version=0.2.3
 group=com.monkopedia.kplusplus
 signing.gnupg.keyName=5B83421E2338B907
 kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "2.3.0"
+kotlin = "2.4.0"
 coroutines = "1.10.2"
 serialization = "1.10.0"
-ksrpc = "0.11.0"
+ksrpc = "1.1.1"
 clikt = "5.1.0"
 guava = "33.5.0-jre"
 ktlint-gradle = "14.0.1"

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.jetbrains.kotlin.gradle.plugin.mpp.DisableCacheInKotlinVersion
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCacheApi
+
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlin.serialization)
@@ -52,6 +55,13 @@ kotlin {
     hostTarget.apply {
         binaries {
             executable()
+            all {
+                @OptIn(KotlinNativeCacheApi::class)
+                disableNativeCache(
+                    version = DisableCacheInKotlinVersion.`2_4_0`,
+                    reason = "clikt 5.1.0 duplicate-symbol with cached native libs",
+                )
+            }
         }
         compilations.all {
             compileTaskProvider.configure {

--- a/krapper_gen/src/commonMain/kotlin/KrapperService.kt
+++ b/krapper_gen/src/commonMain/kotlin/KrapperService.kt
@@ -15,7 +15,7 @@
  */
 package com.monkopedia.krapper
 
-import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import kotlinx.serialization.Serializable
@@ -30,7 +30,7 @@ data class IndexRequest(
 )
 
 @KsService
-interface KrapperService : RpcService {
+interface KrapperService : RpcBidiService {
     @KsMethod("/ping")
     suspend fun ping(message: String): String
 
@@ -51,7 +51,7 @@ interface KrapperService : RpcService {
 }
 
 @KsService
-interface IndexedService : RpcService {
+interface IndexedService : RpcBidiService {
     @KsMethod("/filter")
     suspend fun filterAndResolve(filter: FilterDefinition)
 

--- a/krapper_gen/src/commonMain/kotlin/MappingService.kt
+++ b/krapper_gen/src/commonMain/kotlin/MappingService.kt
@@ -19,6 +19,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedCType
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedType
+import com.monkopedia.ksrpc.RpcBidiService
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
@@ -55,7 +56,7 @@ data class MapRequest(val parent: ResolvedElement, val childIndex: Int) {
 }
 
 @KsService
-interface MappingService : RpcService {
+interface MappingService : RpcBidiService {
 
     @KsMethod("/get_filter")
     suspend fun getFilter(resolver: ResolverService): FilterDefinition

--- a/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedClass.kt
+++ b/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedClass.kt
@@ -73,7 +73,7 @@ data class ResolvedClass(
 
     private fun calculateNotEmpty(): Boolean = baseClass != null || children.any {
         ((it as? ResolvedMethod)?.methodType != SIZE_OF) &&
-        ((it as? ResolvedMethod)?.methodType != ALIGN_OF) &&
+            ((it as? ResolvedMethod)?.methodType != ALIGN_OF) &&
             ((it as? ResolvedConstructor)?.children?.isNotEmpty() != false)
     }
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -68,10 +68,10 @@ import com.monkopedia.krapper.generator.builders.type
 import com.monkopedia.krapper.generator.resolvedmodel.AllocationStyle.DIRECT
 import com.monkopedia.krapper.generator.resolvedmodel.AllocationStyle.STACK
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType.ALIGN_OF
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.CONSTRUCTOR
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.DESTRUCTOR
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.METHOD
-import com.monkopedia.krapper.generator.resolvedmodel.MethodType.ALIGN_OF
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.SIZE_OF
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.STATIC
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.STATIC_OP
@@ -358,7 +358,12 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
     }
 
-    fun KotlinCodeBuilder.onGenerate(cls: ResolvedClass, method: ResolvedMethod, size: LocalVar?, align: LocalVar?) {
+    fun KotlinCodeBuilder.onGenerate(
+        cls: ResolvedClass,
+        method: ResolvedMethod,
+        size: LocalVar? = null,
+        align: LocalVar? = size
+    ) {
         val uniqueCName =
             extensionMethod(pkg, method.uniqueCName ?: error("Unnamed method $method"))
         when (method.methodType) {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
@@ -297,7 +297,11 @@ open class WrappedMethod(
     }
 
     protected open suspend fun thizArg(resolverContext: ResolveContext): List<ResolvedArgument>? {
-        if (methodType == SIZE_OF || methodType == ALIGN_OF || methodType == STATIC) return emptyList()
+        if (methodType == SIZE_OF || methodType == ALIGN_OF ||
+            methodType == STATIC
+        ) {
+            return emptyList()
+        }
         return listOf(createThisArg(resolverContext) ?: return null)
     }
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedType.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedType.kt
@@ -27,6 +27,7 @@ import clang.CXTypeKind.CXType_RValueReference
 import clang.CXTypeKind.CXType_Unexposed
 import com.monkopedia.krapper.generator.ResolveContext
 import com.monkopedia.krapper.generator.ResolverBuilder
+import com.monkopedia.krapper.generator.canonicalType
 import com.monkopedia.krapper.generator.fullyQualified
 import com.monkopedia.krapper.generator.getTemplateArgumentType
 import com.monkopedia.krapper.generator.isConstQualifiedType
@@ -34,7 +35,6 @@ import com.monkopedia.krapper.generator.kind
 import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedKotlinType
 import com.monkopedia.krapper.generator.model.typeToKotlinType
-import com.monkopedia.krapper.generator.canonicalType
 import com.monkopedia.krapper.generator.numTemplateArguments
 import com.monkopedia.krapper.generator.pointeeType
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement

--- a/krapper_gen/src/nativeTest/kotlin/KotlinCodeTests.kt
+++ b/krapper_gen/src/nativeTest/kotlin/KotlinCodeTests.kt
@@ -78,6 +78,7 @@ class KotlinCodeTests {
             |import kotlinx.cinterop.COpaquePointer
             |import kotlinx.cinterop.MemScope
             |import kotlinx.cinterop.interpretCPointer
+            |import test.pkg.TestLib_EmptyClass_align_of
             |import test.pkg.TestLib_EmptyClass_size_of
             |
             |// BEGIN KRAPPER GEN for TestLib::EmptyClass
@@ -92,8 +93,13 @@ class KotlinCodeTests {
             |                return TestLib_EmptyClass_size_of()
             |            }
             |
+            |        val align: Int
+            |            inline get() {
+            |                return TestLib_EmptyClass_align_of()
+            |            }
+            |
             |        fun MemScope.EmptyClass_Holder(): EmptyClass {
-            |            val memory: COpaquePointer = (interpretCPointer(alloc(size, size).rawPtr) ?: error("Allocation failed"))
+            |            val memory: COpaquePointer = (interpretCPointer(alloc(size, align).rawPtr) ?: error("Allocation failed"))
             |            return EmptyClass(memory, this)
             |        }
             |    }
@@ -584,6 +590,7 @@ class KotlinCodeTests {
             |import kotlinx.cinterop.COpaquePointer
             |import kotlinx.cinterop.MemScope
             |import kotlinx.cinterop.interpretCPointer
+            |import test.pkg.std_vector_std_string_iterator_align_of
             |import test.pkg.std_vector_std_string_iterator_size_of
             |
             |// BEGIN KRAPPER GEN for std::vector<std::string>::iterator
@@ -598,8 +605,13 @@ class KotlinCodeTests {
             |                return std_vector_std_string_iterator_size_of()
             |            }
             |
+            |        val align: Int
+            |            inline get() {
+            |                return std_vector_std_string_iterator_align_of()
+            |            }
+            |
             |        fun MemScope.Iterator__String_Holder(): Iterator__String {
-            |            val memory: COpaquePointer = (interpretCPointer(alloc(size, size).rawPtr) ?: error("Allocation failed"))
+            |            val memory: COpaquePointer = (interpretCPointer(alloc(size, align).rawPtr) ?: error("Allocation failed"))
             |            return Iterator__String(memory, this)
             |        }
             |    }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -179,4 +179,3 @@ signing {
     useGpgCmd()
     sign(publishing.publications)
 }
-


### PR DESCRIPTION
Resurrect the long-stale `main` (Kotlin 2.3.0 / ksrpc 0.11.0) to a buildable, green state and cut patch release **0.2.3**.

## What changed
- **Versions:** Kotlin 2.3.0 → 2.4.0, ksrpc 0.11.0 → 1.1.1 (`gradle/libs.versions.toml`), `version` 0.2.2 → 0.2.3 (`gradle.properties`).
- **ksrpc 0.11 → 1.1 migration:** the host API is unchanged; the only real delta is that 1.1's compiler plugin enforces service-kind constraints — a `@KsService` that accepts/returns another `@KsService` must extend `RpcBidiService`. Applied to exactly the three flagged interfaces (`KrapperService`, `IndexedService`, `MappingService`); `ResolverService`/`RemoteLogger` stay plain `RpcService` (pure inputs).
- **Kotlin 2.4.0 fixes:** `KotlinWriter.onGenerate` gains defaults `size: LocalVar? = null, align: LocalVar? = size` (`align = size`, not `null` — the method path passes only `size` and goldens expect `alloc(size, size)`); `disableNativeCache` pinned to `2_4_0` (the clikt 5.1.0 duplicate-symbol returns at native link otherwise).
- **Golden refresh:** `testEmptyFile` / `testTemplateNaming` now emit a companion `align` getter + `_align_of` import + `alloc(size, align)`.
- **Pre-existing ktlint-cli 1.8.0 violations** fixed (cosmetic import/line/indent) so `:build` is green.

## Verification (JDK 17)
- `:krapper_gen:nativeTest` — **257 tests, 0 failures**
- `:krapper_gen:compileKotlinNative`, `:linkDebugExecutableNative`, `:krapper_gen:ktlintCheck` — green
- `:plugin:compileKotlin` / `:assemble` / `:ktlintCheck` / `:functionalTest` — green, but `:plugin:functionalTest` runs **only under JDK 21** (the plugin module hardcodes `targetCompatibility = VERSION_21`, pre-existing on `main`, unchanged here)

## Notes for review
- **Java 21 caveat:** unchanged from `main` — flagging since it affects whoever builds the plugin module. Lowering the plugin's Java target to 17 is deliberately out of scope for this patch.
- **Publish gating:** this PR is the code-landing step only. Publishing `0.2.3` to Maven Central is a separate, gated post-merge action.
- Pre-existing, unrelated: `:testlib_kotlin:cinteropTestlibNative` fails on a clean checkout (points at a gitignored generated `.def`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)