### PR TITLE
Enable auto-publish + bump vanniktech 0.36.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ ktlint-gradle = "14.0.1"
 ktlint-cli = "1.8.0"
 klinker = "0.2.0"
 gradle-plugin-publish = "2.1.0"
-vannik = "0.35.0"
+vannik = "0.36.0"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -171,7 +171,7 @@ mavenPublishing {
             url.set("http://github.com/Monkopedia/kplusplus/")
         }
     }
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
 }
 


### PR DESCRIPTION
Small publish-setup change so the `0.2.3` release (and future releases) propagate to Maven Central **fully automatically**, then bump the publish plugin to latest.

## What changed (2 lines)
- `plugin/build.gradle.kts`: `publishToMavenCentral()` → `publishToMavenCentral(automaticRelease = true)`. Previously a publish run *staged* the deployment on the Sonatype Central Portal and waited for a manual "Release" click; with `automaticRelease = true` it uploads **and** releases in one step, so `publish.yaml` (which runs `:plugin:publish` on the `release` event) now fully publishes without a manual portal step.
- `gradle/libs.versions.toml`: vanniktech maven-publish `0.35.0` → `0.36.0` (latest).

## Why it's safe under 0.36.0
- **No Dokka** in the plugin module, so 0.36.0's "Dokka v1 removed" change doesn't apply.
- **Gradle already 9.4.1** on main (ahead of 0.36.0's raised minimum) — no Gradle upgrade needed.
- Kotlin already 2.4.0 (this PR sits on top of the 0.2.3 bump).

## Verification (JDK 21)
- `:plugin:assemble` — **BUILD SUCCESSFUL**
- `:plugin:tasks` — both `publishToMavenCentral` and `publishAndReleaseToMavenCentral` present; `automaticRelease = true` resolves cleanly (no API break).

This is the prerequisite for cutting the `v0.2.3` release — once this lands, the release flow auto-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)