### PR TITLE
krapper_gen: don't normalize a pointer-carried basic_string<char> (GAP B follow-up)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -649,28 +649,44 @@ private val CHAR_BASIC_STRING_BASES = setOf("std::basic_string", "std::__cxx11::
  * `wstring`/`u16string`/`u32string` (`basic_string<wchar_t>`/`<char16_t>`/`<char32_t>`) are
  * NOT `char*` strings, so they are left untouched and follow the normal policy behavior.
  *
- * Reuses [operateOn] purely as a recursive walk: the handler never removes, so the rewrite
- * reaches the basic_string node even for the multi-arg `<char, char_traits<char>,
- * allocator<char>>` spelling (whose inner trait/allocator args would otherwise be the first
- * to drop), and re-wraps it through any by-value / `const` / `const&` carrier. Gated on the
- * basic_string class being UNRESOLVABLE: when it IS bound (an explicit allowlist entry) the
- * type is left as the wrapped class.
+ * Descends only carriers the STRING boundary can actually marshal: by-value, `const`, and
+ * reference (`&`), re-wrapping the basic_string node through them. A POINTER (`*`) or array
+ * (`[]`) carrier is a HARD STOP — a `std::string*` out-param (e.g. `clang::Decl::getAvailability(
+ * std::string*)`) can't ride the `const char*` boundary: the cast-var is declared with the
+ * pointer-typed `targetType`, so normalizing it would emit `std::string* x = std::string(arg)`,
+ * which does not compile and aborts the whole wrapper build. Leaving such a type unbound makes
+ * the arg/method DROP cleanly (the pre-GAP-B behavior) instead of producing broken codegen.
+ * Matches the basic_string node even for the multi-arg `<char, char_traits<char>,
+ * allocator<char>>` spelling. Gated on the basic_string class being UNRESOLVABLE: when it IS
+ * bound (an explicit allowlist entry) the type is left as the wrapped class.
  */
 private suspend fun WrappedType.normalizeMissingCharString(context: ResolveContext): WrappedType =
-    when (
-        val result = operateOn { leaf ->
-            if (leaf is WrappedTemplateType &&
-                leaf.baseType.toString() in CHAR_BASIC_STRING_BASES &&
-                leaf.templateArgs.firstOrNull()?.toString() == "char" &&
-                !context.tracker.canResolve(leaf, context)
-            ) {
-                ReplaceWith(WrappedType("std::string"))
-            } else {
-                ElementUnchanged
-            }
-        }
-    ) {
-        is ReplaceWith -> result.replacement
+    when {
+        // Pointer / array carrier: cannot marshal through the const char* boundary — stop.
+        this is WrappedModifiedType && (modifier == "*" || modifier == "[]") -> this
+
+        this is WrappedModifiedType ->
+            WrappedModifiedType(baseType.normalizeMissingCharString(context), modifier)
+
+        this is WrappedPrefixedType ->
+            WrappedPrefixedType(baseType.normalizeMissingCharString(context), modifier)
+
+        this is WrappedTemplateType &&
+            baseType.toString() in CHAR_BASIC_STRING_BASES &&
+            templateArgs.firstOrNull()?.toString() == "char" &&
+            !context.tracker.canResolve(this, context) ->
+            WrappedType("std::string")
+
+        // A non-string template still carries value-position args (e.g. a by-value
+        // `pair<std::string,int>`); descend into them so a nested marshallable string survives.
+        this is WrappedTemplateType ->
+            WrappedTemplateType(
+                baseType,
+                templateArgs.map {
+                    it.normalizeMissingCharString(context)
+                }
+            )
+
         else -> this
     }
 

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -164,6 +164,52 @@ class ReturnShapeTest {
         )
     }
 
+    // GAP B regression: the normalization must NOT reach a basic_string<char> behind a POINTER.
+    // A `std::string*` out-param (the real `clang::Decl::getAvailability(std::string*)` shape)
+    // can't ride the STRING -> `const char*` boundary: the cast-var is declared with the
+    // pointer-typed targetType, so normalizing it emitted `std::string* x = std::string(arg)`,
+    // which does NOT compile and aborted the whole clangwalk wrapper build. The pointer-carried
+    // method must DROP cleanly (the pre-GAP-B behavior), while a by-value and a `const&` string
+    // on the same class still survive (those marshal through a value-typed cast-var).
+    @Test
+    fun scopedStringPointerParamDropsNotCrashes() {
+        val methods = scopedMethodsOf(
+            """
+            |#include <string>
+            |struct PtrStrProbe {
+            |    std::string getName() const { return "x"; }
+            |    int byConstRef(const std::string& s) const { return (int) s.size(); }
+            |    bool isDeprecated(std::string* message) const { return message != nullptr; }
+            |    int id() const { return 1; }
+            |};
+            """.trimMargin(),
+            "PtrStrProbe"
+        )
+        // The std::string* out-param method must drop (it can't marshal a pointer-to-string).
+        assertTrue(
+            methods.none { it.name == "isDeprecated" },
+            "a std::string* out-param method must DROP, not bind with broken codegen; " +
+                "got ${methods.map { it.name }}"
+        )
+        // ...but a `const std::string&` IN param still marshals from Kotlin String.
+        assertTrue(
+            methods.any { it.name == "byConstRef" },
+            "a const std::string& in-param method must still bind; got ${methods.map { it.name }}"
+        )
+        // ...while the by-value std::string return and the sibling plain method still bind.
+        val getName = methods.firstOrNull { it.name == "getName" }
+        val getNameType = getName?.returnType?.kotlinType?.fullyQualified
+        assertTrue(
+            getNameType?.startsWith("kotlin.String") == true,
+            "by-value std::string return `getName` must still survive as Kotlin String; " +
+                "got ${methods.map { it.name }}"
+        )
+        assertTrue(
+            methods.any { it.name == "id" },
+            "sibling plain method `id` must bind; got ${methods.map { it.name }}"
+        )
+    }
+
     // T1.6 / G8: a trivially-copyable value type returned by value, AND with a
     // top-level const. Both must bind (the const-by-value one must not get a
     // spurious `const T` in its emitted C type).


### PR DESCRIPTION
## What
GAP B (#37) normalizes an unbound canonical `std::__cxx11::basic_string<char>` to `std::string` so it rides the STRING -> `const char*` boundary. But `normalizeMissingCharString` descended through **every** carrier — including a **pointer**. A `std::string*` out-param (e.g. `clang::Decl::getAvailability(std::string*)` / `isDeprecated(std::string*)`) therefore got normalized, and since the STRING arg cast-var is declared with the pointer-typed `targetType`, the wrapper emitted:

```cpp
std::string* x = std::string(arg);   // value assigned to a pointer — won't compile
```

…which aborts the **entire** generated-wrapper build. This was the wall for the clangwalk self-host harness once the `QualType`/`ASTContext` surface is bound.

## Fix
`normalizeMissingCharString` now descends only carriers the `const char*` boundary can actually marshal (by-value, `const`, reference, and value-position template args) and **hard-stops at a pointer/array carrier** — leaving the unbound `basic_string` in place so the arg/method drops cleanly (the pre-GAP-B behavior) instead of emitting broken codegen. By-value and `const std::string&` still normalize (their cast-var is value-typed — an lvalue that binds fine).

## Safety
The mapper short-circuits before `normalizeMissingCharString` for `INCLUDE_MISSING` (featuregen's policy), so **featuregen output stays byte-identical**; the rewrite only ever ran under the missing-tolerant policies.

## Test
`ReturnShapeTest.scopedStringPointerParamDropsNotCrashes` locks it: under `IGNORE_MISSING` + `only(...)`, a `std::string*` out-param method DROPS while a by-value `std::string` return and a `const std::string&` in-param on the same class survive.

## Verify (JDK 17)
- `:krapper_gen:nativeTest` green
- `:krapper_gen:ktlintCheck` clean
- `:featuregen:kplusplusSync` byte-identical + `:featuregen:nativeTest` green

Proven end-to-end: the clangwalk stage1 walk now binds `clang::NamedDecl::getNameAsString()` and `clang::QualType::getAsString()` and prints real names + type spellings (`freeFunction : void (int)`, `globalVar : int`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)