### PR TITLE
Fix INCLUDE_MISSING cycle guard: key the in-progress marker on the leaf, not the wrapped type (#10 step 1)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -561,7 +561,20 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
                         if (context.tracker.resolvedClasses[it.toString()] != null) {
                             return@operateOn RemoveElement
                         }
-                        context.tracker.otherResolved.add(t.toString())
+                        // Cycle guard: an outer frame may already be expanding this very
+                        // leaf (Clang's AST is densely cyclic — mutual Decl refs, CRTP
+                        // bases, pointer/ref members back into the hierarchy). If so, don't
+                        // recurse; the outer frame will store it. Key on the leaf `it` —
+                        // exactly what canResolve queries — NOT the wrapped carrier `t`
+                        // (e.g. `const clang::X &`). When a class is reached only through a
+                        // wrapped carrier, a `t`-keyed marker never matches the leaf the
+                        // guard checks, so a base/member edge re-entering the in-flight
+                        // class isn't deduped and resolution descends until the native
+                        // stack overflows.
+                        if (context.tracker.otherResolved.contains(it.toString())) {
+                            return@operateOn ElementUnchanged
+                        }
+                        context.tracker.otherResolved.add(it.toString())
                         try {
                             // Reference expansion: keep the legacy hard-fail when a
                             // pulled class's primary base can't resolve (don't
@@ -579,7 +592,7 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
                             context.tracker.resolvedClasses[resolved.type.toString()] = resolved
                             context.tracker.classes[wrapper.type.toString()] = wrapper
                         } finally {
-                            context.tracker.otherResolved.remove(t.toString())
+                            context.tracker.otherResolved.remove(it.toString())
                         }
                     } catch (original: Throwable) {
                         try {

--- a/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
@@ -369,6 +369,80 @@ class ParseTest {
         }
     }
 
+    // Issue #10 (broad-binding scale tail): regression coverage for the INCLUDE_MISSING
+    // cyclic-expansion guard. A seed class `Seed` exposes a `const Node&` accessor; `Node`
+    // (not seeded) has a `const Node&` self-accessor — a self-cycle closed by a WRAPPED
+    // const-reference, the minimal shape of Clang's self-referential AST nodes (a `Decl`'s
+    // accessors handing back `Decl&`). `Node` is reachable ONLY through the wrapped carrier,
+    // so the expansion mapper's in-progress marker is the leaf-vs-carrier case this fix
+    // targets.
+    //
+    // The mapper marks an in-progress leaf in `otherResolved`; the re-entry guard
+    // (`canResolve`) follows a wrapped type down to its BARE LEAF and queries the set by that
+    // leaf string. The marker used to be keyed on the WRAPPED carrier (`const fixture::Node
+    // &`) while the guard checks the leaf (`fixture::Node`), so for a wrapped-only class the
+    // marker was dead — the cycle was never deduped at the marker level and `Node` got
+    // re-resolved redundantly. This fix keys the marker on the leaf, so `canResolve(Node)`
+    // hits and the self-edge is cut.
+    //
+    // NOTE: at this UNIT scale the cycle still terminates WITHOUT the fix — the
+    // `resolvedClasses` cache + `mappingCache` + the (correctly-keyed-by-coincidence) bare
+    // own-type marker bound the redundant work to a constant factor. The native stack
+    // overflow that blocks the broad Clang surface is an emergent property of its dense
+    // ~1269-class graph and is not reproducible in a small fixture (verified empirically
+    // across pointer/const-ref/inheritance/self-ref fixtures). This test therefore asserts
+    // the cyclic INCLUDE_MISSING path TERMINATES and BINDS — it guards against a regression
+    // that would turn the now-deduped cycle back into unbounded descent — rather than
+    // claiming to crash the old code on its own.
+    @Test
+    fun testIncludeMissingCyclicReferenceTerminates() = memScoped {
+        runBlocking {
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val tmpFile = "/tmp/krapper_cyclic_${random()}_${random()}.h"
+            File(tmpFile).writeText(
+                """
+                |namespace fixture {
+                |class Node {
+                |public:
+                |    const Node& self() const;
+                |    int nodeValue() const;
+                |};
+                |class Seed {
+                |public:
+                |    const Node& getNode() const;
+                |};
+                |}
+                """.trimMargin()
+            )
+            val resolver = parseHeader(index, listOf(tmpFile), generateIncludes("clang++"))
+            // Seed only the second class — Node is reachable ONLY as a wrapped reference and
+            // must be pulled in by INCLUDE_MISSING, exercising the cyclic-expansion guard.
+            val allow = AllowListFilter(listOf("fixture::Seed"))
+            val found = resolver.findClasses(allow.wrapperFilter())
+            val foundNames = found.mapNotNull { (it as? WrappedClass)?.type?.toString() }
+            println("Cyclic seed found: $foundNames")
+            assertEquals(
+                setOf("fixture::Seed"),
+                foundNames.toSet(),
+                "Allowlist should select exactly Seed; got $foundNames"
+            )
+            // Resolution must terminate and the self-cyclic class must bind (a regression
+            // that un-keyed the marker would turn this into unbounded descent on the dense
+            // broad graph).
+            val resolved = found.resolveAll(resolver, ReferencePolicy.INCLUDE_MISSING)
+            val resolvedNames = resolved.filterIsInstance<ResolvedClass>()
+                .map { it.type.type }
+                .toSet()
+            println("Cyclic resolved: $resolvedNames")
+            assertTrue(
+                "fixture::Node" in resolvedNames,
+                "Node (the self-referential class) must be pulled in and bind under " +
+                    "INCLUDE_MISSING; got $resolvedNames"
+            )
+        }
+    }
+
     @Test
     fun testInstantiateAndWrite(): Unit = runBlocking {
         val outDir = "/tmp/krapper_slice_${random()}_${random()}"


### PR DESCRIPTION
## What

Corrects a mis-keyed cycle guard in the `INCLUDE_MISSING` expansion mapper (`krapper_gen/.../Resolver.kt`).

The mapper marks an in-progress leaf in `ResolveTracker.otherResolved` while it expands a missing referenced type. The re-entry guard `canResolve` follows a wrapped type down to its **bare leaf** and queries that set by the leaf string. But the marker was set/cleared on the **outer wrapped carrier** `t` (e.g. `const clang::X &`), not the leaf `it` (`clang::X`):

```
otherResolved.add(t.toString())     // "const clang::X &"
...
otherResolved.remove(t.toString())
```

For any class reached **only** through a wrapped carrier, the marker therefore never matched the leaf the guard checks — it was effectively dead. A base/member edge re-entering the in-flight class was not deduped at the marker level, so the class got re-resolved redundantly.

## Fix (2 lines + a defensive guard)

- Key the marker on the leaf `it` on both add and remove (matching what `canResolve` queries).
- Add a defensive short-circuit: if the leaf is already in progress, take the cycle exit (`ElementUnchanged`) instead of recursing.

## Test

Adds `ParseTest.testIncludeMissingCyclicReferenceTerminates`: a self-referential `const Node&` class reached only via a wrapped carrier from a seed class, under `INCLUDE_MISSING`. Asserts the cyclic path **terminates and binds**.

## Honest scope note (please read)

The root-cause hand-off predicted that a minimal mutually-referential pair would **SIGSEGV** without this fix. I could **not** reproduce that at unit scale. I tested four distinct minimal cyclic fixtures — pointer pair, const-ref pair, inheritance cycle, and self-reference — and **all terminate even with the buggy keying**. The `resolvedClasses` cache + `mappingCache` + the bare own-type marker (which is correctly keyed by coincidence, since `t == it` for a bare type) bound the redundant work to a constant factor in small graphs. The native stack overflow that blocks forcing the broad Clang surface is an **emergent property of its dense ~1269-class graph**, not reproducible in a small fixture.

So this PR is framed as **the correct cycle-guard keying + dedup, with regression coverage of the cyclic `INCLUDE_MISSING` path** — not as a fixture that crashes the old code on its own. A full broad-surface run (seed the `clang::Decl` hierarchy under `INCLUDE_MISSING` and confirm resolution terminates + capture the real C++ error tail, replacing the stale 284) is the right follow-up verification; I was unable to complete it in this turn because the broad clangwalk config needs the `only(...)` Decl seed kept (removing it empties the seed) and an environment hiccup cut the run short.

## Verification

- `:krapper_gen:nativeTest` — **306/0** (305 + the new test)
- `:featuregen:nativeTest` — **188/0**; `krapped/src` **byte-identical** (working tree shows only the 2 changed source files — normal generation unchanged)
- `:krapper_gen:ktlintCheck` — green

## Note for reviewers

A sibling branch `fix-include-missing-cycle-10b` exists (parallel/retry of this same task). This PR (`fix-include-missing-cycle-10`) is the one to review; please de-dup if the other surfaces.

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
