### PR TITLE
Hermeticity: unique per-run temp files + cleanup (no more fixed /tmp collisions) (#11 part 1)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -188,52 +188,53 @@ class KrapperGen : CliktCommand() {
                 )
             )
             val indexService = service.index(IndexRequest(header, library))
-            // v2 flow: when both --header and --instantiate are present, parse
-            // the headers first (filterAndResolve) then layer the requested
-            // template instantiations on top. This is what the v8 example
-            // needs — a "wrap this whole header set" import combined with the
-            // narrow fixups passed via --fixup-file.
-            val hasHeaders = header.isNotEmpty()
-            val hasInstantiations = instantiate.isNotEmpty()
-            if (hasHeaders) {
-                // Scoped-import allowlist (T1.0a): when --only/--only-file name an
-                // explicit class set, bind ONLY those (referenced-but-unlisted types
-                // fall to --referencePolicy). Otherwise keep the DefaultFilter
-                // (bind-everything-non-std) behavior.
-                val allowList = loadAllowList()
-                val filter = if (allowList.isEmpty()) {
-                    DefaultFilter
-                } else {
-                    Log.i("Scoped import: binding only ${allowList.size} class(es): $allowList")
-                    AllowListFilter(allowList)
+            try {
+                // v2 flow: when both --header and --instantiate are present, parse
+                // the headers first (filterAndResolve) then layer the requested
+                // template instantiations on top. This is what the v8 example
+                // needs — a "wrap this whole header set" import combined with the
+                // narrow fixups passed via --fixup-file.
+                val hasHeaders = header.isNotEmpty()
+                val hasInstantiations = instantiate.isNotEmpty()
+                if (hasHeaders) {
+                    // Scoped-import allowlist (T1.0a): when --only/--only-file name an
+                    // explicit class set, bind ONLY those (referenced-but-unlisted types
+                    // fall to --referencePolicy). Otherwise keep the DefaultFilter
+                    // (bind-everything-non-std) behavior.
+                    val allowList = loadAllowList()
+                    val filter = if (allowList.isEmpty()) {
+                        DefaultFilter
+                    } else {
+                        Log.i("Scoped import: binding only ${allowList.size} class(es): $allowList")
+                        AllowListFilter(allowList)
+                    }
+                    indexService.filterAndResolve(filter)
                 }
-                indexService.filterAndResolve(filter)
-            }
-            if (hasInstantiations) {
-                for (spec in instantiate) {
-                    indexService.requestInstantiation(parseInstantiation(spec))
+                if (hasInstantiations) {
+                    for (spec in instantiate) {
+                        indexService.requestInstantiation(parseInstantiation(spec))
+                    }
                 }
-            }
-            // Apply declarative fixups from --fixup-file (v2 escape hatch).
-            // Empty / missing file is a no-op.
-            val fixups = loadFixups(fixupFile)
-            if (fixups.isNotEmpty()) {
-                Log.i("Loaded ${fixups.size} fixup(s) from $fixupFile")
-                FixupApplier.apply(indexService, fixups)
-            }
-            if (hasInstantiations && !hasHeaders) {
-                // Pure-instantiation path: matches the original M11 sync flow.
-                // Skip the legacy hardcoded v8 mappings entirely (they have
-                // been migrated to the user-supplied --fixup-file).
-                indexService.writeTo(output ?: getcwd())
-                return@runBlocking
-            }
-            // Legacy / headers-only / headers+instantiations path: previous
-            // releases also wired a hardcoded set of v8-specific mappings
-            // here. Those have been migrated to the declarative Fixup
-            // directives (see kplusplus { fixup { ... } } in the compiler
-            // gradle subplugin). The block remains so the same code path
-            // serves both the legacy CLI invocation and the new sync flow.
+                // Apply declarative fixups from --fixup-file (v2 escape hatch).
+                // Empty / missing file is a no-op.
+                val fixups = loadFixups(fixupFile)
+                if (fixups.isNotEmpty()) {
+                    Log.i("Loaded ${fixups.size} fixup(s) from $fixupFile")
+                    FixupApplier.apply(indexService, fixups)
+                }
+                if (hasInstantiations && !hasHeaders) {
+                    // Pure-instantiation path: matches the original M11 sync flow.
+                    // Skip the legacy hardcoded v8 mappings entirely (they have
+                    // been migrated to the user-supplied --fixup-file).
+                    indexService.writeTo(output ?: getcwd())
+                    return@runBlocking
+                }
+                // Legacy / headers-only / headers+instantiations path: previous
+                // releases also wired a hardcoded set of v8-specific mappings
+                // here. Those have been migrated to the declarative Fixup
+                // directives (see kplusplus { fixup { ... } } in the compiler
+                // gradle subplugin). The block remains so the same code path
+                // serves both the legacy CLI invocation and the new sync flow.
 //            for (file in header) {
 //                val tu =
 //                    index.parseTranslationUnit(file, args, null) ?: error("Failed to parse $file")
@@ -267,7 +268,13 @@ class KrapperGen : CliktCommand() {
 // //                    Log.i("Cursor $cursor ${cursor?.children?.size} ${tu.cursor.kind}")
 // //                }
 //            }
-            indexService.writeTo(output ?: getcwd())
+                indexService.writeTo(output ?: getcwd())
+            } finally {
+                // Always release the index and delete the run's throwaway temp dir, even
+                // when resolution/writeTo throws — so forcing-header intermediates never
+                // leak into $TMPDIR.
+                indexService.close()
+            }
         }
     }
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -69,9 +69,23 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     private var classes: List<ResolvedElement> = emptyList()
     private val mappings = mutableListOf<MappingService>()
 
-    // Headers synthesized by requestInstantiation to force template instantiations.
-    // writeTo references these so the generated wrapper #includes the needed std headers.
+    // Forcing headers synthesized by requestInstantiation to make libclang instantiate a
+    // template specialization. Keyed forceName -> file contents. They are PARSED from a
+    // per-run temp dir (hermetic, cleaned in close()) and then re-materialized into the
+    // output dir by writeTo, so the generated wrapper #includes them by a stable, relative,
+    // self-contained path (no /tmp leak, deterministic across runs).
+    private val forcingHeaders = linkedMapOf<String, String>()
+
+    // The output-relative paths the generated .cc/.h should #include for the forcing headers.
+    // Populated by writeTo once the output dir is known.
     private val syntheticHeaders = mutableListOf<String>()
+
+    // Process-unique scratch dir for parsing the forcing headers. Created lazily on the
+    // first instantiation (a run with no --instantiate touches nothing) and removed in
+    // close(). Per-run unique (pid + counter) so concurrent runs never clobber each other.
+    private var tempDir: File? = null
+    private fun tempDir(): File =
+        tempDir ?: File.createTempDir("krapper_inst").also { tempDir = it }
 
     // What the run was explicitly ASKED to bind: the --only allowlist entries plus each
     // --instantiate target. The drop-ledger report diffs this against what actually
@@ -159,25 +173,26 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             // is unaffected.
             .replace("*", "Ptr")
             .replace("&", "Ref")
-        val tmpFile = "/tmp/krapper_inst_$forceName.h"
-        File(tmpFile).writeText(
-            buildString {
-                // Every type in the instantiation must be declared, not just the
-                // outer base — previously only stdHeaderFor(req.base) was included,
-                // so std::vector<std::string> failed (basic_string undeclared).
-                // Include std headers TARGETED to the types named in `target`
-                // (scanning, so nested element types are covered) plus the
-                // consumer's own headers (for user element types like a wrapped
-                // struct in std::vector<Point>). Targeted rather than a blanket
-                // bundle: a broad include drags unrelated system structs in under
-                // INCLUDE_MISSING (e.g. <sys/timex.h>'s `timex`), which then
-                // generate invalid wrappers.
-                for (stdHeader in stdHeadersFor(target)) appendLine("#include $stdHeader")
-                for (userHeader in request.headers) appendLine("#include \"$userHeader\"")
-                appendLine("struct $forceName { $target value; };")
-            }
-        )
-        syntheticHeaders.add(tmpFile)
+        val forcingContent = buildString {
+            // Every type in the instantiation must be declared, not just the
+            // outer base — previously only stdHeaderFor(req.base) was included,
+            // so std::vector<std::string> failed (basic_string undeclared).
+            // Include std headers TARGETED to the types named in `target`
+            // (scanning, so nested element types are covered) plus the
+            // consumer's own headers (for user element types like a wrapped
+            // struct in std::vector<Point>). Targeted rather than a blanket
+            // bundle: a broad include drags unrelated system structs in under
+            // INCLUDE_MISSING (e.g. <sys/timex.h>'s `timex`), which then
+            // generate invalid wrappers.
+            for (stdHeader in stdHeadersFor(target)) appendLine("#include $stdHeader")
+            for (userHeader in request.headers) appendLine("#include \"$userHeader\"")
+            appendLine("struct $forceName { $target value; };")
+        }
+        forcingHeaders[forceName] = forcingContent
+        // Parse from a per-run temp file (cleaned in close()); the same header is
+        // re-materialized into the output dir by writeTo for the generated wrapper.
+        val tmpFile = File(tempDir(), "$forceName.h").path
+        File(tmpFile).writeText(forcingContent)
         Log.i("Forcing instantiation of $target via $tmpFile")
         val resolver = scope.parseHeader(
             index,
@@ -291,9 +306,18 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
                 .joinToString(",\n    ")
             Log.i("Generating for [\n    $resolvedClasses\n]")
         }
-        val headers = request.headers + syntheticHeaders
         val outputBase = File(output)
         outputBase.mkdirs()
+        // Re-materialize the forcing headers into the output dir so the generated wrapper
+        // #includes them by a stable relative path (no /tmp), and the emitted .cc is
+        // self-contained / re-compilable. Deterministic name -> deterministic output.
+        syntheticHeaders.clear()
+        for ((forceName, content) in forcingHeaders) {
+            val forcingFile = File(outputBase, "$forceName.h")
+            forcingFile.writeText(content)
+            syntheticHeaders.add(forcingFile.path)
+        }
+        val headers = request.headers + syntheticHeaders
         val namer = NameHandler()
         Log.i("Generating header file")
         File(outputBase, "${config.moduleName}.h").writeText(
@@ -492,7 +516,12 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
 
     override suspend fun close() {
         super.close()
-        index.dispose()
+        // Throwaway forcing-header intermediates — written to a per-run temp dir purely so
+        // libclang can parse them; never part of generated output, so always safe to delete.
+        // Cleared here so they don't accumulate in $TMPDIR across runs.
+        tempDir?.takeIf { it.exists() }?.rmR()
+        // index is disposed by the Arena's deferred cleanup in scope.clear(); disposing it
+        // here too would double-free (clang_disposeIndex on a freed handle → abort).
         scope.clear()
     }
 }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -374,7 +374,11 @@ End of search list.
  */
 
 fun generateIncludes(compiler: String) = memScoped {
-    val emptyFile = File("/tmp/clang_includes.c")
+    // Per-run unique scratch dir (pid + counter) so concurrent generator runs never
+    // collide on a fixed /tmp path; removed before returning so it never accumulates.
+    val tmpDir = File.createTempDir("krapper_includes")
+    defer { tmpDir.rmR() }
+    val emptyFile = File(tmpDir, "clang_includes.c")
     emptyFile.writeText("")
     val process = Process {
         system("$compiler -E -x c++ -v ${emptyFile.path}")

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/File.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/File.kt
@@ -15,6 +15,7 @@
  */
 package com.monkopedia.krapper.generator.codegen
 
+import kotlin.concurrent.AtomicInt
 import kotlin.native.internal.NativePtr
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.alloc
@@ -37,6 +38,8 @@ import platform.posix.fcntl
 import platform.posix.fopen
 import platform.posix.fputs
 import platform.posix.fread
+import platform.posix.getenv
+import platform.posix.getpid
 import platform.posix.mkdir
 import platform.posix.opendir
 import platform.posix.readdir
@@ -150,5 +153,24 @@ data class File(val pathSegments: List<String>) {
     companion object {
         val CWD: File
             get() = File(getcwd())
+
+        // Monotonic per-process counter so two temp dirs created in the same run never
+        // collide even when getpid() is identical.
+        private val tempCounter = AtomicInt(0)
+
+        /**
+         * Creates and returns a freshly-made, process-unique temporary directory under
+         * `$TMPDIR` (default `/tmp`). The name embeds the pid and a per-process counter so
+         * concurrent generator runs (distinct pids) and repeated calls within one run never
+         * clobber each other's intermediate files. Caller owns cleanup (e.g. [rmR]).
+         */
+        fun createTempDir(prefix: String): File {
+            val tmpRoot =
+                getenv("TMPDIR")?.toKString()?.trimEnd('/').takeUnless { it.isNullOrEmpty() }
+                    ?: "/tmp"
+            val dir = File("$tmpRoot/${prefix}_${getpid()}_${tempCounter.addAndGet(1)}")
+            dir.mkdirs()
+            return dir
+        }
     }
 }


### PR DESCRIPTION
## Scope (issue #11, part 1 of N — the `/tmp` part only)

The generator wrote two **fixed-name** temp files that concurrent runs clobbered and that were never cleaned up:
- `IndexedServiceImpl` → `/tmp/krapper_inst_<forceName>.h` (template-forcing headers)
- `Parsing.generateIncludes` → `/tmp/clang_includes.c` (include-path probe)

Parallel module builds / concurrent agent runs with the same `forceName` raced on identical paths, and the files accumulated in `/tmp` forever.

## The fix

- **`File.createTempDir(prefix)`** — a process-unique temp dir under `$TMPDIR` (default `/tmp`), named `<prefix>_<pid>_<atomic-counter>`. Distinct pids (concurrent runs) and the per-process counter (repeated calls in one run) guarantee no collision.
- **`generateIncludes()`** writes `clang_includes.c` into a per-run dir and `rmR()`s it via a `memScoped` `defer` (cleaned even on throw). This file is pure throwaway — it never appears in generated output.
- **Forcing headers**: parsed from a per-run temp dir, then **re-materialized into the output dir** by `writeTo()` so the generated `.cc` `#include`s them by a stable, relative, self-contained path (`KrapperForce_*.h`) instead of a fixed `/tmp` path. The per-run temp dir is `rmR()`'d in `close()`.
- **`close()`**: dropped the redundant explicit `index.dispose()` — the `Arena`'s deferred dispose in `scope.clear()` already releases the `CXIndex`; doing both double-freed it (`clang_disposeIndex` on a freed handle → SIGABRT). This latent bug only surfaced once `close()` began being called from the CLI path.
- **App CLI path** now wraps the run in `try { … } finally { indexService.close() }`, so the temp dir is always cleaned (and the index released) even on error. This is the path `gradle :…:kplusplusSync` invokes, so `/tmp` no longer accumulates.

## Behaviour-preserving

Regenerated `featuregen/krapped` with the base (`a01349f`) kexe and this branch's kexe over the same 17-instantiation set, then diffed:
- **all 112 Kotlin bindings `src/*.kt`: byte-identical**
- **`feature.h`: byte-identical**
- **`feature.def`: identical** (modulo the test harness's distinct `-o` dir)
- **`feature.cc`: ONLY the forcing-header `#include` paths change** — from the old non-hermetic `/tmp` refs (`../krapper_inst_*.h`, dead after the run) to self-contained siblings (`KrapperForce_*.h`). The `.cc` is compiled into `lib<module>.a` during `writeTo` and never recompiled by the consumer (cinterop reads `feature.h` + the `.a`), so this change is functionally inert — proven by featuregen staying 186/0.

**No temp files leak**: after a run, no `/tmp/krapper_inst_*` or `/tmp/krapper_includes_*` remain. (Baseline left 25+ stale `krapper_inst` files in `/tmp`.)

## Verification (JDK 17)

- `:krapper_gen:nativeTest` — **304/0**
- `:featuregen:kplusplusSync` — green (needed the documented #25 manifest-convergence passes on this cold worktree)
- `:featuregen:nativeTest` — **186/0**
- `:krapper_gen:ktlintCheck` — green

Refs #11 (does **not** close it — globals threading, batch re-resolve, and the clangwalk `llvm-config` derivation remain separate sub-PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)