### PR TITLE
Bump ksrpc-jni 1.1.0 -> 1.1.1 in compiler/ to match the catalog (#4)

### DIFF
--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // Spike #2: in-compiler JNI bridge to libkrapper.so for live libclang access.
     // `api` (not `implementation`) so the dep surfaces to the K/N compiler's
     // plugin-classpath resolution — `implementation` is hidden from consumers.
-    api("com.monkopedia.ksrpc:ksrpc-jni:1.1.0")
+    api(libs.ksrpc.jni)
 }
 
 // The native plugin shares its sources with the JVM plugin module; sync them in

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.0")
     // Spike #2: in-compiler JNI bridge to libkrapper.so for live libclang access.
-    implementation("com.monkopedia.ksrpc:ksrpc-jni:1.1.0")
+    implementation(libs.ksrpc.jni)
 }
 
 tasks.withType<KotlinCompile> {

--- a/compiler/settings.gradle.kts
+++ b/compiler/settings.gradle.kts
@@ -9,6 +9,14 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
     }
+    // This is a separate includeBuild with its own settings, so the root
+    // catalog isn't auto-imported. Wire it in explicitly so compiler-side
+    // deps resolve the same versions as the rest of the build and can't drift.
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 
 rootProject.name = "kplusplus-compiler"


### PR DESCRIPTION
## What

The compiler includeBuild hardcoded `com.monkopedia.ksrpc:ksrpc-jni:1.1.0` in two places while the version catalog (`gradle/libs.versions.toml`) is at `ksrpc = 1.1.1`. Commit ac1054c bumped the catalog + the Kotlin literals here but left these two ksrpc-jni literals at 1.1.0 — version drift that risks a compiled-against-one / loaded-against-another runtime mismatch.

## Fix chosen: durable (catalog wiring), not the minimal literal bump

The `compiler` is a separate includeBuild whose `settings.gradle.kts` already has a `dependencyResolutionManagement` block, so wiring the root catalog in was clean and low-risk:

- `compiler/settings.gradle.kts`: add `versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }`
- `compiler/plugin/build.gradle.kts`: `implementation("...ksrpc-jni:1.1.0")` -> `implementation(libs.ksrpc.jni)`
- `compiler/native/build.gradle.kts`: `api("...ksrpc-jni:1.1.0")` -> `api(libs.ksrpc.jni)`

This resolves the same ksrpc as the rest of the build and removes the literal entirely, so it can never drift again.

## Verification

- Compiler build (Java 21, the compiler pins JDK 21): `./gradlew -p compiler :kplusplus-compiler-plugin:build :kplusplus-compiler-plugin-native:build :kplusplus-compiler-gradle:build` — BUILD SUCCESSFUL (`libs.ksrpc.jni` resolves; a missing catalog would fail at configuration).
- Plugin end-to-end (Java 17): `./gradlew :featuregen:kplusplusSync :featuregen:nativeTest` — kplusplusSync regenerated 17 instantiations, nativeTest **183 tests, 0 failures, 0 errors** (the expected 183/0).

Note: `:featuregen:nativeTest` must run in the same invocation as `kplusplusSync` (Gradle orders sync before the native-test compile); running it standalone against a stale generated-source cache fails on nested-vector bindings — this is unrelated to this change and reproduces identically on the pristine base.

Closes #4