### PR TITLE
krapper_gen: cumulative forcing recovery — ALL range accessors of one class survive multi-instantiation (TRAVERSE gap)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -92,6 +92,15 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     // for an unrestricted DefaultFilter import (every non-std class is requested).
     private val requested = mutableListOf<String>()
 
+    // The container specializations forced by instantiation requests SO FAR, accumulated
+    // across every requestInstantiation call. Threaded into each resolveForcing so a later
+    // request's pass-3 re-resolve of an already-bound class can recover EVERY range accessor
+    // of that class (one per forced container) at once — not just the one this request forced,
+    // which the per-call fresh tracker + last-wins merge would otherwise leave as the sole
+    // survivor (e.g. CXXRecordDecl keeping only decls() and dropping methods()/bases()). See
+    // `resolveForcing`'s [forcedContainerKeys] doc.
+    private val forcedContainerKeys = mutableSetOf<String>()
+
     init {
         scope.defer {
             index.dispose()
@@ -254,7 +263,8 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         val newClasses = scopedFound.resolveForcing(
             resolver,
             config.referencePolicy,
-            alreadyBoundKeys
+            alreadyBoundKeys,
+            forcedContainerKeys
         )
         classes = classes + newClasses.filter {
             it !is ResolvedMethod || it.forcingIdentity in boundMethodIds

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -184,11 +184,27 @@ suspend fun List<WrappedElement>.resolveAll(
  * bound classes are excluded from the count; the writer's last-wins dedup still picks up
  * the re-resolved bound classes, which is how `items()` is restored). The full
  * resolved set (minus the transient forcing struct) is returned for appending.
+ *
+ * [forcedContainerKeys] is a CUMULATIVE, in/out set of the container specs forced by every
+ * EARLIER instantiation request, shared across the whole run. It exists because each request
+ * gets its OWN `resolveForcing` with a FRESH tracker holding only THAT request's container,
+ * yet a single owning class can have SEVERAL range accessors over DIFFERENT containers (e.g.
+ * Clang's `CXXRecordDecl` with `methods() -> vector<CXXMethodDecl*>`, `bases() ->
+ * vector<CXXBaseSpecifier*>` and `decls() -> vector<Decl*>`). With only the current request's
+ * container in the tracker, pass 3 recovers THAT one range method and re-drops the others
+ * (their containers aren't visible), and the writer's last-wins dedup keeps whichever request
+ * ran last — silently losing the rest (`decls()` survived only by sorting last). Seeding the
+ * prior containers here (IGNORE_MISSING only — see pass 3) makes `canResolve` true for ALL of
+ * them, so pass 3 recovers EVERY range accessor of the re-resolved class regardless of the
+ * order requests are processed in (the set is cumulative, so whichever request runs last sees
+ * every container). This function also ADDS the container(s) it forces to the set, for the
+ * next request.
  */
 suspend fun List<WrappedElement>.resolveForcing(
     resolver: Resolver,
     policy: ReferencePolicy,
-    alreadyBoundKeys: Set<String>
+    alreadyBoundKeys: Set<String>,
+    forcedContainerKeys: MutableSet<String> = mutableSetOf()
 ): List<ResolvedElement> {
     val classes = filterIsInstance<WrappedClass>()
     // The `KrapperForce_*` struct's `value` member type IS the forced container
@@ -320,6 +336,20 @@ suspend fun List<WrappedElement>.resolveForcing(
         boundClasses.map { it.type.toString() }.toSet()
     }
     evictKeys.forEach { baseContext.tracker.resolvedClasses.remove(it) }
+    // CUMULATIVE forcing recovery: make every PRIOR request's container visible to this
+    // pass-3 re-resolve, not just the one this request forced. `otherResolved` is the set
+    // `canResolve` short-circuits on (it returns true before reaching any on-demand class
+    // resolution), so seeding it keeps a range method whose return container was forced by an
+    // EARLIER request — e.g. when this request forced `vector<Decl*>`, the owning
+    // `CXXRecordDecl`'s `methods()`/`bases()` (forced by sibling requests) are recovered here
+    // too instead of being re-dropped and overwriting the earlier recovery via last-wins.
+    // Seeds are query-only: they don't enter `resolvedClasses`, so they're neither emitted nor
+    // returned (the container is emitted by the request that actually forced it). IGNORE_MISSING
+    // only: under INCLUDE_MISSING nothing dropped in pass 1 (methods materialize on-demand), so
+    // there's nothing to recover and seeding would needlessly perturb the featuregen-stable path.
+    if (policy == ReferencePolicy.IGNORE_MISSING) {
+        baseContext.tracker.otherResolved.addAll(forcedContainerKeys)
+    }
     val pass3 = baseContext
         .withPolicyKeepingNamer(policy)
         .copy(mappingCache = mutableMapOf())
@@ -339,10 +369,18 @@ suspend fun List<WrappedElement>.resolveForcing(
     // transient forcing struct (it's scaffolding, never emitted) and return the rest.
     val resolved = baseContext.tracker.resolvedClasses.values.toList()
         .filter { it.type.toString().contains("KrapperForce_").not() } + methods
-    val newCount = resolved.count { element ->
-        (element as? ResolvedClass)?.type?.toString()?.let { it !in alreadyBoundKeys } == true
+    // Record the container(s) THIS request forced (the genuinely-new resolved classes pass 2
+    // materialized — i.e. those not already bound) so the NEXT request's pass 3 can see them.
+    // This is the cumulative half of the order-independent recovery seeded above. Captured for
+    // every policy (cheap, and never read back under INCLUDE_MISSING where seeding is gated off).
+    val newClassKeys = resolved.mapNotNull { element ->
+        (element as? ResolvedClass)?.type?.toString()?.takeIf { it !in alreadyBoundKeys }
     }
-    Log.i("Forcing introduced $newCount new class(es) (re-resolved ${resolved.size} total)")
+    forcedContainerKeys.addAll(newClassKeys)
+    Log.i(
+        "Forcing introduced ${newClassKeys.size} new class(es) " +
+            "(re-resolved ${resolved.size} total)"
+    )
     return resolved
 }
 

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -23,6 +23,7 @@ import com.monkopedia.krapper.generator.codegen.File
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ArgumentCastMode
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -573,6 +574,128 @@ class ReturnShapeTest {
                 newSpecs.any { it.contains("vector", ignoreCase = true) },
                 "Forcing std::vector<Thing*> under IGNORE_MISSING must bind the container " +
                     "specialization; new specs were $newSpecs"
+            )
+        }
+    }
+
+    // TRAVERSE gap: when SEVERAL element vectors are force-instantiated over the SAME owning
+    // class, ALL of that class's range accessors must survive — not just the last one. This is
+    // the analog of Clang's `CXXRecordDecl` with `methods() -> vector<CXXMethodDecl*>`,
+    // `bases() -> vector<CXXBaseSpecifier*>` and `decls() -> vector<Decl*>`: each request runs
+    // its OWN resolveForcing with a fresh tracker holding only THAT request's container, so
+    // pass 3 re-resolves the owning class against one container, recovers THAT range method and
+    // re-drops the others — and the writer's last-wins dedup (KotlinWriter `associateBy` by
+    // type) keeps whichever request ran last, silently losing the rest (`decls()` survived only
+    // by sorting last). The cumulative `forcedContainerKeys` makes every prior container visible
+    // to pass 3, so the recovery is COMPLETE and order-independent.
+    //
+    // Both containers are instantiated in a SINGLE forcing parse (two `KrapperForce_*` structs),
+    // then resolveForcing is driven once PER container — mirroring two requestInstantiation
+    // calls accumulating `classes` with the last-wins merge — to avoid a second `<vector>`
+    // forcing TU (see ForcingCharacterizationTest's note on repeated-forcing-TU fragility).
+    // PRE-FIX: only the last-forced accessor (`bitems`) survives; this asserts BOTH do.
+    @Test
+    fun multiContainerForcingRecoversAllRangeAccessorsUnderIgnoreMissing() = memScoped {
+        runBlocking {
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            // Owner has TWO iterator_range accessors over DIFFERENT element types; each
+            // materializes to a distinct std::vector<X*> (the recon-2 range shape), so each
+            // needs its own forced container.
+            val header =
+                """
+                |#include <vector>
+                |namespace llvm {
+                |template <class It> class iterator_range {
+                |    It b_, e_;
+                |public:
+                |    iterator_range(It b, It e) : b_(b), e_(e) {}
+                |    It begin() const { return b_; }
+                |    It end() const { return e_; }
+                |};
+                |}
+                |struct Alpha { int x; };
+                |struct Beta { int y; };
+                |struct AlphaIter {
+                |    typedef Alpha* value_type;
+                |    Alpha** p_;
+                |    Alpha* operator*() const { return *p_; }
+                |    AlphaIter& operator++() { ++p_; return *this; }
+                |    bool operator!=(const AlphaIter& o) const { return p_ != o.p_; }
+                |};
+                |struct BetaIter {
+                |    typedef Beta* value_type;
+                |    Beta** p_;
+                |    Beta* operator*() const { return *p_; }
+                |    BetaIter& operator++() { ++p_; return *this; }
+                |    bool operator!=(const BetaIter& o) const { return p_ != o.p_; }
+                |};
+                |struct Owner {
+                |    Alpha** adata_; unsigned an_;
+                |    Beta** bdata_; unsigned bn_;
+                |    llvm::iterator_range<AlphaIter> aitems() const {
+                |        return llvm::iterator_range<AlphaIter>(AlphaIter{adata_}, AlphaIter{adata_ + an_});
+                |    }
+                |    llvm::iterator_range<BetaIter> bitems() const {
+                |        return llvm::iterator_range<BetaIter>(BetaIter{bdata_}, BetaIter{bdata_ + bn_});
+                |    }
+                |};
+                """.trimMargin()
+            val headerFile = "/tmp/krapper_multiforce_${random()}_${random()}.h"
+            File(headerFile).writeText(header)
+
+            // Main resolve under IGNORE_MISSING (the real-Clang policy): both range accessors
+            // drop, their materialized vector<X*> containers being unbound.
+            val mainResolver =
+                parseHeader(index, listOf(headerFile), generateIncludes("clang++"))
+            var classes: List<ResolvedElement> =
+                mainResolver.findClasses(AllowListFilter(listOf("Owner")).wrapperFilter())
+                    .resolveAll(mainResolver, ReferencePolicy.IGNORE_MISSING)
+
+            // ONE forcing parse with BOTH KrapperForce structs (libclang instantiates both
+            // vector specs without a second <vector> TU).
+            val forceFile = "/tmp/krapper_multiforce_inst_${random()}.h"
+            File(forceFile).writeText(
+                """
+                |#include <vector>
+                |#include "$headerFile"
+                |struct KrapperForce_Alpha { std::vector<Alpha*> value; };
+                |struct KrapperForce_Beta { std::vector<Beta*> value; };
+                """.trimMargin()
+            )
+            val forceResolver =
+                parseHeader(index, listOf(forceFile), generateIncludes("clang++"))
+
+            // Drive resolveForcing once per container, accumulating `classes` (append +
+            // last-wins) and SHARING the cumulative forcedContainerKeys set across calls —
+            // exactly what IndexedServiceImpl.requestInstantiation does across requests.
+            val forcedKeys = mutableSetOf<String>()
+            for (forceName in listOf("KrapperForce_Alpha", "KrapperForce_Beta")) {
+                val alreadyBound = classes.filterIsInstance<ResolvedClass>()
+                    .mapTo(HashSet()) { it.type.toString() }
+                val scoped = forceResolver.findClasses { defaultFilter() }.filter {
+                    val cls = it as? WrappedClass ?: return@filter true
+                    val key = cls.type.toString()
+                    key.contains(forceName) || key in alreadyBound
+                }
+                classes = classes + scoped.resolveForcing(
+                    forceResolver,
+                    ReferencePolicy.IGNORE_MISSING,
+                    alreadyBound,
+                    forcedKeys
+                )
+            }
+
+            // The writer dedups resolved classes last-wins (KotlinWriter associateBy type), so
+            // assert against the LAST surviving Owner — the copy that actually reaches codegen.
+            val owner = classes.filterIsInstance<ResolvedClass>()
+                .associateBy { it.type.toString() }
+                .values.first { it.type.type == "Owner" }
+            val accessors = owner.children.filterIsInstance<ResolvedMethod>().map { it.name }
+            assertTrue(
+                "aitems" in accessors && "bitems" in accessors,
+                "BOTH range accessors must survive after forcing both element containers; " +
+                    "got $accessors (pre-fix only the last-forced `bitems` survives)"
             )
         }
     }


### PR DESCRIPTION
## The bug (TRAVERSE gap)

When several element vectors are force-instantiated (`--instantiate`) over the **same** owning class, only **one** of that class's range accessors survives; the others drop with `Couldn't resolve return`. Against Clang's AST: `DeclContext::decls()` (`vector<Decl*>`) survives but `CXXRecordDecl::methods()` (`vector<CXXMethodDecl*>`) and `bases()` (`vector<CXXBaseSpecifier*>`) drop — so the self-bootstrap front-end can EXTRACT (getNameAsString/getAsString) but cannot TRAVERSE a record's methods.

## Root cause (re-confirmed in code)

- Each `requestInstantiation` runs its **own** `resolveForcing` with a **fresh per-call tracker** (`Resolver.kt` builds `baseContext...withClasses(classes)` once per call) holding only **that** request's container specialization.
- `resolveForcing` pass 3 re-resolves the already-bound class (fresh `mappingCache` + `evictKeys`) to recover a range method whose return container is the just-forced spec. It can only recover the accessor whose container is **in this tracker**; the others' return containers `canResolve == false`, so they re-drop.
- The cross-request merge `classes = classes + newClasses` (`IndexedServiceImpl.kt`) appends, and `KotlinWriter` dedups via `associateBy { it.type.toString() }` = **last-wins**. So the last-processed request's owning-class copy (recovering only its own accessor) overwrites the earlier ones. `decls()` survives only because `vector<Decl*>` sorts last.

## The fix — cumulative, order-independent (approach A via a shared accumulator)

Thread a shared `forcedContainerKeys` set across every `requestInstantiation`. Before each forcing run's pass-3 re-resolve, seed the **prior** requests' container keys into the tracker's `otherResolved` (the set `canResolve` short-circuits on); after the run, record the container(s) it forced. So whichever request runs **last** re-resolves the owning class against **every** forced container at once and recovers **all** its range accessors — independent of processing order (the set is cumulative; last always sees the full set).

Constraints honored:
- **Determinism:** recovery no longer depends on `vector<Decl*>` sorting last; the cumulative set is order-independent and stable across runs.
- **No re-explosion:** seeds are query-only (they never enter `resolvedClasses`), so nothing extra is emitted and the shared-tracker bound on pass 2 is untouched.
- **featuregen byte-identical:** seeding is gated to `IGNORE_MISSING` only. Under `INCLUDE_MISSING` (featuregen) nothing drops in pass 1 (methods materialize on-demand), so the path is unchanged. `decls()`/`redecls()` recovery and `evictKeys` semantics are preserved.

## Test

`ReturnShapeTest.multiContainerForcingRecoversAllRangeAccessorsUnderIgnoreMissing` — an `Owner` class (CXXRecordDecl analog) with two `iterator_range` accessors over distinct element types, both force-instantiated, driving `resolveForcing` once per container with the last-wins merge. **Fails pre-fix** (only the last-forced `bitems` survives — confirmed by temporarily disabling the seed: `AssertionError`), **passes post-fix** (both survive). Uses a single forcing parse to stay within the documented repeated-forcing-TU budget.

## Verify (JDK 17, one foreground run + a second sync for stability)

`./gradlew :krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck`

- `:krapper_gen:nativeTest` — green (incl. the new test)
- `:featuregen:kplusplusSync` — **byte-identical**, zero `featuregen/krapped/` git drift, stable across two consecutive syncs
- `:featuregen:nativeTest` — green (UP-TO-DATE: generated sources unchanged)
- `:krapper_gen:ktlintCheck` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)