### PR TITLE
Resolver: skip-not-crash on unmodelable callback params (self-bootstrap GAP A)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
@@ -623,9 +623,32 @@ class WrappedArgument(
             // Secondary path: when the value instead survives as a literal STRING token
             // (the spelling-reconstruction path can yield `Mask<4>` with arg `"4"`),
             // [isNonTypeTemplateArg] classifies that token. Either path catches it.
+            //
+            // Third path — an unmodelable CALLBACK param (`llvm::function_ref<R(Args)>`,
+            // `std::function<R(Args)>`): the template arg is a FUNCTION TYPE (`int (Thing
+            // *)`), which the type model can't bind, so the param fails to resolve. But the
+            // hasDefault cursor heuristic misreads the callback signature's parenthesized
+            // param list as a default value (e.g. `cb`'s "default" surfaces as `Thing*`), so
+            // a callback param with NO real C++ default looks omittable. Trimming it then
+            // emits a SHORT call (`m(a)` for a 2-arg method) — an arity mismatch that fails
+            // to compile and aborts the whole build (the clangwalk self-host hit this on
+            // `clang::ASTContext::adjustType` / `forEachMultiversionedFunctionVersion`). A
+            // function-type arg is never a genuine, trimmable default, so treat it as a false
+            // default: the whole method drops (skip-not-crash, ledgered) instead.
             return referent is WrappedTemplateType &&
-                referent.templateArgs.any { it == UNRESOLVABLE || it.isNonTypeTemplateArg }
+                referent.templateArgs.any {
+                    it == UNRESOLVABLE || it.isNonTypeTemplateArg || it.isFunctionTypeArg
+                }
         }
+
+    // A template-argument WrappedType that is a FUNCTION TYPE — the `R(Args...)` callback
+    // signature inside `function_ref<R(Args...)>` / `std::function<R(Args...)>`. It surfaces
+    // as a bare type spelling carrying a parenthesized parameter list (`int (Thing *)`);
+    // plain/pointer/reference/template type spellings never contain `(`, so a `(` is the
+    // clean structural signal that this arg is a (function-)callable type the model can't
+    // bind by value.
+    private val WrappedType.isFunctionTypeArg: Boolean
+        get() = '(' in toString()
 
     // A template-argument WrappedType whose spelling is a VALUE literal rather than a
     // type name — i.e. a non-type template parameter's argument that survived as a string

--- a/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ParseTest.kt
@@ -369,6 +369,86 @@ class ParseTest {
         }
     }
 
+    // GAP A skip-not-crash on an unmodelable CALLBACK param. Under IGNORE_MISSING a method
+    // whose param is `llvm::function_ref<R(Args)>` / `std::function<R(Args)>` (here the
+    // self-contained `FnRef<int(Thing*)>` mimic — a partial specialization over a FUNCTION
+    // TYPE) can't be modeled. The bug: the hasDefault cursor heuristic misread the callback
+    // signature's parenthesized param list as a default value, so the param looked
+    // "omittable" and was silently TRIMMED — emitting a short call `withCallback(a)` for a
+    // 2-arg method (an arity mismatch that fails to compile and aborts the whole build, the
+    // clangwalk self-host's exit-134 on `clang::ASTContext::adjustType` /
+    // `forEachMultiversionedFunctionVersion`). Correct behavior: drop the WHOLE method
+    // (skip-not-crash, ledgered), exactly like an unresolvable return type. The genuinely-
+    // defaulted `withDefaulted` (a real `= Holder<Thing>()` default over a TYPE arg) must
+    // STILL bind by trimming its trailing default — proving the fix doesn't break the
+    // legitimate omittable-default path (e.g. buildASTFromCode's defaulted trailing params).
+    @Test
+    fun testUnmodelableCallbackParamDropsWholeMethod() = memScoped {
+        runBlocking {
+            DropLedger.reset()
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val tmpFile = "/tmp/krapper_callbackparam_${random()}_${random()}.h"
+            File(tmpFile).writeText(
+                """
+                |namespace fixture {
+                |class Thing { public: int v() const; };
+                |// Mimic of llvm::function_ref: a partial specialization over a function type.
+                |template <typename Fn> class FnRef;
+                |template <typename Ret, typename... Params>
+                |class FnRef<Ret(Params...)> {
+                |public:
+                |    FnRef() {}
+                |    template <typename C> FnRef(C&&) {}
+                |    Ret operator()(Params...) const;
+                |};
+                |template <typename T> class Holder { public: T* p; };
+                |class Fix {
+                |public:
+                |    int normal(int a) const;
+                |    int withCallback(int a, FnRef<int(Thing*)> cb) const;
+                |    int withDefaulted(int a, Holder<Thing> s = Holder<Thing>()) const;
+                |};
+                |}
+                """.trimMargin()
+            )
+            val resolver = parseHeader(index, listOf(tmpFile), generateIncludes("clang++"))
+            val allow = AllowListFilter(listOf("fixture::Fix"))
+            val found = resolver.findClasses(allow.wrapperFilter())
+            val resolved = found.resolveAll(resolver, ReferencePolicy.IGNORE_MISSING)
+            val fix = resolved.filterIsInstance<ResolvedClass>()
+                .first { it.type.type == "fixture::Fix" }
+            val methodNames = fix.children.filterIsInstance<ResolvedMethod>().map { it.name }
+            println("Callback-param resolved methods: $methodNames")
+            // The plain method still binds.
+            assertTrue(
+                "normal" in methodNames,
+                "the ordinary method must still bind; got $methodNames"
+            )
+            // The callback-param method is dropped WHOLE — never emitted with a trimmed
+            // (arity-mismatched) signature.
+            assertTrue(
+                "withCallback" !in methodNames,
+                "the unmodelable-callback-param method must be dropped, not trimmed; " +
+                    "got $methodNames"
+            )
+            // The genuinely-defaulted param method still binds (trailing default trimmed),
+            // proving the legitimate omittable-default path is intact.
+            assertTrue(
+                "withDefaulted" in methodNames,
+                "a genuinely-defaulted trailing param must STAY omittable; got $methodNames"
+            )
+            // The drop is recorded in the ledger with a reason.
+            val drop = DropLedger.drops.firstOrNull { "withCallback" in it.symbol }
+            assertTrue(
+                drop != null && drop.reason.isNotBlank(),
+                "the dropped callback method must be ledgered with a reason; " +
+                    "got ${DropLedger.drops}"
+            )
+            File(tmpFile).delete()
+        }
+    }
+
     // Issue #10 (broad-binding scale tail): regression coverage for the INCLUDE_MISSING
     // cyclic-expansion guard. A seed class `Seed` exposes a `const Node&` accessor; `Node`
     // (not seeded) has a `const Node&` self-accessor — a self-cycle closed by a WRAPPED


### PR DESCRIPTION
## Self-bootstrap GAP A — skip-not-crash on unmodelable callback params

### Root cause
Under `referencePolicy = IGNORE_MISSING` (the `clangwalk/` self-host harness), a method whose parameter is an unmodelable callback — `llvm::function_ref<R(Args)>` / `std::function<R(Args)>` — was **not** skip-not-crashed.

The callback's template argument is a **function type** (`int (Thing *)`) the type model can't bind, so the param fails to resolve. But the `hasDefault` cursor heuristic misreads the callback signature's parenthesized parameter list as a default value (the param's "default" surfaces as e.g. `Thing*`). So a genuinely-**required** param looked `isOmittableDefault` and was silently **trimmed** from the signature, while the emitted C++ glue still called the original method with its full arity:

```
withCallback(a)   // 2-arg method called with 1 arg → "too few arguments"
```

That arity mismatch fails to compile and aborts the whole build (the clangwalk stage-1 exit-134 on `clang::ASTContext::adjustType` and `forEachMultiversionedFunctionVersion`, previously papered over with `RemoveMethodByCName` fixups).

### Fix
`WrappedArgument.typeCarriesFalseDefault` already classifies array-bound and non-type-template-arg tokens as *false* defaults (a misread of a type token as a value). Extend it to also recognize a **function-type template argument** — structural signal: its spelling carries a `(`; plain / pointer / reference / template type spellings never do. A function-type arg is never a genuine, trimmable default, so the param is no longer `isOmittableDefault` and the **existing** param-resolution path drops the **whole method** (skip-not-crash, recorded in the `DropLedger`) — exactly like an unresolvable return type.

The legitimate omittable-default path is preserved: a genuinely-defaulted trailing param over a *type* arg (e.g. `buildASTFromCode`'s defaulted params, `shared_ptr<X>`) still trims and binds. `INCLUDE_MISSING` / featuregen output is unchanged.

### Test
`ParseTest.testUnmodelableCallbackParamDropsWholeMethod` — a self-contained `FnRef<int(Thing*)>` mimic (partial specialization over a function type) under `IGNORE_MISSING` asserts:
- the callback-param method is **dropped** and **ledgered** (no arity-mismatched short call),
- the plain sibling method binds,
- a genuinely-defaulted sibling (`Holder<Thing> s = Holder<Thing>()`) **still** binds (legitimate omit path intact).

### Verify (JDK 17, clean base off 6152cf5)
`./gradlew :krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck` — **BUILD SUCCESSFUL**
- krapper_gen **307/0** (baseline + the new test)
- featuregen **188/0**, `kplusplusSync` byte-identical (no git delta)
- ktlintCheck clean

Note: the `clangwalk/fixups.json` `removeMethod` workarounds for `adjust_type` / `for_each_multiversioned_function_version` become unnecessary after this fix, but clangwalk is on a separate branch and was left untouched (not verified end-to-end in this PR's budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)