### PR TITLE
Soundness: drop-ledger makes skip-not-crash binding drops visible (#6)

### DIFF
--- a/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
+++ b/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
@@ -46,5 +46,10 @@ data class KrapperConfig(
     // behavior: top-level user types -> package `root`, C++ namespaces -> their
     // bare path (`std`, `geo`). When set (e.g. "com.acme.app"), every generated
     // binding's package becomes <rootPackage> + the C++ namespace path.
-    val rootPackage: String? = null
+    val rootPackage: String? = null,
+    // When true, a run that dropped ANY unmodelable symbol (skip-not-crash) fails
+    // after emitting the drop-ledger report, instead of completing leniently. Opt-in
+    // (default false) so existing green runs keep succeeding: drops are always logged
+    // and ledgered, but only this flag turns a drop into a non-zero exit.
+    val failOnDrop: Boolean = false
 )

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -141,6 +141,12 @@ class KrapperGen : CliktCommand() {
             "class name per line; blank lines and lines starting with # are ignored). " +
             "Merged with any --only entries."
     )
+    val failOnDrop by option(
+        "--fail-on-drop",
+        help = "Fail the run (non-zero exit) if the generator dropped any unmodelable " +
+            "symbol (skip-not-crash). Default: lenient — drops are logged + reported in " +
+            "the drop ledger, but the run still succeeds."
+    ).flag()
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -167,7 +173,8 @@ class KrapperGen : CliktCommand() {
                     referencePolicy = referencePolicy,
                     debug = debug,
                     cppStandard = cppStandard,
-                    rootPackage = rootPackage
+                    rootPackage = rootPackage,
+                    failOnDrop = failOnDrop
                 )
             )
             val indexService = service.index(IndexRequest(header, library))

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/DropLedger.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/DropLedger.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+/**
+ * The phase of the generation pipeline a drop happened in. PARSE drops are the
+ * cursor-level skip-not-crash decisions made while building the [WrappedElement]
+ * model (no [ResolveContext] exists yet); RESOLVE drops are made while resolving a
+ * built element against the type graph; DEDUP drops are the post-resolve model
+ * cleanups (e.g. const-overload de-duplication).
+ */
+enum class DropPhase {
+    PARSE,
+    RESOLVE,
+    DEDUP
+}
+
+/**
+ * A single skip-not-crash drop: a symbol the generator could not model and chose to
+ * skip rather than crash on. [symbol] is the best identity available at the drop site
+ * (an element's `toString()`, a type spelling, a cursor name); [reason] is the
+ * human-readable cause; [phase] is which pass dropped it.
+ */
+data class DropRecord(val symbol: String, val reason: String, val phase: DropPhase)
+
+/**
+ * Process-scoped collector for skip-not-crash binding drops.
+ *
+ * The breadth strategy drops unmodelable methods/fields/classes with only a log line.
+ * Each known drop site funnels its `{symbol, reason}` here so a run can report exactly
+ * what it dropped and why — turning "the binding isn't there" from an unanswerable
+ * question ("did C++ not have it, or did the generator drop it?") into a diffable list.
+ *
+ * Modeled as an object (matching the sibling [Log] object and the `rootPackageOverride`
+ * global): the generator runs one request at a time under `runBlocking`, so a shared
+ * collector is the cohesive carrier without threading a ledger handle through every
+ * resolve signature. [reset] clears it between runs (tests and the service path both
+ * call it before a fresh generation).
+ */
+object DropLedger {
+    private val records = mutableListOf<DropRecord>()
+
+    /** The drops recorded so far, in the order they occurred. */
+    val drops: List<DropRecord>
+        get() = records
+
+    /** Record a skip-not-crash drop of [symbol] for [reason] in [phase]. */
+    fun record(symbol: String, reason: String, phase: DropPhase) {
+        records.add(DropRecord(symbol, reason, phase))
+    }
+
+    /** Clear all recorded drops. Call before each fresh generation run. */
+    fun reset() {
+        records.clear()
+    }
+
+    /**
+     * Render the end-of-run drop report: a `requested R / bound B / dropped D` summary
+     * line followed by the dropped symbols and their reasons. [requested] is the
+     * allowlist/instantiation the run was asked for (empty when the run was an
+     * unrestricted DefaultFilter import); [bound] is the set of binding identities that
+     * actually resolved. When an allowlist was supplied, any requested entry that is
+     * neither bound nor explicitly dropped is reported as MISSING (coverage gap).
+     */
+    fun report(requested: Collection<String>, bound: Collection<String>): String = buildString {
+        val boundSet = bound.toSet()
+        appendLine(
+            "Drop ledger: requested ${requested.size} / bound ${boundSet.size} / " +
+                "dropped ${records.size}"
+        )
+        if (records.isNotEmpty()) {
+            appendLine("  Dropped (${records.size}):")
+            for (record in records) {
+                appendLine("    [${record.phase}] ${record.symbol} — ${record.reason}")
+            }
+        }
+        if (requested.isNotEmpty()) {
+            val droppedSymbols = records.map { it.symbol }.toSet()
+            val uncovered = requested.filter { it !in boundSet && it !in droppedSymbols }
+            if (uncovered.isNotEmpty()) {
+                appendLine("  Requested but NOT bound and NOT dropped (${uncovered.size}):")
+                for (entry in uncovered) {
+                    appendLine("    $entry")
+                }
+            }
+        }
+    }.trimEnd('\n')
+
+    /** True when at least one symbol was dropped (used by the opt-in --fail-on-drop gate). */
+    fun hasDrops(): Boolean = records.isNotEmpty()
+}

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -17,6 +17,7 @@ package com.monkopedia.krapper.generator
 
 import com.monkopedia.krapper.AddToChild
 import com.monkopedia.krapper.AddToParent
+import com.monkopedia.krapper.AllowListFilter
 import com.monkopedia.krapper.FilterDefinition
 import com.monkopedia.krapper.IndexRequest
 import com.monkopedia.krapper.IndexedService
@@ -72,10 +73,19 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     // writeTo references these so the generated wrapper #includes the needed std headers.
     private val syntheticHeaders = mutableListOf<String>()
 
+    // What the run was explicitly ASKED to bind: the --only allowlist entries plus each
+    // --instantiate target. The drop-ledger report diffs this against what actually
+    // bound so a coverage gap (requested-but-neither-bound-nor-dropped) is visible. Empty
+    // for an unrestricted DefaultFilter import (every non-std class is requested).
+    private val requested = mutableListOf<String>()
+
     init {
         scope.defer {
             index.dispose()
         }
+        // Start each generation run with a clean ledger so its report reflects only this
+        // run's drops (the collector is process-scoped, shared with any prior run).
+        DropLedger.reset()
         // Root the generated binding packages under config.rootPackage. Must be set
         // BEFORE any resolution (requestInstantiation / filterAndResolve) — a type's
         // Kotlin package is baked into its ResolvedKotlinType at resolve time, so
@@ -101,6 +111,11 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     }
 
     override suspend fun filterAndResolve(filter: FilterDefinition) {
+        // Record the explicit allowlist as the requested set (DefaultFilter requests
+        // everything, so it contributes nothing to diff against).
+        if (filter is AllowListFilter) {
+            requested.addAll(filter.qualifiedNames)
+        }
         Log.i("Parsing headers: ${request.headers}")
         val resolver = scope.parseHeader(
             index,
@@ -128,6 +143,7 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
 
     override suspend fun requestInstantiation(req: InstantiationRequest) {
         val target = "${req.base}<${req.args.joinToString(", ")}>"
+        requested.add(target)
         val forceName = "KrapperForce_" + target
             .replace("::", "_")
             .replace("<", "_")
@@ -330,7 +346,25 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             classes
         )
         writeCppBindingAnnotation(srcDir)
+        reportDrops()
         Log.i("Code generation complete")
+    }
+
+    /**
+     * Emit the drop-ledger report (requested / bound / dropped + the dropped list and any
+     * requested-but-uncovered entries) and, when [KrapperConfig.failOnDrop] is set, fail
+     * the run if anything was dropped. Default (failOnDrop=false) only logs, so existing
+     * green runs are unchanged: drops are surfaced but never fatal unless opted in.
+     */
+    private suspend fun reportDrops() {
+        val bound = classes.filterIsInstance<ResolvedClass>().map { it.type.toString() }
+        Log.i(DropLedger.report(requested, bound))
+        if (config.failOnDrop && DropLedger.hasDrops()) {
+            error(
+                "--fail-on-drop: ${DropLedger.drops.size} symbol(s) were dropped " +
+                    "(see the drop ledger above)"
+            )
+        }
     }
 
     /**

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -137,6 +137,11 @@ suspend fun List<WrappedElement>.resolveAll(
         .withPolicy(policy)
     classes.forEach {
         if (resolveContext.resolve(it.type) == null) {
+            DropLedger.record(
+                it.type.toString(),
+                "Filtered class did not resolve",
+                DropPhase.RESOLVE
+            )
             Log.w("Warning: can't resolve filtered class ${it.type}")
         }
     }
@@ -232,6 +237,11 @@ suspend fun List<WrappedElement>.resolveForcing(
     val pass1 = baseContext.withPolicyKeepingNamer(policy)
     boundClasses.forEach {
         if (pass1.resolve(it.type) == null) {
+            DropLedger.record(
+                it.type.toString(),
+                "Filtered class did not resolve",
+                DropPhase.RESOLVE
+            )
             Log.w("Warning: can't resolve filtered class ${it.type}")
         }
     }
@@ -247,6 +257,11 @@ suspend fun List<WrappedElement>.resolveForcing(
     val pass2 = baseContext.withPolicyKeepingNamer(ReferencePolicy.INCLUDE_MISSING)
     forcingStructs.forEach {
         if (pass2.resolve(it.type) == null) {
+            DropLedger.record(
+                it.type.toString(),
+                "Forcing struct did not resolve",
+                DropPhase.RESOLVE
+            )
             Log.w("Warning: can't resolve forcing struct ${it.type}")
         }
     }
@@ -465,6 +480,16 @@ data class ResolveContext(
         type: WrappedType?,
         message: String
     ): T? {
+        // Ledger every resolve-phase drop so the end-of-run report can diff it against
+        // the requested allowlist. This is the central choke point: every model element
+        // that fails to resolve returns through here, so recording once covers the
+        // method/field/class drop sites uniformly. The (debug-gated) log line stays for
+        // the live KRAPPER_DEBUG_RESOLVE trace.
+        DropLedger.record(
+            symbol = element?.toString() ?: type?.toString() ?: "<unknown>",
+            reason = message,
+            phase = DropPhase.RESOLVE
+        )
         if (debugFilter?.invoke(element, type, message) == true) {
             Log.w("$element failed resolving $type: $message")
         }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
@@ -17,6 +17,8 @@ package com.monkopedia.krapper.generator.model
 
 import clang.CXCursor
 import clang.CXFile
+import com.monkopedia.krapper.generator.DropLedger
+import com.monkopedia.krapper.generator.DropPhase
 import com.monkopedia.krapper.generator.ResolveContext
 import com.monkopedia.krapper.generator.ResolverBuilder
 import com.monkopedia.krapper.generator.includedFile
@@ -205,6 +207,11 @@ class WrappedClass(
             val constOverload = overloads.singleOrNull { it.isConst } ?: return@forEach
             val nonConst = overloads.single { it !== constOverload }
             if (nonConst.isConst) return@forEach
+            DropLedger.record(
+                "$name::${nonConst.name}",
+                "Non-const overload duplicates a const overload (kept the const half)",
+                DropPhase.DEDUP
+            )
             removeChild(nonConst)
         }
     }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
@@ -22,6 +22,8 @@ import clang.CXCursorKind.CXCursor_ClassDecl
 import clang.CXCursorKind.CXCursor_ClassTemplate
 import clang.CXCursorKind.CXCursor_StructDecl
 import clang.CX_CXXAccessSpecifier
+import com.monkopedia.krapper.generator.DropLedger
+import com.monkopedia.krapper.generator.DropPhase
 import com.monkopedia.krapper.generator.ResolveContext
 import com.monkopedia.krapper.generator.ResolverBuilder
 import com.monkopedia.krapper.generator.accessSpecifier
@@ -212,6 +214,12 @@ abstract class WrappedElement(
                         // A nested class inside a NON-template class (`Outer::Inner`) IS
                         // nameable and is NOT dropped.
                         if (value.isNestedInClassTemplate) {
+                            DropLedger.record(
+                                value.spelling.toKString() ?: "<unnamed class>",
+                                "Class nested inside a class template " +
+                                    "(unnameable without template args)",
+                                DropPhase.PARSE
+                            )
                             println(
                                 "WARN skip-not-crash: dropping class " +
                                     "'${value.spelling.toKString()}' nested inside a class " +
@@ -401,6 +409,12 @@ abstract class WrappedElement(
                 // escape as a fatal crash. When parsing everything, a single
                 // unmodelable cursor must drop-and-log: if this reference is genuinely
                 // needed it resurfaces during resolution, where it fails gracefully.
+                DropLedger.record(
+                    value.spelling.toKString()?.takeIf { it.isNotEmpty() }
+                        ?: value.kind.toString(),
+                    "Unmodelable ${value.kind} cursor (${t.message})",
+                    DropPhase.PARSE
+                )
                 println(
                     "WARN skip-not-crash: dropping ${value.kind} cursor " +
                         "'${value.spelling.toKString()}' (${t.message})"

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedKotlinType.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedKotlinType.kt
@@ -15,6 +15,8 @@
  */
 package com.monkopedia.krapper.generator.model
 
+import com.monkopedia.krapper.generator.DropLedger
+import com.monkopedia.krapper.generator.DropPhase
 import com.monkopedia.krapper.generator.builders.KotlinFactory.Companion.C_FUNCTION
 import com.monkopedia.krapper.generator.builders.KotlinFactory.Companion.C_OPAQUE_POINTER
 import com.monkopedia.krapper.generator.builders.KotlinFactory.Companion.C_POINTER
@@ -231,6 +233,12 @@ fun WrappedKotlinType(type: WrappedType): WrappedKotlinType {
                 } + "__" + templateTypes.joinToString("__") { it.name }
             )
         }.getOrElse {
+            DropLedger.record(
+                name,
+                "Failed to parse qualified template spelling (${it.message}); " +
+                    "degraded to opaque leaf",
+                DropPhase.PARSE
+            )
             println(
                 "WARN skip-not-crash: failed to parse qualified template spelling " +
                     "'$name' (${it.message}); surfacing as opaque type"
@@ -277,6 +285,11 @@ fun WrappedKotlinType(nameIn: String): WrappedKotlinType {
                 )
             )
         }.getOrElse {
+            DropLedger.record(
+                name,
+                "Failed to parse template spelling (${it.message}); degraded to opaque leaf",
+                DropPhase.PARSE
+            )
             println(
                 "WARN skip-not-crash: failed to parse template spelling '$name' " +
                     "(${it.message}); surfacing as opaque type"

--- a/krapper_gen/src/nativeTest/kotlin/SkipNotCrashTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/SkipNotCrashTest.kt
@@ -21,6 +21,7 @@ import com.monkopedia.krapper.KrapperConfig
 import com.monkopedia.krapper.ReferencePolicy
 import com.monkopedia.krapper.generator.codegen.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
@@ -71,6 +72,43 @@ class SkipNotCrashTest {
         File(outDir).rmR()
         File(headerFile).delete()
         return cc
+    }
+
+    /**
+     * Run the full generator over [header] and return the drop-ledger records collected
+     * during the run. Mirrors [generate] but hands back the ledger instead of the emitted
+     * C++, so a test can assert WHAT was dropped and WHY (not just that the run survived).
+     * [failOnDrop] toggles the strict gate; [runBody] receives the snapshot taken right
+     * after writeTo (a successful run) — for the strict-failure case the caller inspects
+     * the throw separately.
+     */
+    private fun generateLedger(header: String, failOnDrop: Boolean = false): List<DropRecord> {
+        val tag = "${random()}_${random()}"
+        val headerFile = "/tmp/krapper_ledger_$tag.h"
+        File(headerFile).writeText(header)
+        val outDir = "/tmp/krapper_ledger_out_$tag"
+        val records = runBlocking {
+            val config = KrapperConfig(
+                pkg = "krapper.skip",
+                compiler = "clang++",
+                moduleName = "skip",
+                errorPolicy = ErrorPolicy.LOG,
+                referencePolicy = ReferencePolicy.INCLUDE_MISSING,
+                debug = false,
+                failOnDrop = failOnDrop
+            )
+            val service = IndexedServiceImpl(
+                config,
+                IndexRequest(listOf(headerFile), emptyList())
+            )
+            service.filterAndResolve(com.monkopedia.krapper.DefaultFilter)
+            service.writeTo(outDir)
+            // The ledger is process-scoped; snapshot it before any teardown runs.
+            DropLedger.drops.toList()
+        }
+        File(outDir).rmR()
+        File(headerFile).delete()
+        return records
     }
 
     // G1: a method whose param/return type has a deeply-nested template spelling
@@ -214,6 +252,89 @@ class SkipNotCrashTest {
             "deleted default ctor wrapper must be skipped:\n$cc"
         )
     }
+
+    // L1: the drop ledger records a dropped symbol WITH A REASON. G4's unbindable
+    // required-param method is the deliberately-unmodelable shape; after the run the
+    // ledger must contain a record naming it (so a consumer can tell "the generator
+    // dropped takesBad" from "C++ never had it"), while the bindable `fine` is NOT in
+    // the ledger.
+    @Test
+    fun l1_dropped_symbol_is_recorded_in_the_ledger_with_a_reason() {
+        val drops = generateLedger(
+            """
+            #pragma once
+            template <class T> struct Opaque { T x; };
+            struct L1 {
+                int fine(int a) const { return a; }
+                void takesBad(Opaque<int>&& bad) {}
+            };
+            """.trimIndent()
+        )
+        assertTrue(
+            drops.any { "takesBad" in it.symbol },
+            "the unbindable method must be recorded in the drop ledger:\n$drops"
+        )
+        val takesBad = drops.first { "takesBad" in it.symbol }
+        assertTrue(
+            takesBad.reason.isNotBlank(),
+            "every drop must carry a reason:\n$takesBad"
+        )
+        assertFalse(
+            drops.any { "fine" in it.symbol },
+            "a successfully-bound method must NOT be in the ledger:\n$drops"
+        )
+    }
+
+    // L2: a clean run (no unmodelable shapes) records ZERO drops — the ledger doesn't
+    // false-positive on ordinary bindable members.
+    @Test
+    fun l2_clean_run_records_no_drops() {
+        val drops = generateLedger(
+            """
+            #pragma once
+            struct L2 {
+                int value() const { return 7; }
+                int field = 0;
+            };
+            """.trimIndent()
+        )
+        assertEquals(
+            emptyList(),
+            drops,
+            "a fully-bindable header must drop nothing:\n$drops"
+        )
+    }
+
+    // L3: --fail-on-drop turns a drop into a hard failure (non-zero exit / thrown
+    // error), while the same header passes leniently by default. Locks the opt-in
+    // strict-mode contract.
+    @Test
+    fun l3_fail_on_drop_fails_when_something_is_dropped() {
+        val header =
+            """
+            #pragma once
+            template <class T> struct Opaque { T x; };
+            struct L3 {
+                int fine(int a) const { return a; }
+                void takesBad(Opaque<int>&& bad) {}
+            };
+            """.trimIndent()
+        // Lenient (default) completes.
+        assertTrue(generateLedger(header).isNotEmpty())
+        // Strict mode throws.
+        var threw = false
+        try {
+            generateLedger(header, failOnDrop = true)
+        } catch (t: Throwable) {
+            threw = true
+            assertTrue(
+                "fail-on-drop" in (t.message ?: t.cause?.message ?: ""),
+                "strict-mode failure must mention fail-on-drop: ${t.message}"
+            )
+        }
+        assertTrue(threw, "--fail-on-drop must fail the run when a symbol was dropped")
+    }
+
     // G6 (template-arg namespace qualification) is intentionally NOT covered here:
     // the standard nested-namespace shape (`std::vector<ns::Inner>`) already emits a
     // correctly-qualified arg via referencedDecl.fullyQualified, and a fixture that


### PR DESCRIPTION
## What

The breadth strategy dropped unmodelable methods/fields/classes with only a `Log.w` / `println` — never counted, never diffed against the requested allowlist. A consumer could not tell "C++ doesn't have it" from "the generator dropped it." This adds a **drop-ledger** that makes every skip-not-crash drop visible.

## Design

A process-scoped `DropLedger` collector (modeled on the sibling `Log` object + the `rootPackageOverride` global — the generator runs one request at a time under `runBlocking`, so a shared collector is the cohesive carrier without threading a ledger handle through every resolve signature). Each known drop site funnels `{symbol, reason, phase}`:

- **RESOLVE**: `ResolveContext.notifyFailed` — the central choke point every model element returns through when it fails to resolve, so recording once covers the method/field/class drop sites uniformly; plus the top-level filtered-class / forcing-struct resolve failures in `resolveAll` / `resolveForcing`.
- **PARSE**: the cursor-level skip-not-crash drops in `WrappedElement` (nested-in-class-template class, unmodelable cursor) and the opaque-leaf template-spelling degradations in `WrappedKotlinType`.
- **DEDUP**: the const-overload de-duplication in `WrappedClass.dropConstOverloadDuplicates`.

`IndexedServiceImpl` tracks the requested set (`--only` allowlist entries + each `--instantiate` target), resets the ledger per run, and emits a `requested X / bound Y / dropped Z` report (with the dropped list + reasons, and a requested-but-neither-bound-nor-dropped coverage line) at the end of `writeTo`.

Strict mode is **opt-in** via `--fail-on-drop` (`KrapperConfig.failOnDrop`, default `false`): drops are always logged + ledgered, but only this flag turns a drop into a non-zero exit — so existing green runs are unchanged.

## Tests

`SkipNotCrashTest`:
- `l1` — a deliberately-unbindable required-param method is recorded in the ledger with a reason, while its bound sibling is not.
- `l2` — a fully-bindable header records zero drops (no false positives).
- `l3` — `--fail-on-drop` fails the run iff something was dropped (and the same header passes leniently by default).

## Verification

- `:krapper_gen:nativeTest` — **298/0** (295 baseline + 3 new ledger tests)
- `:featuregen:nativeTest` — **183/0**
- `:krapper_gen:ktlintCheck` — green

## Deferred / known limitation

The requested-vs-bound coverage line is best-effort: an `--instantiate` request string (`std::pair<int, int>`) and a bound `ResolvedClass.type` spelling can differ, so an instantiation may show as "uncovered" even when bound. It is informational only (never a gate), and the dropped list — the issue's actual acceptance criterion ("reports exactly what it dropped and why") — is precise.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)