### PR TITLE
krapper_gen: bind by-value std::string returns under IGNORE_MISSING (self-bootstrap GAP B)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -522,8 +522,8 @@ data class ResolveContext(
 }
 
 private fun typeMapper(policy: ReferencePolicy): TypeMapping {
-    return when (policy) {
-        ReferencePolicy.IGNORE_MISSING -> return { t, context ->
+    val mapper: TypeMapping = when (policy) {
+        ReferencePolicy.IGNORE_MISSING -> { t, context ->
             t.operateOn {
                 if (context.tracker.canResolve(it, context)) {
                     ElementUnchanged
@@ -533,7 +533,7 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
             }
         }
 
-        ReferencePolicy.OPAQUE_MISSING -> return { t, context ->
+        ReferencePolicy.OPAQUE_MISSING -> { t, context ->
             t.operateOn {
                 if (context.tracker.canResolve(it, context)) {
                     ElementUnchanged
@@ -543,7 +543,7 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
             }
         }
 
-        ReferencePolicy.THROW_MISSING -> return { t, context ->
+        ReferencePolicy.THROW_MISSING -> { t, context ->
             t.operateOn {
                 if (context.tracker.canResolve(it, context)) {
                     ElementUnchanged
@@ -553,7 +553,7 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
             }
         }
 
-        ReferencePolicy.INCLUDE_MISSING -> return { t, context ->
+        ReferencePolicy.INCLUDE_MISSING -> { t, context ->
             t.operateOn {
                 if (it.isArray) return@operateOn RemoveElement
                 if (!context.tracker.canResolve(it, context)) {
@@ -608,7 +608,71 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
             }
         }
     }
+    // INCLUDE_MISSING binds the basic_string class itself (so std::string returns surface
+    // as the wrapped Basic_string__Char) — leave it untouched so its output stays
+    // byte-identical. Under the missing-tolerant policies, first normalize an unbound
+    // canonical `basic_string<char>` to `std::string` so it survives as a STRING boundary
+    // instead of being dropped/opaqued. See [normalizeMissingCharString].
+    if (policy == ReferencePolicy.INCLUDE_MISSING) return mapper
+    return { t, context ->
+        val normalized = t.normalizeMissingCharString(context)
+        val result = mapper(normalized, context)
+        // When normalization rewrote `t` (basic_string<char> -> std::string) but the mapper
+        // then left the result unchanged (std::string resolves cleanly), `map()` would read
+        // ElementUnchanged as "keep the ORIGINAL `t`" and discard the rewrite. Surface the
+        // normalized type as a ReplaceWith so the std::string actually flows through.
+        if (normalized.toString() == t.toString()) {
+            result
+        } else {
+            when (result) {
+                ElementUnchanged -> ReplaceWith(normalized)
+                else -> result
+            }
+        }
+    }
 }
+
+// libstdc++ spells std::string's canonical type as the ABI-tagged template
+// `std::__cxx11::basic_string<char,...>` (or the plain `std::basic_string<char,...>`),
+// NOT the literal `std::string`. A method returning one by value (e.g. Clang's
+// `QualType::getAsString` / `NamedDecl::getNameAsString`) thus carries a template type
+// that — under a scoped (`only(...)`) import whose allowlist doesn't bind basic_string —
+// matches neither the STRING fast-path nor any tracked class, so a missing-tolerant
+// policy silently DROPS the whole method (self-bootstrap GAP B).
+private val CHAR_BASIC_STRING_BASES = setOf("std::basic_string", "std::__cxx11::basic_string")
+
+/**
+ * Normalize an unbound canonical `basic_string<char,...>` anywhere in [this] to the
+ * always-available `std::string`, so it rides the existing STRING -> `const char*` ->
+ * Kotlin String marshalling (the same destination [Parsing.rewriteViewReturns] routes
+ * `llvm::StringRef` to) instead of being dropped/opaqued as a missing reference. char-only:
+ * `wstring`/`u16string`/`u32string` (`basic_string<wchar_t>`/`<char16_t>`/`<char32_t>`) are
+ * NOT `char*` strings, so they are left untouched and follow the normal policy behavior.
+ *
+ * Reuses [operateOn] purely as a recursive walk: the handler never removes, so the rewrite
+ * reaches the basic_string node even for the multi-arg `<char, char_traits<char>,
+ * allocator<char>>` spelling (whose inner trait/allocator args would otherwise be the first
+ * to drop), and re-wraps it through any by-value / `const` / `const&` carrier. Gated on the
+ * basic_string class being UNRESOLVABLE: when it IS bound (an explicit allowlist entry) the
+ * type is left as the wrapped class.
+ */
+private suspend fun WrappedType.normalizeMissingCharString(context: ResolveContext): WrappedType =
+    when (
+        val result = operateOn { leaf ->
+            if (leaf is WrappedTemplateType &&
+                leaf.baseType.toString() in CHAR_BASIC_STRING_BASES &&
+                leaf.templateArgs.firstOrNull()?.toString() == "char" &&
+                !context.tracker.canResolve(leaf, context)
+            ) {
+                ReplaceWith(WrappedType("std::string"))
+            } else {
+                ElementUnchanged
+            }
+        }
+    ) {
+        is ReplaceWith -> result.replacement
+        else -> this
+    }
 
 suspend fun WrappedType.operateOn(typeHandler: suspend (WrappedType) -> MapResult): MapResult {
     when {

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -53,6 +53,27 @@ class ReturnShapeTest {
         }
     }
 
+    // Resolve [className] under a SCOPED import (only [className] is allowlisted) with the
+    // IGNORE_MISSING policy — the clangwalk self-host harness's exact configuration. Unlike
+    // [classOf] (INCLUDE_MISSING, which pulls std::basic_string in as a wrapped class), here
+    // basic_string is a missing reference, so the GAP B normalization is what keeps a
+    // std::string-by-value return alive (as a STRING boundary) instead of dropping it.
+    private fun scopedMethodsOf(header: String, className: String): List<ResolvedMethod> =
+        memScoped {
+            runBlocking {
+                val index = createIndex(0, 0) ?: error("Failed to create Index")
+                defer { index.dispose() }
+                val tmpFile = "/tmp/krapper_retshape_scoped_${random()}_${random()}.h"
+                File(tmpFile).writeText(header)
+                val resolver = parseHeader(index, listOf(tmpFile), generateIncludes("clang++"))
+                val found = resolver.findClasses(AllowListFilter(listOf(className)).wrapperFilter())
+                found.resolveAll(resolver, ReferencePolicy.IGNORE_MISSING)
+                    .filterIsInstance<ResolvedClass>()
+                    .first { it.type.type == className }
+                    .children.filterIsInstance<ResolvedMethod>()
+            }
+        }
+
     // Emit the C++ wrapper body for one method of a resolved class (the same CppWriter path
     // the real generator runs) so a test can assert the emitted C boundary code.
     private fun emittedCpp(cls: ResolvedClass, method: ResolvedMethod): String = runBlocking {
@@ -99,6 +120,47 @@ class ReturnShapeTest {
         assertTrue(
             methods.any { it.name == "name" },
             "const std::string-by-value method `name` must bind; got ${methods.map { it.name }}"
+        )
+    }
+
+    // GAP B (self-bootstrap front-end): under a SCOPED import (`only(...)`) + IGNORE_MISSING
+    // — the clangwalk harness config — a `std::string`-by-value return surfaces under its
+    // canonical template spelling `std::__cxx11::basic_string<char>`, whose basic_string
+    // class is NOT allowlisted. Before the fix the whole method was silently DROPPED as a
+    // missing dependency (this is the wall for Clang's `QualType::getAsString` /
+    // `NamedDecl::getNameAsString`). The normalization rewrites the unbound basic_string<char>
+    // to `std::string`, so the method SURVIVES and surfaces as Kotlin String. Covers the
+    // by-value and the top-level-`const` by-value forms (both real on the Clang surface).
+    @Test
+    fun scopedStringByValueReturnBindsAsString() {
+        val methods = scopedMethodsOf(
+            """
+            |#include <string>
+            |struct ScopedStrProbe {
+            |    std::string getNameAsString() const { return "x"; }
+            |    const std::string getAsString() const { return "y"; }
+            |    int id() const { return 1; }
+            |};
+            """.trimMargin(),
+            "ScopedStrProbe"
+        )
+        for (name in listOf("getNameAsString", "getAsString")) {
+            val method = methods.firstOrNull { it.name == name }
+            assertTrue(
+                method != null,
+                "scoped std::string-by-value method `$name` must survive IGNORE_MISSING; " +
+                    "got ${methods.map { it.name }}"
+            )
+            assertTrue(
+                method.returnType.kotlinType.fullyQualified.startsWith("kotlin.String"),
+                "`$name` must surface as Kotlin String; " +
+                    "got ${method.returnType.kotlinType.fullyQualified}"
+            )
+        }
+        // Sanity: a sibling plain method binds too (the class itself isn't the problem).
+        assertTrue(
+            methods.any { it.name == "id" },
+            "sibling plain method `id` must bind; got ${methods.map { it.name }}"
         )
     }
 


### PR DESCRIPTION
## Self-bootstrap GAP B: by-value `std::string` returns dropped under scoped IGNORE_MISSING

A method returning `std::string` **by value** — e.g. `clang::QualType::getAsString()` and `clang::NamedDecl::getNameAsString()`, the type-string + name extraction at the crux of the clangwalk self-host front-end — was **silently DROPPED** under a scoped (`only(...)`) import + `IGNORE_MISSING` (the `clangwalk/` harness config). This is the wall for the front-end campaign.

### Confirmed root cause
libclang spells `std::string`'s canonical type as the libstdc++ ABI-tagged template **`std::__cxx11::basic_string<char>`** (NOT the literal `std::string`). Empirically confirmed via the scoped repro: the return surfaces as `std::__cxx11::basic_string<char>` (a `WrappedTemplateType`), `getNameAsString` drops, and a sibling `int`-returning method survives.

Under a scoped import whose allowlist doesn't bind `basic_string`, that template matches neither the STRING fast-path (`isString == name == "std::string"`) nor any tracked class, so a missing-tolerant policy treats it as a missing dependency and drops the whole method. (This is also why the brick-1 in-build-script workaround of adding `"std::string"` to `only()` failed — name mismatch.)

### Fix
In `typeMapper` (`Resolver.kt`), for the missing-tolerant policies (IGNORE/OPAQUE/THROW), normalize an **unbound** canonical `basic_string<char,...>` to the always-available `std::string` *before* the policy decision, so it rides the EXISTING `STRING -> const char* -> Kotlin String` marshalling (the same destination `rewriteViewReturns` routes `llvm::StringRef` to). No marshalling logic is duplicated.

- **Gated on the `basic_string` class being unresolvable**, so `INCLUDE_MISSING` (featuregen) — which binds `basic_string` as the wrapped `Basic_string__Char` class — is left untouched and its emitted output stays **byte-identical**.
- **char-only**: `wstring`/`u16string`/`u32string` (`basic_string<wchar_t>`/`<char16_t>`/`<char32_t>`) are not `char*` strings and are left alone.
- Reuses `operateOn` as a non-removing recursive walk, so it reaches the `basic_string` node even for the multi-arg `<char, char_traits<char>, allocator<char>>` spelling, and re-wraps through by-value / `const` / `const&` carriers.
- A small wrapper surfaces the normalized type as a `ReplaceWith` (the mapper otherwise returns `ElementUnchanged`, which `map()` reads as "keep the original" and would discard the rewrite).

### Test
`ReturnShapeTest.scopedStringByValueReturnBindsAsString` locks the `IGNORE_MISSING` + `only()` path: a by-value and a top-level-`const` by-value `std::string` return must SURVIVE resolution and surface as Kotlin `String`.

### Verify (single foreground run, JDK 17)
`./gradlew :krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck`
- krapper_gen nativeTest: **308 / 0**
- featuregen kplusplusSync: **byte-identical** (no `krapped/` drift)
- featuregen nativeTest: **188 / 0**
- krapper_gen ktlintCheck: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)