### PR TITLE
Wire :featuregen:nativeTest to depend on kplusplusSync (no more stale-krapped flake) (#16)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -64,6 +64,43 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             val generatedFile = File(krappedDir, "generated.txt")
             val fixupFile = File(krappedDir, "fixups.json")
             val moduleName = target.name
+            // Declare up-to-date inputs/outputs so Gradle can (a) order this task
+            // ahead of the native compile that consumes krapped/ (see
+            // wireGeneratedBindings), and (b) skip the regeneration when nothing
+            // that feeds it has changed. Inputs: the generator kexe, the
+            // compiler-written manifest, the configured headers, and the
+            // extension config that becomes krapper_gen CLI args. Output: the
+            // whole krapped/ dir (the kexe regenerates it wholesale each run).
+            //
+            // The header-driven path intentionally has no per-method change
+            // tracking (see the hasHeaders force-regenerate note below), so when
+            // headers are configured we leave the task always out-of-date by
+            // declaring no output — Gradle then re-runs it every invocation,
+            // which is the existing, correct behaviour for that path.
+            val ext = target.extensions.findByType(KPlusPlusExtension::class.java)
+            val hasHeadersAtConfig = ext?.headers?.isNotEmpty() == true
+            it.inputs.file(kexe).withPropertyName("krapperGenKexe")
+                .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.NONE)
+            it.inputs.files(manifestFile).withPropertyName("requestedManifest")
+                .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.NONE)
+                .optional(true)
+            ext?.let { e ->
+                it.inputs.property("instantiations", e.instantiations.sorted())
+                it.inputs.property("referencePolicy", e.referencePolicy ?: "")
+                it.inputs.property("cppStandard", e.cppStandard ?: "")
+                it.inputs.property("rootPackage", e.rootPackage ?: "")
+                it.inputs.property("only", e.only.sorted())
+                it.inputs.property("onlyFile", e.onlyFile ?: "")
+                it.inputs.property("fixups", e.fixups.toJsonArray())
+                if (e.headers.isNotEmpty()) {
+                    it.inputs.files(e.headers.map { h -> target.file(h) })
+                        .withPropertyName("headers")
+                        .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
+                }
+            }
+            if (!hasHeadersAtConfig) {
+                it.outputs.dir(krappedDir).withPropertyName("krappedDir")
+            }
             it.doLast {
                 if (!kexe.exists()) {
                     throw GradleException(
@@ -73,10 +110,9 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                             "settings.gradle.kts."
                     )
                 }
-                // Resolve the v2 extension (created in apply()). The block is
+                // The v2 extension (created in apply(), captured above) is
                 // optional — projects with no header import and no fixups
                 // still work via the existing pure-instantiation flow.
-                val ext = target.extensions.findByType(KPlusPlusExtension::class.java)
                 val hasHeaders = ext?.headers?.isNotEmpty() == true
                 val seededInstantiations = ext?.instantiations.orEmpty()
                 val hasManifest = manifestFile.exists()
@@ -336,6 +372,16 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // and the wiring picks up.
         if (kotlinCompilation is KotlinNativeCompilation && kotlinCompilation.name == "main") {
             wireGeneratedBindings(kotlinCompilation, project)
+            // The main compile consumes the generated krapped/ sources and
+            // cinterop .def. Make it (and thereby the test compile, which
+            // depends on it) depend on kplusplusSync so the generator runs —
+            // and Gradle's up-to-date check regenerates stale output — before
+            // anything compiles against it. Without this, `:featuregen:nativeTest`
+            // run as its own invocation would compile whatever krapped/ happened
+            // to be on disk (issue #16).
+            kotlinCompilation.compileTaskProvider.configure { compileTask ->
+                compileTask.dependsOn("kplusplusSync")
+            }
         }
         // Per-compilation manifest path: matches the krapped/ layout the sync
         // task + wireGeneratedBindings already use, so the on-disk wiring stays
@@ -361,12 +407,46 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val krappedDir = File(project.projectDir, "krapped")
         val krappedDef = File(krappedDir, "$moduleName.def")
         val krappedSrc = File(krappedDir, "src")
-        if (krappedDef.exists()) {
+        // Wire the generated cinterop .def + Kotlin source dir into the main
+        // native compilation. This must happen even when the artifacts don't yet
+        // exist at configuration time: kplusplusSync produces them, and the
+        // cinterop/compile tasks depend on it (below), so they run after the
+        // generator. Conditioning on existence (the old behaviour) was the
+        // chicken-and-egg in issue #16 — a stale/missing def at configure time
+        // meant the cinterop was never created, so a sync that regenerated the
+        // def couldn't be picked up in the same invocation and the compile failed
+        // on the unresolved `<module>` cinterop package.
+        //
+        // Only wire when the project is actually configured to generate bindings
+        // (a kplusplus { } block with headers/instantiations, or a manifest the
+        // compiler wrote, or already-present artifacts). A project that does
+        // neither has no krapped/ to consume and must not get a cinterop pointed
+        // at a def that will never exist.
+        project.afterEvaluate {
+            val ext = project.extensions.findByType(KPlusPlusExtension::class.java)
+            val manifestFile = File(krappedDir, "requested.txt")
+            val willGenerate = ext?.headers?.isNotEmpty() == true ||
+                ext?.instantiations?.isNotEmpty() == true ||
+                manifestFile.exists()
+            if (!willGenerate && !krappedDef.exists() && !krappedSrc.exists()) {
+                return@afterEvaluate
+            }
             compilation.cinterops.create("kplusplus") { interop ->
                 interop.defFile = krappedDef
             }
-        }
-        if (krappedSrc.exists()) {
+            // The cinterop task reads the generated .def; make it regenerate via
+            // kplusplusSync first so it can't process a stale def (issue #16).
+            // The interop task is named cinterop<Name><Target>; for the
+            // "kplusplus" interop on the "native" target that is
+            // cinteropKplusplusNative.
+            val interopTaskName = "cinteropKplusplus" +
+                compilation.target.targetName.replaceFirstChar { it.uppercase() }
+            project.tasks.matching { it.name == interopTaskName }.configureEach {
+                it.dependsOn("kplusplusSync")
+            }
+            // The generated Kotlin sources live under krapped/src. srcDir tolerates
+            // a not-yet-existing directory at configure time; kplusplusSync (a
+            // compile dependency) creates it before compilation reads it.
             compilation.defaultSourceSet.kotlin.srcDir(krappedSrc)
         }
     }


### PR DESCRIPTION
## Problem (#16)

`:featuregen:nativeTest` did not depend on `:featuregen:kplusplusSync`. Run as its own Gradle invocation it compiled against whatever generated `krapped/` sources happened to be on disk; if stale/partial it failed on `kplusplus-sync-required: …` / unresolved bindings (`CvNestedTest`). Three coder agents independently hit this and bisected staleness, and it risks training agents to dismiss a real generation regression as "the known artifact."

## The wiring

1. **`compileKotlinNative` depends on `kplusplusSync`** — and the test compile depends on the main compile, so the generator runs (and Gradle's up-to-date check regenerates stale output) before anything compiles against `krapped/`.
2. **`kplusplusSync` now declares real inputs/outputs** — the generator kexe, the compiler-written `requested.txt` manifest, the configured headers, and the extension config that becomes krapper_gen CLI args, plus the `krapped/` output dir. (The header-driven path keeps its existing always-regenerate behaviour by declaring no output when headers are configured — there's no per-method change tracking there.)
3. **The cinterop `.def` + `krapped/src` source dir are now wired UNCONDITIONALLY** (in an `afterEvaluate`, gated on the project actually being configured to generate bindings). Previously they were wired only if the artifacts already existed at *configuration* time — that was the chicken-and-egg: a stale/missing def at configure time meant the `kplusplus` cinterop was never created, so a sync that regenerated the def couldn't be picked up in the same invocation and the compile failed on the unresolved `<module>` cinterop package. The cinterop task also depends on `kplusplusSync` so it can't process a stale def.

The fix lives in the kplusplus Gradle plugin, so every consumer (not just featuregen) gets the guarantee.

## Acceptance — standalone regenerates + greens (the point)

With a converged manifest, deliberately staled `krapped/` (deleted `featuregen.def` + `src/CppBinding.kt`), then ran ONLY `./gradlew :featuregen:nativeTest`:

```
> Task :featuregen:kplusplusSync
kplusplusSync: headers=1 regenerating 17 instantiation(s): Box<…>, …, std::vector<std::vector<int>>
> Task :featuregen:cinteropKplusplusNative
> Task :featuregen:compileKotlinNative
> Task :featuregen:compileTestKotlinNative
BUILD SUCCESSFUL
```

`kplusplusSync` ran first and regenerated all 17 instantiations, then the cinterop/compile/test ran green — no manual sync. Confirmed the *old* behaviour failed the same scenario on the unresolved `featuregen` cinterop package before the unconditional-wiring change.

## Verification (full gate)

`./gradlew :krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck` — BUILD SUCCESSFUL:
- krapper_gen: **304/0** (baseline)
- featuregen: **186/0**
- ktlint: green

Plugin compiles clean (only the pre-existing `defFile` deprecation warning).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)