### PR TITLE
Reduce: consolidate the 3 top-level-split helpers into one (#17)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -859,35 +859,11 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     }
 
     // Split a comma-separated template-arg list at top level only (so a nested
-    // `Inner<a, b>` arg stays intact).
+    // `Inner<a, b>` arg stays intact). A trailing blank segment is dropped (so an
+    // empty arg list yields no entries); segments are returned untrimmed.
     private fun splitTopLevelArgs(args: String): List<String> {
-        val result = mutableListOf<String>()
-        var depth = 0
-        val current = StringBuilder()
-        for (c in args) {
-            when (c) {
-                '<' -> {
-                    depth++
-                    current.append(c)
-                }
-
-                '>' -> {
-                    depth--
-                    current.append(c)
-                }
-
-                ',' -> if (depth == 0) {
-                    result.add(current.toString())
-                    current.clear()
-                } else {
-                    current.append(c)
-                }
-
-                else -> current.append(c)
-            }
-        }
-        if (current.isNotBlank()) result.add(current.toString())
-        return result
+        val segments = splitTopLevel(args)
+        return if (segments.last().isBlank()) segments.dropLast(1) else segments
     }
 
     /**
@@ -1970,22 +1946,9 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         val inner = literal.substring(1, close).trim()
         val ret = literal.substring(arrow + 2).trim()
         if (inner.isEmpty()) return emptyList<String>() to ret
-        val args = mutableListOf<String>()
-        var depth = 0
-        var start = 0
-        inner.forEachIndexed { i, c ->
-            when (c) {
-                '(', '<' -> depth++
-
-                ')', '>' -> depth--
-
-                ',' -> if (depth == 0) {
-                    args.add(inner.substring(start, i).trim())
-                    start = i + 1
-                }
-            }
-        }
-        args.add(inner.substring(start).trim())
+        // Track both `()` and `<>` nesting so a nested function/generic arg type
+        // stays intact; every segment is kept (incl. a trailing blank) and trimmed.
+        val args = splitTopLevel(inner, opens = "(<", closes = ")>").map { it.trim() }
         return args to ret
     }
 
@@ -2555,4 +2518,41 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
         +Return(retValue.reference)
     }
+}
+
+/**
+ * Split [s] on top-level commas only, tracking nesting depth across the bracket
+ * pairs in [opens]/[closes] (paired by position — `opens[i]` closes with
+ * `closes[i]`) so commas inside a nested `Inner<a, b>` / `(a, b)` group are not
+ * split on. The delimiting commas are dropped; every other character (incl. the
+ * bracket chars) is preserved in its segment. Always returns at least one segment
+ * (the input with no top-level comma yields the whole string); segments are not
+ * trimmed. Callers apply their own trimming / trailing-blank handling.
+ */
+internal fun splitTopLevel(s: String, opens: String = "<", closes: String = ">"): List<String> {
+    val result = mutableListOf<String>()
+    var depth = 0
+    val current = StringBuilder()
+    for (c in s) {
+        when {
+            c in opens -> {
+                depth++
+                current.append(c)
+            }
+
+            c in closes -> {
+                depth--
+                current.append(c)
+            }
+
+            c == ',' && depth == 0 -> {
+                result.add(current.toString())
+                current.clear()
+            }
+
+            else -> current.append(c)
+        }
+    }
+    result.add(current.toString())
+    return result
 }


### PR DESCRIPTION
## What

Three functions hand-rolled the same "split on top-level commas, respecting bracket depth" logic. This extracts one shared helper and routes the two that share a shape through it.

### Shared helper
```kotlin
internal fun splitTopLevel(s: String, opens: String = "<", closes: String = ">"): List<String>
```
Splits `s` on top-level commas, tracking nesting depth across the position-paired bracket set `opens`/`closes`. Drops the delimiting commas, preserves every other char (incl. brackets), always returns >=1 segment, does NOT trim — callers keep their own trimming / trailing-blank handling.

### Consolidated (2 of 3)
- **`splitTopLevelArgs`** (KotlinWriter, `<>` only) -> `splitTopLevel(args)` then drop a trailing blank segment (preserving its old `isNotBlank()` final-segment rule).
- **`parseFunctionType`** arg-split (KotlinWriter, `()`+`<>`) -> `splitTopLevel(inner, "(<", ")>").map { it.trim() }` (keeps all segments incl. trailing blank, trims each — exactly as before).

### Left out (1 of 3) — and why
- **`findTemplates`** (`model/WrappedKotlinType.kt`) is a genuinely different shape and is **not** folded in:
  - returns `List<IntRange>` (index ranges), not `List<String>`;
  - uses recursive `findEnd` index math that **throws** on unbalanced `>`, and that helper is **shared with `findQualifiers`**;
  - tracks only `<>` (no `()`), and **includes the leading comma** in each range (the caller `parseTypes` does `.trimStart(',')`).
  Forcing it into the string-splitter shape would change `parseTypes`' contract and silently drop the throw-on-malformed behavior. Correctness over a forced total consolidation — it stays as-is.

## Behavior-preserving — byte-identical
`featuregen/krapped` md5 manifest is **byte-for-byte identical** between clean `725f76e` (converged) and this change: 141 files, manifest md5 `4e5258dab1b16eb92e89221ebe6a2e13` on both. `diff` reports zero differences.

## Net line delta
`1 file changed, +44/-44` raw; the real change removes two duplicated depth-tracking loops (~26 + ~18 lines) in favor of one ~30-line shared helper plus two short delegations — the duplicated loop now exists once instead of twice.

## Verification (all green, baseline counts)
- `:krapper_gen:nativeTest` — **304/0**
- `:featuregen:nativeTest` — **186/0**
- `:krapper_gen:ktlintCheck` — green
- (cold worktree needed the #25 manifest-convergence sync passes to reach a stable 17 instantiations; not part of this change)

refs #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)