### PR TITLE
Reduce: merge the string-return twins + the hand-rolled cast emitters in CppWriter (#17 items 2,8)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CppWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CppWriter.kt
@@ -193,35 +193,30 @@ class CppWriter(
     //   false -> `dynamic_cast<D*>(value)`           (standard C++ RTTI).
     // Both yield `D*`-or-null, which the shim returns as the opaque `void*`.
     private fun dynOrLlvmCast(derivedType: String, value: Symbol, useLlvmDynCast: Boolean): Symbol =
-        object : Symbol {
-            override fun build(builder: CodeStringBuilder) {
-                if (useLlvmDynCast) {
-                    builder.append("llvm::dyn_cast_or_null<$derivedType>(")
-                } else {
-                    builder.append("dynamic_cast<$derivedType*>(")
-                }
-                value.build(builder)
-                builder.append(")")
-            }
+        if (useLlvmDynCast) {
+            castSymbol("llvm::dyn_cast_or_null<$derivedType>(", value)
+        } else {
+            castSymbol("dynamic_cast<$derivedType*>(", value)
         }
 
     // `static_cast<type>(value)` — used to apply a base subobject offset in the upcast
     // helpers (the wrappers' usual RawCast/reinterpret can't shift the pointer).
-    private fun staticCast(type: String, value: Symbol): Symbol = object : Symbol {
-        override fun build(builder: CodeStringBuilder) {
-            builder.append("static_cast<$type>(")
-            value.build(builder)
-            builder.append(")")
-        }
-    }
+    private fun staticCast(type: String, value: Symbol): Symbol =
+        castSymbol("static_cast<$type>(", value)
 
     // `reinterpret_cast<type>(arg)` over a RAW C++ type string (not a ResolvedType) — used
     // only by the cast helpers, where the type is built by hand. Named distinctly from the
     // ResolvedType-typed `reinterpret` below to avoid confusing the two at the call site.
-    private fun reinterpretRaw(arg: LocalVar, type: String): Symbol = object : Symbol {
+    private fun reinterpretRaw(arg: LocalVar, type: String): Symbol =
+        castSymbol("reinterpret_cast<$type>(", arg.reference)
+
+    // A C++ cast expression `prefix value )` — every cast helper above is just a fixed
+    // `cast<...>(` prefix wrapped around a value and closed with `)`. [prefix] must include
+    // the trailing `(`.
+    private fun castSymbol(prefix: String, value: Symbol): Symbol = object : Symbol {
         override fun build(builder: CodeStringBuilder) {
-            builder.append("reinterpret_cast<$type>(")
-            arg.reference.build(builder)
+            builder.append(prefix)
+            value.build(builder)
             builder.append(")")
         }
     }
@@ -584,56 +579,42 @@ class CppWriter(
         }
     }
 
-    private fun CppCodeBuilder.createPointedStringReturn(call: Symbol) {
+    private fun CppCodeBuilder.createPointedStringReturn(call: Symbol) =
+        createStringReturn(call, byPointer = true)
+
+    // Build the `const char*` boundary return from a (by-value or by-pointer) std::string.
+    // [byPointer] selects the member-access form: `->`/`->length()` for a `std::string*`
+    // ([ResolvedType.PSTRING]) source, `.`/`.length()` for a by-value `std::string`
+    // ([ResolvedType.STRING]). The emitted C++ must stay byte-identical for either form.
+    private fun CppCodeBuilder.createStringReturn(call: Symbol, byPointer: Boolean = false) {
+        val sourceType = if (byPointer) ResolvedType.PSTRING else ResolvedType.STRING
+        // The raw `.length()` / `->length()` access on the source local, as a C++ string.
+        val lengthAccess = "${if (byPointer) "->" else "."}length()"
+        val access: Symbol.(Symbol) -> Symbol = if (byPointer) Symbol::arrow else Symbol::dot
         val returnStr = +define(
             "ret_value",
-            ResolvedType.PSTRING,
+            sourceType,
             initializer = call
         )
         val returnArray = +define(
             "ret_value_cast",
             ResolvedType.CSTRING,
-            initializer = New(Raw("char[${returnStr.name}->length() + 1]"))
+            initializer = New(Raw("char[${returnStr.name}$lengthAccess + 1]"))
         )
         +(
-            returnStr.reference arrow Call(
-                "copy",
-                returnArray.reference,
-                returnStr.reference arrow Call("length"),
-                Raw("0")
+            returnStr.reference.access(
+                Call(
+                    "copy",
+                    returnArray.reference,
+                    returnStr.reference.access(Call("length")),
+                    Raw("0")
+                )
             )
             )
         // std::basic_string::copy does NOT NUL-terminate — the `+ 1` slot is allocated but
         // never written, so toKString() (which scans to the first '\0') reads a garbage byte
         // past the string (the `Point` -> `PointU` corruption). Terminate it explicitly.
-        +Raw("${returnArray.name}[${returnStr.name}->length()] = '\\0'")
-        +Return(returnArray.reference)
-    }
-
-    private fun CppCodeBuilder.createStringReturn(call: Symbol) {
-        val returnStr =
-            +define(
-                "ret_value",
-                ResolvedType.STRING,
-                initializer = call
-            )
-        val returnArray = +define(
-            "ret_value_cast",
-            ResolvedType.CSTRING,
-            initializer = New(Raw("char[${returnStr.name}.length() + 1]"))
-        )
-        +(
-            returnStr.reference dot Call(
-                "copy",
-                returnArray.reference,
-                returnStr.reference dot Call("length"),
-                Raw("0")
-            )
-            )
-        // std::basic_string::copy does NOT NUL-terminate — the `+ 1` slot is allocated but
-        // never written, so toKString() (which scans to the first '\0') reads a garbage byte
-        // past the string (the `Point` -> `PointU` corruption). Terminate it explicitly.
-        +Raw("${returnArray.name}[${returnStr.name}.length()] = '\\0'")
+        +Raw("${returnArray.name}[${returnStr.name}$lengthAccess] = '\\0'")
         +Return(returnArray.reference)
     }
 


### PR DESCRIPTION
## What

Two genuine line-removers from the reduction backlog (#17), both in `CppWriter.kt`, both proven to emit **byte-identical** generated C++.

**Item 2 — merge the string-return twins.** `createStringReturn` and `createPointedStringReturn` differed only in (a) `.` vs `->` member access and (b) the `STRING` vs `PSTRING` source type, with the NUL-termination comment block duplicated verbatim. Collapsed into one `createStringReturn(call, byPointer: Boolean)` parameterized on the member-access form (`Symbol::dot` / `Symbol::arrow`), the `.length()`/`->length()` access string, and the source `ResolvedType`. `createPointedStringReturn` is now a one-line delegate. The `ret[length()] = '\0'` NUL-terminate (the `Point`→`PointU` corruption fix) and the explanatory comment are preserved, now stated once.

**Item 8 — one cast-emitter helper.** The four hand-rolled `object : Symbol { build() }` cast emitters (both `dynOrLlvmCast` arms, `staticCast`, `reinterpretRaw`) each just wrapped `prefix + value + ")"`. Collapsed into one `private fun castSymbol(prefix: String, value: Symbol): Symbol`; each helper is now a one-liner.

## Byte-identical proof (critical)

Generated the featuregen `krapped/` output (124 files, incl. `featuregen.cc`/`.h`) from clean base and again after the change; md5 manifests are **identical** — zero behavior change:

```
diff /tmp/before.md5 /tmp/after.md5  →  (no output, all 124 files match)
```

## Net delta

`1 file changed, 37 insertions(+), 56 deletions(-)` → **-19 lines**.

## Verification

`:krapper_gen:nativeTest :featuregen:nativeTest :krapper_gen:ktlintCheck` — all green:
- krapper_gen **304/0**
- featuregen **186/0**
- ktlint green

Refs #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)