### PR TITLE
Bring the clangwalk stage1 harness onto main (gated behind -PenableClang)

### DIFF
--- a/clangwalk/.gitignore
+++ b/clangwalk/.gitignore
@@ -1,0 +1,1 @@
+/krapped/

--- a/clangwalk/build.gradle.kts
+++ b/clangwalk/build.gradle.kts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.klinker.klinkedExecutable
+
+plugins {
+    kotlin("multiplatform")
+    id("com.monkopedia.kplusplus.compiler")
+    id("com.monkopedia.klinker.plugin") version "0.2.0"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+kotlin {
+    linuxX64("native") {
+        binaries {
+            klinkedExecutable {
+                // klinker links with the system clang++ (needed for modern libclang-cpp's
+                // glibc/libstdc++ symbol versions, absent from K/N's bundled old sysroot).
+                // K/N's DEBUG build pulls in the precompiled platform.linux cinterop cache
+                // WHOLE (no whole-program DCE), and it references dozens of OBSOLETE glibc
+                // symbols (__argp_parse, __argz_*, cfree, getmsg, …) modern glibc removed →
+                // ~111 undefined refs. `--gc-sections` lets the system linker dead-strip the
+                // unreferenced per-function sections (K/N emits one section per wrapper for
+                // exactly this) — giving DEBUG the same DCE release already gets from -opt.
+                // So BOTH build types link now: runDebugExecutableKlinker + the release one.
+                // (The durable home for this is a klinker default — see its LinkTask.)
+                linkerOpts("--gc-sections")
+                // The generated wrapper calls into Clang's C++ AST API, so the final
+                // executable links libclang-cpp (the monolithic LLVM/Clang shared lib)
+                // + LLVM core. -lstdc++ for the C++ wrapper runtime.
+                compilerOpts(
+                    "-L/usr/lib",
+                    "-lclang-cpp",
+                    "-lLLVM-22",
+                    "-lstdc++",
+                    "-lm",
+                    "-lpthread"
+                )
+                runTask()
+            }
+        }
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    optIn.add("kotlinx.cinterop.ExperimentalForeignApi")
+                    freeCompilerArgs.add("-g")
+                }
+            }
+        }
+    }
+}
+
+// Stage1 self-bootstrap consumer: bind a SLICE of Clang's C++ AST (the Decl hierarchy +
+// the buildASTFromCode entry point) and walk a real AST on the generated Kotlin bindings.
+// Scoped import (only + IGNORE_MISSING) keeps the bound surface to the allowlist instead
+// of exploding into Clang's whole transitive closure.
+kplusplus {
+    header("include/clang_slice.h")
+    // Clang's AST headers must be compiled with clang++, NOT the konan-bundled GCC-8.3
+    // (resolveDefaultCompiler's default) — GCC-8.3/libstdc++ aborts on them (exit 134).
+    compiler = "clang++"
+    cppStandard = "c++17"
+    referencePolicy = "IGNORE_MISSING"
+    only(
+        // Entry point: build an AST from a code string, reach the TU.
+        "clang::tooling::buildASTFromCode",
+        "clang::ASTUnit",
+        "clang::ASTContext",
+        // The Decl hierarchy we walk.
+        "clang::Decl",
+        "clang::NamedDecl",
+        "clang::DeclContext",
+        "clang::TranslationUnitDecl",
+        "clang::TagDecl",
+        "clang::RecordDecl",
+        "clang::CXXRecordDecl",
+        "clang::CXXMethodDecl",
+        "clang::FieldDecl",
+        "clang::ValueDecl",
+        "clang::DeclaratorDecl",
+        "clang::TypeDecl",
+        "clang::CXXBaseSpecifier"
+    )
+    // Materialize the range returns the walk iterates (decls()/methods()/bases()).
+    instantiate("std::vector<clang::Decl*>")
+    instantiate("std::vector<clang::CXXMethodDecl*>")
+    instantiate("std::vector<clang::CXXBaseSpecifier*>")
+}

--- a/clangwalk/include/clang_slice.h
+++ b/clangwalk/include/clang_slice.h
@@ -1,0 +1,4 @@
+#include <clang/Frontend/ASTUnit.h>
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/Tooling/Tooling.h>

--- a/clangwalk/src/nativeMain/kotlin/AstWalk.kt
+++ b/clangwalk/src/nativeMain/kotlin/AstWalk.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import clang.tooling.buildASTFromCode
+import kotlinx.cinterop.memScoped
+
+// Stage1 self-bootstrap: parse C++ into a real Clang AST and walk it — entirely on the
+// kplusplus-generated bindings of Clang's own C++ AST API (no libclang). This is the proof
+// that kplusplus can host the very frontend it was built with.
+fun main(args: Array<String>) = memScoped {
+    val source = """
+        struct Point { int x; int y; };
+        class Shape { public: virtual double area(); };
+        void freeFunction(int n);
+        int globalVar;
+    """.trimIndent()
+
+    // Entry point: clang::tooling::buildASTFromCode (unique_ptr<ASTUnit> -> owned ASTUnit).
+    val unit = buildASTFromCode(source, "input.cc")
+        ?: return@memScoped println("clangwalk: buildASTFromCode returned null")
+    val context = unit.getASTContext()
+        ?: return@memScoped println("clangwalk: no ASTContext")
+    val tu = context.getTranslationUnitDecl()
+        ?: return@memScoped println("clangwalk: no TranslationUnitDecl")
+
+    println("clangwalk: top-level declarations of the parsed TU")
+    var count = 0
+    // TranslationUnitDecl is-a DeclContext (upcast); decls() materializes the
+    // llvm::iterator_range<decl_iterator> into an iterable std::vector<clang::Decl*>.
+    for (decl in tu.asDeclContext().decls()) {
+        if (decl == null) continue
+        count++
+        val kind = decl.getDeclKindName() ?: "?"
+        // A NamedDecl has a name; down-cast (llvm::dyn_cast) to read it.
+        val name = decl.asNamedDecl()?.getName() ?: "<unnamed>"
+        println("  [$kind] $name")
+    }
+    println("clangwalk: walked $count top-level declarations via real libclang-cpp")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,17 @@ include(":plugin")
 include(":slice")
 include(":feature-tests")
 include(":featuregen")
+
+// :clangwalk is the stage1 self-bootstrap harness — it binds Clang's own C++ AST
+// (libclang-cpp) and walks a real AST on the generated bindings. It REQUIRES an LLVM
+// toolchain on the box (system clang++, libclang-cpp, LLVM-22) that an ordinary build
+// host won't have, so it is OFF by default and never configured on an LLVM-absent box.
+// Opt in with `-PenableClang` (or set `enableClang=true`); the probe also auto-includes
+// it when an explicit LLVM is requested via the `llvmConfig` property pointing at a real
+// llvm-config. Default OFF keeps `./gradlew` green everywhere.
+val enableClang = settings.providers.gradleProperty("enableClang").orNull
+val clangEnabled = (enableClang != null && enableClang != "false") ||
+    settings.providers.gradleProperty("llvmConfig").orNull?.let { File(it).canExecute() } == true
+if (clangEnabled) {
+    include(":clangwalk")
+}


### PR DESCRIPTION
## What this brings

The `clangwalk/` stage1 self-bootstrap harness, imported from `clang-selfhost`: kplusplus binds Clang's own C++ AST (libclang-cpp) and a Kotlin program walks a real parsed AST entirely on the generated bindings — no libclang-C. This is the first-class home for the campaign's end goal: replacing krapper_gen's libclang-C reducer with kplusplus-generated libclang-cpp bindings (full self-hosting).

Files: `clangwalk/build.gradle.kts`, `clangwalk/src/nativeMain/kotlin/AstWalk.kt`, `clangwalk/include/clang_slice.h`, `clangwalk/.gitignore`.

## Reconciliation against current main

`clang-selfhost` was branched off an old base (26b3d51), predating the v2/hermeticity/cold-start work now on main. On reconciliation:
- The kplusplus DSL used by the module — `header` / `compiler` / `cppStandard` / `referencePolicy` / `only(...)` / `instantiate(...)` — all still exist on current main's `KPlusPlusExtension`. No DSL drift.
- `klinker` pinned at `0.2.0`, matching `example/kotlin_project`. No hardcoded Kotlin version (inherits root). No `disableNativeCache`/`cacheKind` override needed — the module relies on `--gc-sections` to dead-strip K/N DEBUG's obsolete-glibc refs, so DEBUG and RELEASE both link.
- Generated output (`clangwalk/krapped/`) is gitignored; only source is tracked.

No code changes to the imported module were required beyond placing it under the gate.

## Gate mechanism

`settings.gradle.kts` only `include(":clangwalk")` when opted in:
- `-PenableClang` (bare flag or `=true`), or
- `-PllvmConfig=/path/to/llvm-config` pointing at a real executable.

Default OFF, so a plain `./gradlew` on an LLVM-absent box never configures the module (it needs system clang++, libclang-cpp, LLVM-22 — absent on ordinary hosts).

## Proof (this box: LLVM-22 + system clang++)

Gate OFF (default) — `./gradlew projects` excludes the module:
```
+--- Project ':feature-tests'
+--- Project ':featuregen'
+--- Project ':krapper_gen'
+--- Project ':plugin'
+--- Project ':slice'
+--- Project ':testlib_kotlin'
\--- Project ':testlib_kotlin_manual'
```
(no `:clangwalk`)

Gate ON — `./gradlew -PenableClang projects` includes `+--- Project ':clangwalk'`.

`./gradlew -PenableClang :clangwalk:kplusplusSync` → binds libclang-cpp, BUILD SUCCESSFUL (regenerated the 3 vector instantiations).

`./gradlew -PenableClang :clangwalk:runDebugExecutableKlinker` → the AST walk runs:
```
clangwalk: top-level declarations of the parsed TU
  [Typedef] __int128_t
  [Typedef] __uint128_t
  [Typedef] __NSConstantString
  [Typedef] __builtin_ms_va_list
  [Typedef] __builtin_va_list
  [CXXRecord] Point
  [CXXRecord] Shape
  [Function] freeFunction
  [Var] globalVar
clangwalk: walked 9 top-level declarations via real libclang-cpp
```

Rest-of-tree sanity (gate OFF, normal path): `./gradlew :featuregen:nativeTest` → 188/0.

## Note on requirements

`:clangwalk` needs `compiler = "clang++"` (konan's bundled GCC-8.3 aborts on Clang headers) plus `-lclang-cpp -lLLVM-22 -L/usr/lib`. CI / ordinary hosts without LLVM are unaffected because the gate defaults OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)