### PR TITLE
Codegen: get/at-keyed concrete element + RangeReturn drop visibility (#7 items 3,5)

### DIFF
--- a/featuregen/src/cppMain/include/strings_feature.h
+++ b/featuregen/src/cppMain/include/strings_feature.h
@@ -371,6 +371,27 @@ struct ShapeProbe {
     }
 };
 
+// CV-getat-base-elem (#7 item 3): a `get`/`at`-keyed index container whose ELEMENT
+// type is a BASE class (`Shape*`, which has a generated `ShapeApi` interface). The
+// generator upcasts the `at(...)` return to `ShapeApi?`, but the synthesized
+// `iterator()`'s `next()` declares the CONCRETE element type — so WITHOUT the item-3
+// fix the emitted `next(): Shape? = at(i): ShapeApi?` doesn't typecheck and the
+// featuregen build fails to compile. With the fix the `at`/`get` get keeps the
+// concrete element type (matching `operator[]`), so the container binds and the stored
+// concrete Shapes round-trip (area() virtual-dispatches through the element).
+//
+// Index keyed by `at`/`get` (NOT `operator[]`) with a `size_t` size + `size_t` index,
+// so detectIndexIterable selects the `at` fallback rather than the IND operator path.
+struct ShapeBag {
+    Shape* items[3];
+    std::size_t n;
+    ShapeBag() : n(0) { items[0] = items[1] = items[2] = nullptr; }
+    void add(Shape* s) { if (n < 3) items[n++] = s; }
+    std::size_t size() const { return n; }
+    Shape* at(std::size_t i) const { return i < n ? items[i] : nullptr; }
+    Shape* get(std::size_t i) const { return at(i); }
+};
+
 // IH-flatten (3-level chain): Animal <- Dog <- Puppy. `Animal` is polymorphic
 // (virtual speak()/legs() + virtual dtor); `Dog` overrides speak(); `Puppy`
 // overrides speak() AGAIN and inherits legs() unchanged. This exercises the

--- a/featuregen/src/nativeTest/kotlin/CvGetAtBaseElemTest.kt
+++ b/featuregen/src/nativeTest/kotlin/CvGetAtBaseElemTest.kt
@@ -1,0 +1,53 @@
+import kotlinx.cinterop.memScoped
+import root.Circle
+import root.Rectangle
+import root.ShapeBag
+import kotlin.math.PI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// CV-getat-base-elem (#7 item 3): ShapeBag is a `get`/`at`-keyed index container
+// (size_t size + size_t index, no operator[]) whose ELEMENT type is the BASE class
+// `Shape*`. WITHOUT the item-3 fix, the generator upcast the `at`/`get` return to
+// `ShapeApi?` while the synthesized `iterator()`'s `next()` declared the CONCRETE
+// element type — so the emitted `next(): Shape? = at(i): ShapeApi?` wouldn't typecheck
+// and the featuregen build would fail to compile. The mere fact that THIS module
+// compiles + these tests run proves the fix (the get/at index-get now keeps the
+// concrete element type, matching operator[]). The asserts then round-trip the stored
+// concrete Shapes and dispatch their virtual area() through the element.
+class CvGetAtBaseElemTest {
+    @Test fun at_and_get_return_concrete_elements() = memScoped {
+        val ms = this
+        val bag = with(ShapeBag) { ms.ShapeBag() }
+        val circle = with(Circle) { ms.Circle__double(2.0) }            // area = π·4
+        val rect = with(Rectangle) { ms.Rectangle__double_double(3.0, 4.0) } // area = 12
+        bag.add(circle)
+        bag.add(rect)
+
+        assertEquals(2uL, bag.size())
+        // at(i)/get(i) keep the CONCRETE element type; virtual area() dispatches to the
+        // actual stored subtype.
+        assertEquals(PI * 4.0, bag.at(0uL)?.area() ?: 0.0, 1e-9)
+        assertEquals(12.0, bag.at(1uL)?.area() ?: 0.0, 1e-9)
+        assertEquals(PI * 4.0, bag.get(0uL)?.area() ?: 0.0, 1e-9)
+        assertEquals(12.0, bag.get(1uL)?.area() ?: 0.0, 1e-9)
+    }
+
+    // The synthesized Iterable<Shape> over the get/at index-get: `next()` lines up with
+    // the concrete element type, so iteration + the stdlib Iterable surface work.
+    @Test fun iterates_as_concrete_elements() = memScoped {
+        val ms = this
+        val bag = with(ShapeBag) { ms.ShapeBag() }
+        bag.add(with(Circle) { ms.Circle__double(1.0) })   // area = π
+        bag.add(with(Rectangle) { ms.Rectangle__double_double(2.0, 5.0) }) // area = 10
+        bag.add(with(Circle) { ms.Circle__double(3.0) })   // area = π·9
+
+        // The iterator yields the CONCRETE element type (`Shape?`), so area() dispatches
+        // through it; the elements are non-null here.
+        val areas = bag.map { it?.area() ?: 0.0 }
+        assertEquals(3, areas.size)
+        assertEquals(PI, areas[0], 1e-9)
+        assertEquals(10.0, areas[1], 1e-9)
+        assertEquals(PI * 9.0, areas[2], 1e-9)
+    }
+}

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -1403,11 +1403,18 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                     generateOperator(operator, cls, method)
                 } else {
                     val named = fixNaming(method)
+                    // A `get`/`at`-keyed index container's index-get returns a container
+                    // ELEMENT that must stay CONCRETE (so the synthesized iterator's
+                    // `next()` lines up and the element's own methods are reachable) — same
+                    // rule the `[]` operator already gets. Recognize it on the ORIGINAL
+                    // method (detectIndexIterable selects by the un-renamed identity).
+                    val keepConcreteElement = isIndexGetMethod(cls, method)
                     val emit: KotlinCodeBuilder.() -> Unit = {
                         generateBasicMethod(
                             named,
                             uniqueCName,
-                            methodName = overloadMethodName(cls, named)
+                            methodName = overloadMethodName(cls, named),
+                            keepConcreteElement = keepConcreteElement
                         )
                     }
                     // A method declared on the generic template interface OR on a base
@@ -1679,20 +1686,23 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         uniqueCName: Symbol,
         methodName: String = method.name,
         startArgs: List<Symbol> = listOf(ptr),
-        skipFirstArg: Boolean = true
+        skipFirstArg: Boolean = true,
+        keepConcreteElement: Boolean = false
     ) {
         function {
             name = methodName.kotlinMethodName()
             // Declared return upcast to a base interface when applicable; body keeps the
             // concrete returnType (constructs the concrete wrapper). See onGenerate(method).
-            // EXCEPT the index `[]` operator: it returns a CONTAINER ELEMENT, which must stay
+            // EXCEPT the index get: it returns a CONTAINER ELEMENT, which must stay
             // CONCRETE — the synthesized `Iterable<Elem>`/`iterator()` (detectIndexIterable)
             // declares the raw element type, and the element's own methods (e.g. a walked
             // `clang::Decl`'s getDeclKindName/asNamedDecl) live on the concrete class, not the
-            // (member-less) base interface. Remapping `get` to `DeclApi` both mismatched
-            // `next()` and made the elements useless.
+            // (member-less) base interface. Remapping the get to `DeclApi` both mismatched
+            // `next()` and made the elements useless. This covers BOTH the `[]` operator
+            // ([ResolvedOperator.IND]) AND the `get`/`at`-keyed fallbacks (via the
+            // [keepConcreteElement] flag the named-method path sets from [isIndexGetMethod]).
             retType = type(
-                if (method.operator == ResolvedOperator.IND) {
+                if (method.operator == ResolvedOperator.IND || keepConcreteElement) {
                     method.returnType
                 } else {
                     remapReturnType(method.returnType)
@@ -2285,8 +2295,15 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
      * @param elemFq the FQ Kotlin element type (`get`'s return) — `Point?`, or a
      *   `CValuesRef<IntVar>?` element pointer for primitive vectors
      * @param getName the Kotlin name the index get is emitted under (`operator[]` -> `get`)
+     * @param indexGet the resolved index-get method itself (the `operator[]` or the
+     *   `get`/`at` fallback) — so the basic-method emitter can recognize THIS method and
+     *   keep its element type CONCRETE (see [generateBasicMethod]).
      */
-    private data class IndexIterable(val elemFq: String, val getName: String)
+    private data class IndexIterable(
+        val elemFq: String,
+        val getName: String,
+        val indexGet: ResolvedMethod
+    )
 
     /**
      * Detect an index-accessible container (std::vector — exposes a `size()` plus an
@@ -2326,8 +2343,25 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         val getName = indexGet.operator?.kotlinOperatorType?.let {
             (it as? KotlinOperator)?.name
         } ?: overloadMethodName(cls, fixNaming(indexGet))
-        return IndexIterable(renderFqKotlinType(indexGet.returnType.kotlinType), getName)
+        return IndexIterable(
+            renderFqKotlinType(indexGet.returnType.kotlinType),
+            getName,
+            indexGet
+        )
     }
+
+    /**
+     * True when [method] is the index-get of an index-accessible container [cls] (the
+     * `operator[]`, or the `get`/`at` fallback that [detectIndexIterable] selected). Its
+     * return type is a CONTAINER ELEMENT that must stay CONCRETE — the synthesized
+     * `iterator()`'s `next()` calls this get and declares the raw element type, and the
+     * element's own methods live on the concrete class, not the (member-less) base
+     * interface. So the element type must NOT be upcast to a base interface. This covers
+     * `operator[]` (already special-cased via [ResolvedOperator.IND]) AND the `get`/`at`
+     * fallbacks, which route through the plain named-method path.
+     */
+    private fun isIndexGetMethod(cls: ResolvedClass, method: ResolvedMethod): Boolean =
+        detectIndexIterable(cls)?.indexGet === method
 
     /**
      * Emit the synthesized `override operator fun iterator()` for an index-accessible

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/RangeReturn.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/RangeReturn.kt
@@ -19,6 +19,8 @@ import clang.CXCursorKind.CXCursor_TypeAliasDecl
 import clang.CXCursorKind.CXCursor_TypedefDecl
 import clang.CXType
 import clang.CXTypeKind.CXType_Pointer
+import com.monkopedia.krapper.generator.DropLedger
+import com.monkopedia.krapper.generator.DropPhase
 import com.monkopedia.krapper.generator.canonicalType
 import com.monkopedia.krapper.generator.children
 import com.monkopedia.krapper.generator.getTemplateArgumentType
@@ -107,6 +109,17 @@ private fun elementOfIterator(iterator: CValue<CXType>): String? {
     if (canon.numTemplateArguments >= 1) {
         return stripDecoration(canon.getTemplateArgumentType(0u).spelling.toKString())
     }
+    // Recognized an `iterator_range<It>` but couldn't recover the element from `It` (no
+    // pointer/`value_type`/template-arg shape matched). The range method is dropped — keep
+    // that DECISION, but make it discoverable: a silent null here was an unanswerable "did
+    // the generator drop it?". PARSE phase: this is a cursor/CXType-level pass with no
+    // ResolveContext yet. (DropLedger.record is non-suspend, so it's callable here.)
+    DropLedger.record(
+        symbol = iterator.spelling.toKString() ?: "<unknown iterator_range element>",
+        reason = "iterator_range element type not extractable from iterator " +
+            "(no pointer/value_type/template-argument shape matched)",
+        phase = DropPhase.PARSE
+    )
     return null
 }
 

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -304,6 +304,74 @@ class ReturnShapeTest {
         )
     }
 
+    // #7 item 5: a method returning `llvm::iterator_range<It>` whose element type CAN'T be
+    // recovered from `It` (a plain class iterator with NO `value_type` typedef and no
+    // template argument — none of elementOfIterator's pointer/value_type/template-arg shapes
+    // match) is DROPPED from range materialization. The drop DECISION is unchanged, but it
+    // must now be DISCOVERABLE: elementOfIterator records a PARSE DropLedger entry instead of
+    // returning null silently. Asserts the ledger captured the drop with a reason, the
+    // dropped method carries no rangeElementType, and a sibling plain method still binds.
+    @Test
+    fun unextractableIteratorRangeRecordsDrop() {
+        DropLedger.reset()
+        val methods = methodsOf(
+            """
+            |namespace llvm {
+            |template <class It> class iterator_range {
+            |    It b_, e_;
+            |public:
+            |    iterator_range(It b, It e) : b_(b), e_(e) {}
+            |    It begin() const { return b_; }
+            |    It end() const { return e_; }
+            |};
+            |}
+            |struct Thing { int x; };
+            |// A plain (non-template) iterator class with NO value_type typedef: none of
+            |// elementOfIterator's shapes (pointer / value_type / first-template-arg) apply,
+            |// so the element can't be recovered.
+            |struct OpaqueIter {
+            |    Thing* p_;
+            |    Thing& operator*() const { return *p_; }
+            |    OpaqueIter& operator++() { ++p_; return *this; }
+            |    bool operator!=(const OpaqueIter& o) const { return p_ != o.p_; }
+            |};
+            |struct OpaqueRangeHolder {
+            |    OpaqueIter b_, e_;
+            |    llvm::iterator_range<OpaqueIter> things() const {
+            |        return llvm::iterator_range<OpaqueIter>(b_, e_);
+            |    }
+            |    int count() const { return 0; }
+            |};
+            """.trimMargin(),
+            "OpaqueRangeHolder"
+        )
+        // The drop is recorded (discoverable), with a non-empty reason, in the PARSE phase.
+        val rangeDrops = DropLedger.drops.filter {
+            it.phase == DropPhase.PARSE && it.reason.contains("iterator_range")
+        }
+        assertTrue(
+            rangeDrops.isNotEmpty(),
+            "an unextractable iterator_range must record a PARSE DropLedger entry; " +
+                "ledger was ${DropLedger.drops}"
+        )
+        assertTrue(
+            rangeDrops.all { it.reason.isNotBlank() },
+            "the drop record must carry a reason; got ${rangeDrops.map { it.reason }}"
+        )
+        // The range method got no element type (the drop DECISION is unchanged)...
+        val things = methods.firstOrNull { it.name == "things" }
+        assertTrue(
+            things == null || things.rangeElementType == null,
+            "the unextractable range method must not record an element type; " +
+                "got ${things?.rangeElementType}"
+        )
+        // ...but the rest of the class still binds.
+        assertTrue(
+            methods.any { it.name == "count" },
+            "the sibling plain method `count` must still bind; got ${methods.map { it.name }}"
+        )
+    }
+
     // A `const value_type&` arg where value_type is a POINTER (the std::vector<Thing*>
     // push_back/assign/fill-ctor shape the range materialization needs) must resolve to a
     // plain `Thing*`, NOT `const Thing*`. The top-level const on a by-value pointer is


### PR DESCRIPTION
Lands the remaining two items of #7 (items 1/2/4 already landed in v2).

## Item 3 — `operator[]` concrete-element special-case missed `get`/`at`-keyed containers
`generateBasicMethod` kept the CONCRETE element type only for `ResolvedOperator.IND`, but `detectIndexIterable` ALSO accepts a `get`/`at` index-get. A `get`/`at`-keyed container whose element is a base class emitted `next(): Concrete = at(i): BaseApi` — the get's return was upcast to the base interface, while the synthesized `iterator()`'s `next()` declares the concrete element type, so it didn't typecheck (the featuregen module failed to compile).

Fix: thread the container identity into the method. New `keepConcreteElement` flag on `generateBasicMethod`, set from a new `isIndexGetMethod(cls, method)` predicate that reuses `detectIndexIterable`'s exact selection (now also exposing the chosen index-get method). The `get`/`at` index-get gets the same concrete-element treatment as `[]`.

## Item 5 — `RangeReturn.elementOfIterator` dropped silently
It returned `null` when it recognized an `iterator_range<It>` but couldn't recover the element from `It`. Now records the drop into `DropLedger` (PARSE phase, with a clear reason) so it's discoverable. The drop DECISION is unchanged. `DropLedger.record` is non-suspend, so it's callable from this non-suspend path (resolves the earlier suspend-`Log.w` blocker; `DropLedger` merged via #6).

## Fixtures / tests
- **featuregen** `CvGetAtBaseElemTest` + a `ShapeBag` fixture (a `get`/`at`-keyed container with a `Shape*` base element). Without the fix, the synthesized iterator's `next()` vs the upcast `at()` don't typecheck and the module fails to compile; with it the concrete Shapes round-trip and `area()` virtual-dispatches. Verified in the generated binding: `at(i): Shape?` and `next(): Shape? = at(__i++)` line up.
- **krapper_gen** `ReturnShapeTest.unextractableIteratorRangeRecordsDrop`: an `iterator_range` over an opaque iterator (no `value_type`/template-arg) lands a PARSE `DropLedger` record with a reason, while the sibling plain method still binds.

## Verification (REAL gates)
- `:krapper_gen:nativeTest` — **305/0** (304 baseline + 1 new)
- `:featuregen:nativeTest` — **188/0** (186 baseline + 2 new)
- `:krapper_gen:ktlintCheck` — green

No goldens changed: the `keepConcreteElement` flag defaults false, so only `get`/`at` base-element containers (absent from `CppCodeTests`/`KotlinCodeTests`) are affected. Cold worktree needed the #25 manifest-convergence sync passes (not part of this change).

Closes #7 (items 3 + 5 — the remainder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)