### PR TITLE
clangwalk: prove the EXTRACT primitives — bind QualType + walk getNameAsString()/getAsString()

### DIFF
--- a/clangwalk/build.gradle.kts
+++ b/clangwalk/build.gradle.kts
@@ -95,10 +95,24 @@ kplusplus {
         "clang::ValueDecl",
         "clang::DeclaratorDecl",
         "clang::TypeDecl",
-        "clang::CXXBaseSpecifier"
+        "clang::CXXBaseSpecifier",
+        // QualType is the carrier for a decl's type. Binding it lets ValueDecl::getType()
+        // survive and exposes QualType::getAsString() (a by-value std::string return) — the
+        // #37 EXTRACT payoff: under IGNORE_MISSING the string return now normalizes to a
+        // Kotlin String instead of dropping the whole method.
+        "clang::QualType"
     )
     // Materialize the range returns the walk iterates (decls()/methods()/bases()).
     instantiate("std::vector<clang::Decl*>")
     instantiate("std::vector<clang::CXXMethodDecl*>")
     instantiate("std::vector<clang::CXXBaseSpecifier*>")
+    // ASTContext::adjustType(QualType, llvm::function_ref<QualType(QualType)>) has an
+    // un-modelable function_ref second arg. With QualType now bound its return resolves, so
+    // the method is no longer dropped-by-unresolved-return — and the function_ref param is
+    // mis-flagged omittable-default (the cursor-children default heuristic fires on the
+    // function_ref's type tokens), emitting an under-arity `adjustType(Old)` call that won't
+    // compile. Drop it explicitly until that heuristic is tightened (a krapper_gen follow-up).
+    fixup {
+        removeMethod("clang_ASTContext_adjust_type")
+    }
 }

--- a/clangwalk/src/nativeMain/kotlin/AstWalk.kt
+++ b/clangwalk/src/nativeMain/kotlin/AstWalk.kt
@@ -43,9 +43,14 @@ fun main(args: Array<String>) = memScoped {
         if (decl == null) continue
         count++
         val kind = decl.getDeclKindName() ?: "?"
-        // A NamedDecl has a name; down-cast (llvm::dyn_cast) to read it.
-        val name = decl.asNamedDecl()?.getName() ?: "<unnamed>"
-        println("  [$kind] $name")
+        // A NamedDecl has a name; down-cast (llvm::dyn_cast) to read it. getNameAsString()
+        // returns std::string by value — under IGNORE_MISSING that return only binds because
+        // #37 normalizes the canonical basic_string<char> spelling to a Kotlin String.
+        val name = decl.asNamedDecl()?.getNameAsString() ?: "<unnamed>"
+        // A ValueDecl (var / function) carries a QualType; QualType::getAsString() is the
+        // second by-value std::string EXTRACT primitive — the type spelling as Clang reports.
+        val typeStr = decl.asValueDecl()?.getType()?.getAsString()?.let { " : $it" } ?: ""
+        println("  [$kind] $name$typeStr")
     }
     println("clangwalk: walked $count top-level declarations via real libclang-cpp")
 }


### PR DESCRIPTION
## What
Advances the stage1 self-bootstrap harness from "names via `getName()`" to the two by-value `std::string` **EXTRACT** primitives the front-end campaign needs — exercising the GAP B (#37) path against **real Clang headers**, not just the krapper unit test:

- add `clang::QualType` to `only(...)` so a decl's type is reachable;
- the walk now reads `NamedDecl::getNameAsString()` (instead of `getName()`) and, for each `ValueDecl`, `getType().getAsString()` — both `std::string`-by-value returns that only bind because #37 normalizes the canonical `std::__cxx11::basic_string<char>` spelling to a Kotlin `String`.

## Residual gap handled via fixup
Binding `QualType` un-drops `ASTContext::adjustType(QualType, llvm::function_ref<QualType(QualType)>)` (its return now resolves). That exposes a GAP-A-residual: the `function_ref` second arg is mis-flagged omittable-default, so the wrapper emits an under-arity `adjustType(Old)` call that won't compile. Dropped via the supported `fixup { removeMethod("clang_ASTContext_adjust_type") }` until that heuristic is tightened (separate krapper_gen follow-up).

## Safety / dependency
Gated behind `-PenableClang` (+ `clang++` / `-lclang-cpp -lLLVM-22`), so it cannot affect LLVM-absent builds. **Depends on #38** (the pointer-carried-`std::string` fix) to compile the generated wrapper.

## Verified
`:clangwalk:runReleaseExecutableKlinker -PenableClang` parses C++ via `buildASTFromCode`, walks the TU entirely on kplusplus-generated libclang-cpp bindings, and prints real names + Clang-correct type spellings:

```
clangwalk: top-level declarations of the parsed TU
  [CXXRecord] Point
  [CXXRecord] Shape
  [Function] freeFunction : void (int)
  [Var] globalVar : int
clangwalk: walked 9 top-level declarations via real libclang-cpp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)