### PR TITLE
Reduce: extract the repeated name.trimEnd('?') idiom into one plainName extension (#17 item 5)

### DIFF
--- a/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedType.kt
+++ b/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedType.kt
@@ -207,6 +207,13 @@ data class ResolvedKotlinType(
 
 fun nullable(base: ResolvedKotlinType): ResolvedKotlinType = base.copy(isNullable = true)
 
+// The plain Kotlin class name with the nullable `?` of its default use-position
+// stripped. `name` carries that `?` for a nullable type (the same ResolvedKotlinType a
+// nullable field/return uses); a declaration site, an identifier-derived helper name, or
+// a `<Name>Api`/`to<Name>` prefix needs the bare name without it.
+val ResolvedKotlinType.plainName: String
+    get() = name.trimEnd('?')
+
 fun ResolvedKotlinType.typedWith(parseTypes: List<ResolvedKotlinType>): ResolvedKotlinType =
     copy(templates = parseTypes)
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
@@ -19,6 +19,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedCType
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
 
 // The opaque-pointer C type the upcast helpers take and return (`void* D_as_B(void*)`).
 // Shared by CppWriter (definition) and HeaderWriter (declaration).
@@ -31,7 +32,7 @@ data class CastTarget(val cls: ResolvedClass, val base: ResolvedClass) {
     // Kotlin method name (`as<KotlinName>`) and the C helper name are derived from it,
     // so the name is stable across the Kotlin / C / header writers.
     val baseKotlinName: String
-        get() = base.type.kotlinType.name.trimEnd('?')
+        get() = base.type.kotlinType.plainName
 
     // The Kotlin upcast member name, e.g. `asDrawable2`.
     val kotlinMethodName: String
@@ -90,7 +91,7 @@ data class DownCastTarget(
 ) {
     // The derived's plain Kotlin name (no nullable suffix), e.g. "Derived1".
     val derivedKotlinName: String
-        get() = derived.type.kotlinType.name.trimEnd('?')
+        get() = derived.type.kotlinType.plainName
 
     // The Kotlin down-cast member name, e.g. `asDerived1` (returns a nullable `Derived1?`).
     val kotlinMethodName: String

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -101,6 +101,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedType
 import com.monkopedia.krapper.generator.resolvedmodel.type.fullyQualifiedType
 import com.monkopedia.krapper.generator.resolvedmodel.type.nullable
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
 import com.monkopedia.krapper.generator.resolvedmodel.type.typedWith
 
 // Recognizers for the renderable subset of C++ default-argument literals (see
@@ -261,11 +262,9 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // fixed boilerplate with no AST nodes to model.
     private fun renderEnum(enum: ResolvedKotlinType): String {
         val underlying = enum.enumUnderlying?.name ?: "Int"
-        // The enum's DECLARATION name must be the bare class name — `enum.name` carries the
-        // nullable `?` of the type's default use-position (it's the same ResolvedKotlinType
-        // a nullable field/return uses), which is illegal in a class declaration
-        // (`enum class TranslationUnitKind?`). Type USAGES keep the `?`; the declaration trims.
-        val name = enum.name.trimEnd('?')
+        // The enum's DECLARATION name must be the bare class name (`plainName`): an
+        // `enum class TranslationUnitKind?` is illegal. Type USAGES keep the `?`.
+        val name = enum.plainName
         val entries = enum.enumEntries.joinToString(", ") { entry ->
             "${entry.name}(${literalForUnderlying(entry.value, underlying)})"
         }
@@ -326,7 +325,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         // only be obtained by upcast from a concrete subtype, never constructed here.
         // The comment makes that absence discoverable to a reader of the binding.
         if (cls.isAbstract) {
-            val plainName = type.name.trimEnd('?')
+            val plainName = type.plainName
             comment(
                 "Abstract C++ class: no constructor factory is generated. Obtain a " +
                     "$plainName via a concrete subclass (upcast to ${plainName}Api)."
@@ -339,7 +338,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         // only a hazard when a derived is held via a base wrapper. Surface it as a
         // generated-code comment; non-fatal.
         if (hasNonVirtualDestructorHazard(cls)) {
-            val plainName = type.name.trimEnd('?')
+            val plainName = type.plainName
             comment(
                 "WARNING: polymorphic class with a non-virtual destructor — deleting a " +
                     "$plainName through a base pointer is undefined in C++ (the derived " +
@@ -364,7 +363,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
             // Comparable<Self> is needed for sorted()/maxOrNull() etc. — a bare
             // compareTo only gives `<`/`>`. (Composes with a template supertype above.)
             if (cls.children.any { it is ResolvedMethod && it.operator == ResolvedOperator.LT }) {
-                add("kotlin.Comparable<${type.name.trimEnd('?')}>")
+                add("kotlin.Comparable<${type.plainName}>")
             }
             // Iterable<Elem> for an index-accessible container (std::vector): `for (x in
             // v)` needs only the synthesized `iterator()` (emitted in onGenerateMethods),
@@ -672,9 +671,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // Derived::label -> derivedLabel. Lowercases the class initial so the result is
     // a conventional Kotlin member name.
     private fun classPrefixedName(cls: ResolvedClass, method: ResolvedMethod): String {
-        // kotlinType.name can carry a trailing '?' for a nullable wrapper type; strip
-        // it so the prefix is a plain identifier.
-        val clsName = cls.type.kotlinType.name.trimEnd('?')
+        val clsName = cls.type.kotlinType.plainName
         val prefix = clsName.replaceFirstChar { it.lowercase() }
         val suffix = method.name.replaceFirstChar { it.uppercase() }
         return prefix + suffix
@@ -742,7 +739,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                 cls.children.filterIsInstance<ResolvedDestructor>().firstOrNull()
             extensionFunction {
                 receiver = fqType(MEM_SCOPE)
-                name = cls.type.kotlinType.name.trimEnd('?') + "_Holder"
+                name = cls.type.kotlinType.plainName + "_Holder"
                 retType = type(cls.type)
                 body {
                     if (defaultConstructor != null) {
@@ -1163,7 +1160,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         val result = LinkedHashMap<String, BaseInterface>()
         for (typeString in baseTypeStrings) {
             val baseCls = currentClasses[typeString] ?: continue
-            val kotlinName = baseCls.type.kotlinType.name.trimEnd('?')
+            val kotlinName = baseCls.type.kotlinType.plainName
             val interfaceName = kotlinName + "Api"
             val pkg = baseCls.type.kotlinType.pkg
             val interfaceFqType = if (pkg.isEmpty()) interfaceName else "$pkg.$interfaceName"
@@ -1649,7 +1646,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         method.name.startsWith("operator ") &&
             method.name.substring("operator ".length)
                 .firstOrNull()?.let { it.isLetter() || it == '_' } == true ->
-            method.copy(name = "to" + method.returnType.kotlinType.name.trimEnd('?'))
+            method.copy(name = "to" + method.returnType.kotlinType.plainName)
 
         else -> method
     }
@@ -1786,7 +1783,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     private fun renderKotlinDefault(arg: ResolvedArgument): String? {
         val raw = arg.defaultValue?.trim()?.takeIf { it.isNotEmpty() } ?: return null
         val kotlinType = arg.type.kotlinType
-        val typeName = kotlinType.name.trimEnd('?')
+        val typeName = kotlinType.plainName
 
         // nullptr / NULL / 0 for a pointer/wrapper param -> Kotlin null.
         if (kotlinType.isWrapper || kotlinType.isNullable) {
@@ -2072,7 +2069,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                 initializer = memScope dot Call(
                     extensionMethod(
                         kotlinType.fullyQualified + ".Companion",
-                        kotlinType.name.trimEnd('?') + "_Holder"
+                        kotlinType.plainName + "_Holder"
                     )
                 )
             ).also {
@@ -2201,7 +2198,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // generated `_op_eq` C function over the two backing pointers. Using the
     // extensionMethod Call (rather than a Raw) keeps the C symbol's import wired up.
     private fun KotlinCodeBuilder.generateEquals(cls: ResolvedClass, method: ResolvedMethod) {
-        val typeName = cls.type.kotlinType.name.trimEnd('?')
+        val typeName = cls.type.kotlinType.plainName
         override {
             function {
                 name = "equals"
@@ -2523,7 +2520,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
 
     private fun constructorMethod(type: ResolvedKotlinType) = extensionMethod(
         type.pkg,
-        type.name.trimEnd('?')
+        type.plainName
     )
 
     private fun KotlinCodeBuilder.generateStringReturn(call: Symbol, free: Boolean = true) {


### PR DESCRIPTION
Extract the repeated "plain Kotlin class name with the nullable `?` stripped" computation, hand-inlined as `<x>.kotlinType.name.trimEnd('?')`, into one documented extension on `ResolvedKotlinType` (next to where the type is defined):

```kotlin
val ResolvedKotlinType.plainName: String get() = name.trimEnd('?')
```

**Sites folded (14):** CastTargets.kt (2: baseKotlinName, derivedKotlinName) + KotlinWriter.kt (12: renderEnum decl name, abstract/non-virtual-dtor diagnostics, Comparable supertype, classPrefixedName, _Holder factory name, base interface name, to<Target> conversion name, renderKotlinDefault typeName, ARG_CAST _Holder, generateEquals typeName, constructorMethod). Removed the now-redundant per-site comments explaining the trimEnd.

**Left out (genuinely different — not a `ResolvedKotlinType.name` strip):**
- `Resolver.kt:700,721` — `WrappedKotlinType.fullyQualified.first().trimEnd('?')` (different receiver type, different string)
- `KotlinWriter.kt:1925` — receiver is a raw `String` parameter, not a type
- `KotlinWriter.kt:2480` — strips `fullyQualified`, not `name`

**Byte-identical:** `plainName` is literally `name.trimEnd('?')`, so every folded site emits the identical string. Verified empirically — the generated Kotlin (119 files, same converged 17-instantiation set) is `diff -rq` clean before vs after. (The `.cc`/`.h`/`.a` binary churn in a full-tree manifest is the pre-existing #25 sync non-determinism, unrelated to this source-only change.)

**Net line delta:** +5 (the +7-line documented extension offset by dropping redundant per-site comments + shorter call sites).

**Verification:** `krapper_gen:nativeTest` **305/0**, `featuregen:nativeTest` **188/0**, `krapper_gen:ktlintCheck` green.

Refs #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)