### PR TITLE
Diagnostics: skip the bad symbol into the ledger, don't abort the whole run (#9)

### DIFF
--- a/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
+++ b/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
@@ -51,5 +51,14 @@ data class KrapperConfig(
     // after emitting the drop-ledger report, instead of completing leniently. Opt-in
     // (default false) so existing green runs keep succeeding: drops are always logged
     // and ledgered, but only this flag turns a drop into a non-zero exit.
-    val failOnDrop: Boolean = false
+    val failOnDrop: Boolean = false,
+    // When true, ANY `error:`-severity parse diagnostic aborts the whole run (the
+    // historical behavior — appropriate for curated, known-clean headers). Opt-in
+    // (default false): by default an error diagnostic that is attributable to a single
+    // declaration drops THAT symbol into the drop ledger and binding continues over the
+    // rest of the header, so one un-bindable symbol in a real-world library no longer
+    // takes the entire import down. Translation-unit-level / fatal diagnostics (a missing
+    // include, "too many errors", an error with no attributable cursor) abort regardless,
+    // since the recovered AST can't be trusted past them.
+    val strictDiagnostics: Boolean = false
 )

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -147,6 +147,15 @@ class KrapperGen : CliktCommand() {
             "symbol (skip-not-crash). Default: lenient — drops are logged + reported in " +
             "the drop ledger, but the run still succeeds."
     ).flag()
+    val strictDiagnostics by option(
+        "--strict-diagnostics",
+        help = "Abort the whole run on ANY parse `error:` diagnostic (the historical " +
+            "behavior, for curated clean headers). Default: lenient — an error attributable " +
+            "to a single declaration drops THAT symbol into the drop ledger and binding " +
+            "continues, so one bad symbol in a real library doesn't take the import down. " +
+            "Fatal / translation-unit-level errors (missing include, unattributable) abort " +
+            "regardless."
+    ).flag()
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -174,7 +183,8 @@ class KrapperGen : CliktCommand() {
                     debug = debug,
                     cppStandard = cppStandard,
                     rootPackage = rootPackage,
-                    failOnDrop = failOnDrop
+                    failOnDrop = failOnDrop,
+                    strictDiagnostics = strictDiagnostics
                 )
             )
             val indexService = service.index(IndexRequest(header, library))

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -122,7 +122,8 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             request.headers,
             includePaths + request.headerDirectories,
             args = parseArgs(request.headerDirectories),
-            debug = config.debug
+            debug = config.debug,
+            strictDiagnostics = config.strictDiagnostics
         )
         val initialClasses = resolver.findClasses(filter.wrapperFilter())
         Log.i("Found ${initialClasses.size} classes to resolve")
@@ -183,7 +184,8 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             listOf(tmpFile),
             includePaths + request.headerDirectories,
             args = parseArgs(request.headerDirectories),
-            debug = config.debug
+            debug = config.debug,
+            strictDiagnostics = config.strictDiagnostics
         )
         // SCOPE THE FORCING COLLECTION. The synthetic header #includes the consumer's
         // own headers, so `findClasses { defaultFilter() }` collects EVERY class in the

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -15,16 +15,20 @@
  */
 package com.monkopedia.krapper.generator
 
+import clang.CXCursor
 import clang.CXCursorKind
 import clang.CXCursorKind.CXCursor_TypedefDecl
+import clang.CXDiagnosticSeverity
 import clang.CXIndex
 import clang.CXTranslationUnit
 import clang.CXType
 import clang.clang_defaultDiagnosticDisplayOptions
+import clang.clang_disposeDiagnostic
 import clang.clang_disposeString
 import clang.clang_formatDiagnostic
-import clang.clang_getCString
 import clang.clang_getDiagnostic
+import clang.clang_getDiagnosticLocation
+import clang.clang_getDiagnosticSeverity
 import clang.clang_getNumDiagnostics
 import com.monkopedia.krapper.AllowListFilter
 import com.monkopedia.krapper.AndFilter
@@ -527,10 +531,17 @@ suspend fun DeferScope.parseHeader(
     includePaths: Array<String>,
     args: Array<String> = arrayOf("-xc++", "--std=c++14") + includePaths.map { "-I$it" }
         .toTypedArray(),
-    debug: Boolean = false
+    debug: Boolean = false,
+    // When true, any `error:` diagnostic aborts the whole run (historical behavior).
+    // When false (default), an error attributable to a single declaration drops that
+    // symbol into the drop ledger and binding continues; only fatal / unattributable
+    // diagnostics abort. See [handleDiagnostics].
+    strictDiagnostics: Boolean = false
 ): Resolver {
     val builder = ResolverBuilderImpl()
-    val tu = file.map { parseHeader(index, it, builder, includePaths, args, debug) }
+    val tu = file.map {
+        parseHeader(index, it, builder, includePaths, args, debug, strictDiagnostics)
+    }
         .reduceRight { tu1, tu2 ->
             tu1.also {
                 it.addAllChildren(
@@ -558,12 +569,11 @@ private fun DeferScope.parseHeader(
     includePaths: Array<String>,
     args: Array<String> = arrayOf("-xc++", "--std=c++14") + includePaths.map { "-I$it" }
         .toTypedArray(),
-    debug: Boolean = false
+    debug: Boolean = false,
+    strictDiagnostics: Boolean = false
 ): WrappedTU {
     val tu = index.parseTranslationUnit(file, args, null) ?: error("Failed to parse $file")
-    tu.printDiagnostics()?.let {
-        throw RuntimeException("Parse failure: $it")
-    }
+    val droppedUsrs = tu.handleDiagnostics(file, strictDiagnostics)
     defer {
         tu.dispose()
     }
@@ -574,35 +584,154 @@ private fun DeferScope.parseHeader(
             "cursor_${File(file).name}.json"
         ).writeText(Json.encodeToString(Utils.CursorTreeInfo(cursor)))
     }
+    // Excise declarations the diagnostic policy dropped (issue #9) so the broken decl and
+    // its members are never carried into the model / resolution.
+    WrappedElement.setDroppedUsrs(droppedUsrs)
     val element = WrappedElement.mapAll(tu.cursor, resolverBuilder)
     return element as? WrappedTU ?: error("$element is not a WrappedTU, ${tu.cursor.kind}")
 }
 
-fun CXTranslationUnit.printDiagnostics(): String? {
-    val nbDiag = clang_getNumDiagnostics(this)
-    var foundError = false
-    val errorString = buildString {
-        append("There are $nbDiag diagnostics:")
-        append('\n')
+/**
+ * A single error-severity parse diagnostic, paired with the declaration it could be
+ * attributed to. [text] is the formatted diagnostic line; [symbol]/[usr] are the spelling
+ * and USR of the enclosing top-level declaration the error landed inside, or `null` when
+ * the error can't be tied to a single declaration (a translation-unit-level / fatal
+ * error — a missing include, "too many errors", an error at the TU root). [fatal] is true
+ * for `CXDiagnostic_Fatal`, which always aborts because the rest of the AST can't be
+ * trusted.
+ */
+private data class ErrorDiagnostic(
+    val text: String,
+    val symbol: String?,
+    val usr: String?,
+    val fatal: Boolean
+) {
+    /** Attributable to a single declaration -> droppable when not strict and not fatal. */
+    val isAttributable: Boolean get() = symbol != null && usr != null && !fatal
+}
 
-        for (currentDiag in 0 until nbDiag.toInt()) {
-            val diagnotic = clang_getDiagnostic(this@printDiagnostics, currentDiag.toUInt())
-            val errorString =
-                clang_formatDiagnostic(diagnotic, clang_defaultDiagnosticDisplayOptions())
-            val str = clang_getCString(errorString)?.toKString()
-            clang_disposeString(errorString)
-            if (str?.contains("error:") == true) {
-                foundError = true
+/**
+ * Inspect this translation unit's diagnostics and decide whether to abort the run.
+ *
+ * Historically (and still under [strictDiagnostics]) ANY `error:` diagnostic threw,
+ * taking the whole import down — fine for curated clean headers, fatal for pointing at a
+ * real library where one bad declaration would block everything else. The default policy
+ * now SKIPS the affected symbol instead: an error attributable to a single top-level
+ * declaration drops that declaration into the [DropLedger] (PARSE phase, the diagnostic
+ * text as the reason) and binding continues over the rest of the header. libclang still
+ * recovers a usable AST for the surviving declarations, and the downstream model build
+ * (`mapAll`) is already skip-not-crash, so dropping the named symbol here is safe.
+ *
+ * The boundary, by design:
+ *  - strict mode             -> abort on the first error/fatal (the old behavior).
+ *  - fatal severity          -> always abort (recovered AST is untrustworthy).
+ *  - unattributable error    -> always abort (an error at the TU root / with no enclosing
+ *                               declaration is translation-unit-level, e.g. a missing
+ *                               include; we can't surgically drop a single symbol).
+ *  - attributable error      -> drop that symbol into the ledger, continue.
+ */
+private fun CXTranslationUnit.handleDiagnostics(
+    file: String,
+    strictDiagnostics: Boolean
+): Set<String> {
+    val errors = collectErrorDiagnostics()
+    if (errors.isEmpty()) {
+        return emptySet()
+    }
+    val mustAbort = strictDiagnostics || errors.any { !it.isAttributable }
+    if (mustAbort) {
+        val reason = if (strictDiagnostics) {
+            "strict diagnostics"
+        } else {
+            "fatal / translation-unit-level diagnostic(s)"
+        }
+        throw RuntimeException(
+            "Parse failure ($reason) in $file:\n" + errors.joinToString("\n") { it.text }
+        )
+    }
+    // Lenient: every error is attributable -> drop each affected symbol and continue.
+    // Dedup by USR: one bad declaration can raise several diagnostics, but it's one drop.
+    val droppedUsrs = mutableSetOf<String>()
+    for (error in errors) {
+        val symbol = error.symbol ?: continue
+        val usr = error.usr ?: continue
+        if (!droppedUsrs.add(usr)) {
+            continue
+        }
+        DropLedger.record(symbol, error.text, DropPhase.PARSE)
+        println(
+            "WARN skip-not-crash: dropping declaration '$symbol' in $file on parse " +
+                "diagnostic: ${error.text}"
+        )
+    }
+    return droppedUsrs
+}
+
+/**
+ * Collect this TU's `error:`/fatal diagnostics, attributing each to the enclosing
+ * top-level declaration where one exists (via the diagnostic's source location ->
+ * [clang_getCursor] -> walk semantic parents up to the TU root).
+ */
+private fun CXTranslationUnit.collectErrorDiagnostics(): List<ErrorDiagnostic> {
+    val nbDiag = clang_getNumDiagnostics(this)
+    val errors = mutableListOf<ErrorDiagnostic>()
+    for (currentDiag in 0 until nbDiag.toInt()) {
+        val diagnostic = clang_getDiagnostic(this, currentDiag.toUInt())
+        try {
+            val severity = clang_getDiagnosticSeverity(diagnostic)
+            val isError = severity == CXDiagnosticSeverity.CXDiagnostic_Error ||
+                severity == CXDiagnosticSeverity.CXDiagnostic_Fatal
+            if (!isError) {
+                continue
             }
-            append("$str")
-            append('\n')
+            val formatted =
+                clang_formatDiagnostic(diagnostic, clang_defaultDiagnosticDisplayOptions())
+            val text = formatted.toKString().orEmpty()
+            clang_disposeString(formatted)
+            val location = clang_getDiagnosticLocation(diagnostic)
+            val topLevel = topLevelDecl(getCursor(location))
+            errors.add(
+                ErrorDiagnostic(
+                    text = text,
+                    symbol = topLevel?.spelling?.toKString()?.takeIf { it.isNotBlank() },
+                    usr = topLevel?.usr?.toKString()?.takeIf { it.isNotBlank() },
+                    fatal = severity == CXDiagnosticSeverity.CXDiagnostic_Fatal
+                )
+            )
+        } finally {
+            clang_disposeDiagnostic(diagnostic)
         }
     }
-    return if (foundError) {
-        errorString
-    } else {
-        null
+    return errors
+}
+
+/**
+ * Walk [cursor] up its semantic parents to the outermost named, non-namespace declaration
+ * — the one whose semantic parent is the TU or a namespace — and return that cursor, or
+ * `null` when the error can't be tied to a single declaration (a null/invalid cursor, the
+ * TU root itself, or no named non-namespace ancestor — i.e. a translation-unit-level
+ * error). That outermost decl is what the model binds as a top-level symbol, so excising
+ * it (by USR, in WrappedElement.map) cleanly drops the whole bad declaration and all of
+ * its members. Namespaces are skipped as drop targets: a namespace is a container, not a
+ * bindable symbol, and dropping it would take every sibling declaration with it.
+ */
+private fun CXTranslationUnit.topLevelDecl(cursor: CValue<CXCursor>): CValue<CXCursor>? {
+    val tuCursor = this.cursor
+    if (cursor.kind.isInvalid || cursor.equals(tuCursor)) {
+        return null
     }
+    var current = cursor
+    var named: CValue<CXCursor>? = null
+    while (!current.kind.isInvalid && !current.equals(tuCursor)) {
+        if (current.kind.isDeclaration &&
+            current.kind != CXCursorKind.CXCursor_Namespace &&
+            !current.spelling.toKString().isNullOrBlank()
+        ) {
+            named = current
+        }
+        current = current.semanticParent
+    }
+    return named
 }
 
 suspend fun WrappedTemplate.typedAs(

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
@@ -88,6 +88,22 @@ abstract class WrappedElement(
     abstract suspend fun resolve(resolverContext: ResolveContext): ResolvedElement?
 
     companion object {
+        // USRs of declarations the diagnostic policy chose to drop at parse time (issue
+        // #9: an `error:` diagnostic attributable to a single declaration skips THAT
+        // declaration and lets the rest of the header bind). A dropped USR is excised here
+        // in [map] — returning null removes the declaration AND, via the
+        // `map(parentCursor) ?: return@forEachRecursive` guard in [mapAll], all of its
+        // members — so the broken declaration is never carried into resolution.
+        // Parse-scoped: [setDroppedUsrs] is called with each TU's set right before its
+        // [mapAll]. Mirrors the process-scoped [elementLookup] memo above.
+        private var droppedUsrs: Set<String> = emptySet()
+
+        /** Register the USRs of declarations dropped by the diagnostic policy for the next
+         * [mapAll]. */
+        fun setDroppedUsrs(usrs: Set<String>) {
+            droppedUsrs = usrs
+        }
+
         fun mapAll(value: CValue<CXCursor>, resolverBuilder: ResolverBuilder): WrappedElement? {
             val element = map(value, null, null, resolverBuilder) ?: return null
             value.forEachRecursive { childCursor, parentCursor ->
@@ -140,9 +156,14 @@ abstract class WrappedElement(
             parentUsr: String?,
             resolverBuilder: ResolverBuilder
         ): WrappedElement? {
-            val strTag =
-                value.usr.toKString().orEmpty()
-                    .ifEmpty { "$parentUsr:${value.spelling.toKString()}" }
+            val usr = value.usr.toKString().orEmpty()
+            // Excise a declaration the diagnostic policy dropped at parse time (issue #9).
+            // Its members are excised transitively: when this cursor is a member's parent,
+            // mapAll's `map(parentCursor) ?: return@forEachRecursive` guard skips the member.
+            if (usr.isNotEmpty() && usr in droppedUsrs) {
+                return null
+            }
+            val strTag = usr.ifEmpty { "$parentUsr:${value.spelling.toKString()}" }
 
             elementLookup[strTag]?.let { return it }
 

--- a/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
@@ -413,6 +413,133 @@ class ParseTest {
         }
     }
 
+    // Issue #9 (diagnostics policy): a header with ONE un-bindable declaration (a struct
+    // member typed by an undeclared type -> an `error:` parse diagnostic attributed to that
+    // struct) must NOT abort the whole run. By default the bad declaration is dropped into
+    // the drop ledger as a PARSE drop (carrying the diagnostic text) and excised from the
+    // model, while the clean class beside it still parses + resolves. This is the
+    // acceptance criterion: one un-bindable symbol no longer takes the rest of the import
+    // down.
+    @Test
+    fun testParseErrorDropsBadSymbolAndBindsTheRest() = memScoped {
+        runBlocking {
+            DropLedger.reset()
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val tmpFile = "/tmp/krapper_diag_skip_${random()}_${random()}.h"
+            File(tmpFile).writeText(
+                """
+                |namespace fixture {
+                |// `Undeclared` is never defined -> an `error:` diagnostic attributed to Bad.
+                |struct Bad {
+                |    Undeclared broken;
+                |};
+                |struct Good {
+                |    int goodValue() const;
+                |};
+                |}
+                """.trimMargin()
+            )
+            // Default (lenient) diagnostics: the run survives the error diagnostic.
+            val resolver = parseHeader(index, listOf(tmpFile), generateIncludes("clang++"))
+            // The bad declaration is a PARSE drop in the ledger, with the diagnostic text.
+            val badDrop = DropLedger.drops.firstOrNull {
+                it.symbol == "Bad" && it.phase == DropPhase.PARSE
+            }
+            assertTrue(
+                badDrop != null,
+                "the un-bindable struct must be a PARSE drop; got ${DropLedger.drops}"
+            )
+            assertTrue(
+                "error:" in badDrop.reason,
+                "the drop reason must carry the parse diagnostic text; got ${badDrop.reason}"
+            )
+            // The good class still parses + resolves; the bad one is gone from the model.
+            val resolved = resolver.findClasses { defaultFilter() }
+                .resolveAll(resolver, ReferencePolicy.IGNORE_MISSING)
+            val resolvedNames = resolved.filterIsInstance<ResolvedClass>()
+                .map { it.type.type }
+                .toSet()
+            assertTrue(
+                "fixture::Good" in resolvedNames,
+                "the clean class must still bind; got $resolvedNames"
+            )
+            assertTrue(
+                "fixture::Bad" !in resolvedNames,
+                "the dropped class must NOT be bound; got $resolvedNames"
+            )
+        }
+    }
+
+    // Issue #9: --strict-diagnostics restores the historical abort-on-any-error behavior.
+    // The SAME header that binds-the-rest by default now aborts the run.
+    @Test
+    fun testStrictDiagnosticsAbortsOnAnyError() = memScoped {
+        runBlocking {
+            DropLedger.reset()
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val tmpFile = "/tmp/krapper_diag_strict_${random()}_${random()}.h"
+            File(tmpFile).writeText(
+                """
+                |namespace fixture {
+                |struct Bad {
+                |    Undeclared broken;
+                |};
+                |}
+                """.trimMargin()
+            )
+            var threw = false
+            try {
+                parseHeader(
+                    index,
+                    listOf(tmpFile),
+                    generateIncludes("clang++"),
+                    strictDiagnostics = true
+                )
+            } catch (t: Throwable) {
+                threw = true
+                assertTrue(
+                    "strict diagnostics" in (t.message ?: t.cause?.message ?: ""),
+                    "strict-mode failure must mention strict diagnostics: ${t.message}"
+                )
+            }
+            assertTrue(threw, "--strict-diagnostics must abort on an error diagnostic")
+        }
+    }
+
+    // Issue #9: a translation-unit-level / unattributable error (a missing include) aborts
+    // even in lenient mode — there's no single declaration to surgically drop and the rest
+    // of the AST can't be trusted past it. Draws the attributable-vs-fatal boundary.
+    @Test
+    fun testUnattributableErrorAbortsEvenWhenLenient() = memScoped {
+        runBlocking {
+            DropLedger.reset()
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val tmpFile = "/tmp/krapper_diag_fatal_${random()}_${random()}.h"
+            File(tmpFile).writeText(
+                """
+                |#include <this_header_does_not_exist_krapper.h>
+                |namespace fixture {
+                |struct Good { int goodValue() const; };
+                |}
+                """.trimMargin()
+            )
+            var threw = false
+            try {
+                parseHeader(index, listOf(tmpFile), generateIncludes("clang++"))
+            } catch (t: Throwable) {
+                threw = true
+                assertTrue(
+                    "fatal / translation-unit-level" in (t.message ?: t.cause?.message ?: ""),
+                    "an unattributable error must abort with the TU-level reason: ${t.message}"
+                )
+            }
+            assertTrue(threw, "a missing include must abort even in lenient mode")
+        }
+    }
+
     @Test
     fun testResolveConstRef() = memScoped {
         runBlocking {


### PR DESCRIPTION
## What

`parseHeader` (Parsing.kt) previously threw on **any** `error:` diagnostic across the whole translation unit, so a single un-bindable declaration in a real-world header took the entire import down. This makes the diagnostic policy **skip the affected symbol** instead, feeding the existing drop-ledger from #6.

### Default (lenient) policy — skip-not-crash
An `error:` diagnostic attributable to a single top-level declaration:
- resolves the diagnostic's source location to a cursor (`clang_getDiagnosticLocation` → `clang_getCursor`), walks up semantic parents to the outermost named non-namespace decl;
- records a `DropLedger` PARSE drop `{symbol, reason=diagnostic text, phase=PARSE}` (deduped by USR — one bad decl can raise several diagnostics);
- excises that declaration by USR in `WrappedElement.map` (returning `null` there drops the decl **and** its members via the existing `map(parentCursor) ?: return@forEachRecursive` guard), so it never reaches resolution;
- binding continues over the rest of the header.

Because the drop flows through the existing ledger, the end-of-run report and the `--fail-on-drop` strict gate from #6 cover diagnostic-skips for free — no parallel reporting path.

### The attributable-vs-fatal boundary
- **attributable error** → drop that symbol, continue (the new default).
- **fatal severity** (`CXDiagnostic_Fatal`, e.g. a missing `#include`) → always abort; the recovered AST can't be trusted past it.
- **unattributable error** (location resolves to the TU root / no enclosing declaration) → always abort; there's no single symbol to surgically drop. Namespaces are explicitly not drop targets (a container, not a bindable symbol — dropping one would take every sibling with it).

### Strict-mode flag choice
Added a dedicated `--strict-diagnostics` (`KrapperConfig.strictDiagnostics`, default off) rather than folding into `--fail-on-drop`. They're orthogonal: `--fail-on-drop` is a *post-run gate* ("did anything get dropped?"), while parse-strictness is an *in-run policy* ("abort the instant a header errors, before any binding"). A curated-clean-header run wants strict parsing but `--strict-diagnostics` is the cleaner knob; `--fail-on-drop` still independently turns the resulting drop into a non-zero exit.

## Tests (ParseTest, parse+resolve level, decoupled from the wrapper compile)
- `testParseErrorDropsBadSymbolAndBindsTheRest` — a header with one un-bindable struct (`Undeclared` member) ledgers the bad struct as a PARSE drop with the diagnostic text, while the clean sibling class still resolves (acceptance criterion).
- `testStrictDiagnosticsAbortsOnAnyError` — the same header aborts under `--strict-diagnostics`.
- `testUnattributableErrorAbortsEvenWhenLenient` — a missing include aborts even in lenient mode (the fatal/TU-level boundary).

## Verification
- `:krapper_gen:nativeTest` — **301/0** (298 baseline + 3 new)
- `:featuregen:kplusplusSync` + `:featuregen:nativeTest` — **183/0**
- `:krapper_gen:ktlintCheck` — green

All four gates green in a single combined run.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)