### PR TITLE
Reduce: dedup the 4 identical Operator.name() bodies + drop dead cursor-kind stubs (#17 items 1,4)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/Operators.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/Operators.kt
@@ -25,6 +25,17 @@ sealed class Operator {
     abstract fun name(namer: Namer, method: WrappedMethod): String
     protected abstract fun matches(method: WrappedMethod): Boolean
 
+    // Shared base for the operators whose C wrapper name is derived mechanically
+    // from a C-spelling fragment (`cOp`): `<cName>_op_<cOp split + lowercased>`.
+    // ConversionOperator does not extend this — it names by destination type.
+    abstract class NamedByCOp : Operator() {
+        protected abstract val cOp: String
+
+        override fun name(namer: Namer, method: WrappedMethod): String = with(namer) {
+            cName + "_op_" + cOp.splitCamelcase().joinToString("_") { it.lowercase() }
+        }
+    }
+
     companion object {
         val ALL_OPERATORS = listOf(
             BasicBinaryOperator.MINUS,
@@ -71,14 +82,10 @@ sealed class Operator {
 
 data class BasicBinaryOperator private constructor(
     val cppOp: String,
-    private val cOp: String,
+    override val cOp: String,
     override val resolvedOperator: ResolvedOperator,
     val supportsDirectCall: Boolean = true
-) : Operator() {
-
-    override fun name(namer: Namer, method: WrappedMethod): String = with(namer) {
-        return cName + "_op_" + cOp.splitCamelcase().joinToString("_") { it.lowercase() }
-    }
+) : Operator.NamedByCOp() {
 
     override fun matches(method: WrappedMethod): Boolean =
         method.args.size == 1 && method.name.substring("operator".length) == cppOp
@@ -123,13 +130,9 @@ data class BasicBinaryOperator private constructor(
 
 data class BasicAssignmentOperator private constructor(
     private val cppOp: String,
-    private val cOp: String,
+    override val cOp: String,
     override val resolvedOperator: ResolvedOperator
-) : Operator() {
-
-    override fun name(namer: Namer, method: WrappedMethod): String = with(namer) {
-        return cName + "_op_" + cOp.splitCamelcase().joinToString("_") { it.lowercase() }
-    }
+) : Operator.NamedByCOp() {
 
     override fun matches(method: WrappedMethod): Boolean =
         method.args.size == 1 && method.name.substring("operator".length) == cppOp
@@ -144,13 +147,9 @@ data class BasicAssignmentOperator private constructor(
 
 data class BasicCallOperator private constructor(
     private val cppOp: String,
-    private val cOp: String,
+    override val cOp: String,
     override val resolvedOperator: ResolvedOperator
-) : Operator() {
-
-    override fun name(namer: Namer, method: WrappedMethod): String = with(namer) {
-        return cName + "_op_" + cOp.splitCamelcase().joinToString("_") { it.lowercase() }
-    }
+) : Operator.NamedByCOp() {
 
     // operator() can have any arity; match on name alone.
     override fun matches(method: WrappedMethod): Boolean =
@@ -209,13 +208,9 @@ data class ConversionOperator private constructor(override val resolvedOperator:
 
 data class BasicUnaryOperator private constructor(
     private val cppOp: String,
-    private val cOp: String,
+    override val cOp: String,
     override val resolvedOperator: ResolvedOperator
-) : Operator() {
-
-    override fun name(namer: Namer, method: WrappedMethod): String = with(namer) {
-        return cName + "_op_" + cOp.splitCamelcase().joinToString("_") { it.lowercase() }
-    }
+) : Operator.NamedByCOp() {
 
     override fun matches(method: WrappedMethod): Boolean =
         method.args.isEmpty() && method.name.substring("operator".length) == cppOp

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedElement.kt
@@ -210,8 +210,6 @@ abstract class WrappedElement(
             }
             val element = try {
                 when (value.kind) {
-//                CXCursorKind.CXCursor_UnexposedDecl -> TODO()
-//                CXCursorKind.CXCursor_UnionDecl -> TODO()
                     CXCursorKind.CXCursor_StructDecl,
                     CXCursorKind.CXCursor_ClassDecl -> {
                         // An anonymous record (the unnamed `struct { ... }` in
@@ -251,8 +249,6 @@ abstract class WrappedElement(
                         WrappedClass(value, resolverBuilder)
                     }
 
-                    //                CXCursorKind.CXCursor_EnumDecl -> TODO()
-//                CXCursorKind.CXCursor_EnumConstantDecl -> TODO()
                     CXCursorKind.CXCursor_FieldDecl -> {
                         // Anonymous data members (anon bitfield padding `int :3;`, anon
                         // union/struct members) have a blank spelling. They have no name to
@@ -382,18 +378,13 @@ abstract class WrappedElement(
                             }
                         }
 
-                    //                CXCursorKind.CXCursor_NamespaceAlias -> TODO()
                     CXCursorKind.CXCursor_TemplateTypeParameter -> WrappedTemplateParam(
                         value,
                         resolverBuilder
                     )
 
-                    //                CXCursorKind.CXCursor_NonTypeTemplateParameter -> TODO()
-//                CXCursorKind.CXCursor_TemplateTemplateParameter -> TODO()
                     CXCursorKind.CXCursor_ClassTemplate -> WrappedTemplate(value, resolverBuilder)
 
-                    //                CXCursorKind.CXCursor_ClassTemplatePartialSpecialization -> TODO()
-//                CXCursorKind.CXCursor_TypeAliasDecl -> TODO()
                     CXCursorKind.CXCursor_TypeRef -> WrappedTemplateRef(
                         value.spelling.toKString() ?: error("TypeRef without a name")
                     )


### PR DESCRIPTION
Two behavior-preserving line-removers from the reduction backlog (#17).

## Item 1 — dedup the 4 identical `Operator.name()` bodies (Operators.kt)
`BasicBinaryOperator`, `BasicAssignmentOperator`, `BasicCallOperator`, and `BasicUnaryOperator` each carried a **byte-identical** `name()` body and each privately stored `cOp`. Lifted both into a small intermediate abstract class `Operator.NamedByCOp`:

- `NamedByCOp` holds `protected abstract val cOp` and the default `name()` = `<cName>_op_<cOp split + lowercased>`.
- The 4 subclasses now just declare `override val cOp` and extend `Operator.NamedByCOp()` — their duplicate `name()` bodies are gone.
- `ConversionOperator` is untouched: it names by destination type and keeps its own `name()` override.

**Operator C-names are unchanged** — the lifted body is the same expression, so every generated `<cName>_op_…` wrapper name is identical. Confirmed by the codegen / full-Kotlin tests staying green at the same count.

## Item 4 — delete dead commented-out cursor-kind stubs (WrappedElement.kt)
Removed 9 dead `// CXCursorKind.CXCursor_… -> TODO()` lines interleaved in the live `when (value.kind)`. They were unreachable (the `else`/default handles unhandled kinds) and only fragmented the branch list. Pure comment deletion, zero behavior change. The live branches and the default are untouched.

## Line delta
**Net −14** (19 insertions / 33 deletions across the 2 files).

## Verification (JAVA_HOME=java-17)
- `:krapper_gen:nativeTest` — **304/0**
- `:featuregen:nativeTest` — **186/0**
- `:krapper_gen:ktlintCheck` — green

All at the exact baseline counts.

Refs #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)