### PR TITLE
Resolver: drop callback-param methods when function_ref/std::function collapses to a bare type spelling (GAP-A residual)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
@@ -578,10 +578,12 @@ class WrappedArgument(
         get() = hasDefault && !typeCarriesFalseDefault
 
     // True when [hasDefault] is a FALSE positive — the cursor heuristic misread a token in
-    // the param's type as a C++ default, so the param is not legitimately omittable. Three
+    // the param's type as a C++ default, so the param is not legitimately omittable. Four
     // shapes carry a false default: a non-const output reference (the heuristic can misfire
-    // on the `<...>` in `SmallPtrSetImpl<X>&`), an array bound (`int(&)[4]`), and a by-value
-    // template over a NON-TYPE arg (`Mask<4>`'s `4`). A by-value template over only TYPE args
+    // on the `<...>` in `SmallPtrSetImpl<X>&`), an array bound (`int(&)[4]`), an unmodelable
+    // callback (`function_ref<R(Args)>` / `std::function<R(Args)>`, whose parenthesized
+    // signature the heuristic reads as a default), and a by-value template over a NON-TYPE
+    // arg (`Mask<4>`'s `4`). A by-value template over only TYPE args
     // (`shared_ptr<PCHContainerOperations>`) and a CONST reference with a genuine default
     // (`const Alloc& = Alloc()`) keep their real default and stay omittable.
     private val typeCarriesFalseDefault: Boolean
@@ -625,29 +627,36 @@ class WrappedArgument(
             // [isNonTypeTemplateArg] classifies that token. Either path catches it.
             //
             // Third path — an unmodelable CALLBACK param (`llvm::function_ref<R(Args)>`,
-            // `std::function<R(Args)>`): the template arg is a FUNCTION TYPE (`int (Thing
-            // *)`), which the type model can't bind, so the param fails to resolve. But the
+            // `std::function<R(Args)>`): its instantiation carries a FUNCTION TYPE (`int
+            // (Thing *)`) the type model can't bind, so the param never resolves. But the
             // hasDefault cursor heuristic misreads the callback signature's parenthesized
             // param list as a default value (e.g. `cb`'s "default" surfaces as `Thing*`), so
             // a callback param with NO real C++ default looks omittable. Trimming it then
             // emits a SHORT call (`m(a)` for a 2-arg method) — an arity mismatch that fails
             // to compile and aborts the whole build (the clangwalk self-host hit this on
-            // `clang::ASTContext::adjustType` / `forEachMultiversionedFunctionVersion`). A
-            // function-type arg is never a genuine, trimmable default, so treat it as a false
-            // default: the whole method drops (skip-not-crash, ledgered) instead.
+            // `clang::ASTContext::adjustType` / `forEachMultiversionedFunctionVersion`). The
+            // callback signature's parens ride on the referent's OWN spelling whether the
+            // instantiation surfaced as a structured WrappedTemplateType (`FnRef<int (Thing
+            // *)>`, a function-type template arg) OR — at Clang scale, when libclang doesn't
+            // report the template args — collapsed to a bare type-reference string (the same
+            // fallback CollectInheritedProtocols's `SmallPtrSetImpl<...>&` hits above, which
+            // is why the structured-template check alone missed `adjustType`). A function-type
+            // spelling is never a genuine, trimmable default, so a `(` in the referent
+            // spelling is the false-default signal: drop the whole method instead.
+            if (referent.isFunctionType) return true
+            // A by-value template over a NON-TYPE (value) arg also carries a false default
+            // (Mask<4>'s `4`, etc.) — see [isNonTypeTemplateArg] and the UNRESOLVABLE note.
             return referent is WrappedTemplateType &&
-                referent.templateArgs.any {
-                    it == UNRESOLVABLE || it.isNonTypeTemplateArg || it.isFunctionTypeArg
-                }
+                referent.templateArgs.any { it == UNRESOLVABLE || it.isNonTypeTemplateArg }
         }
 
-    // A template-argument WrappedType that is a FUNCTION TYPE — the `R(Args...)` callback
-    // signature inside `function_ref<R(Args...)>` / `std::function<R(Args...)>`. It surfaces
-    // as a bare type spelling carrying a parenthesized parameter list (`int (Thing *)`);
-    // plain/pointer/reference/template type spellings never contain `(`, so a `(` is the
-    // clean structural signal that this arg is a (function-)callable type the model can't
-    // bind by value.
-    private val WrappedType.isFunctionTypeArg: Boolean
+    // A WrappedType whose spelling carries a FUNCTION TYPE — the `R(Args...)` callback
+    // signature of `function_ref<R(Args...)>` / `std::function<R(Args...)>`, whether it rides
+    // as a structured template arg (`FnRef<int (Thing *)>`) or, at Clang scale, as the whole
+    // collapsed type-reference string. Plain/pointer/reference/template type spellings never
+    // contain `(`, so a `(` is the clean structural signal of a (function-)callable type the
+    // model can't bind by value.
+    private val WrappedType.isFunctionType: Boolean
         get() = '(' in toString()
 
     // A template-argument WrappedType whose spelling is a VALUE literal rather than a

--- a/krapper_gen/src/nativeTest/kotlin/FalseDefaultTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/FalseDefaultTest.kt
@@ -105,4 +105,25 @@ class FalseDefaultTest {
         assertTrue(arg(referenceTo(const(WrappedType("Alloc")))).isOmittableDefault)
         assertTrue(arg(referenceTo(const(WrappedType("std::allocator<char>")))).isOmittableDefault)
     }
+
+    // An unmodelable CALLBACK param (`function_ref<R(Args)>`, `std::function<R(Args)>`)
+    // carries a false default: the hasDefault cursor heuristic misreads the callback
+    // signature's parenthesized param list as a default value. The fix keys on the `(` in the
+    // referent spelling, catching the param whether the instantiation surfaced as a structured
+    // template (a function-type arg) OR — at Clang scale, when libclang doesn't report the
+    // template args — collapsed to a bare type-reference string (the same fallback the
+    // SmallPtrSetImpl output ref hits, the case `adjustType` actually presents). Neither is a
+    // real, trimmable default, so the param is NOT omittable (the whole method drops).
+    @Test fun callback_param_is_not_omittable() {
+        // Structured: the function type rides as a template arg.
+        assertFalse(arg(template("std::function", "int (Thing *)")).isOmittableDefault)
+        // Bare-string Clang-scale fallback: libclang didn't report the template args, so the
+        // whole instantiation collapsed to one type-reference spelling carrying the `(`.
+        assertFalse(arg(WrappedType("llvm::function_ref<int (Thing *)>")).isOmittableDefault)
+        // The `adjustType` shape: a const-reference callback, still a bare-string referent.
+        assertFalse(
+            arg(referenceTo(const(WrappedType("llvm::function_ref<QualType (QualType)>"))))
+                .isOmittableDefault
+        )
+    }
 }


### PR DESCRIPTION
## Problem (GAP-A residual)

A method whose parameter is an unmodelable callback `llvm::function_ref<R(Args)>` / `std::function<R(Args)>` (e.g. `clang::ASTContext::adjustType(QualType, llvm::function_ref<QualType(QualType)>)`) was still emitted with an under-arity call (`adjustType(Old)` — the callback param silently trimmed) → C++ compile error → build abort. This aborted the clangwalk self-host (exit-134) on `adjustType` / `forEachMultiversionedFunctionVersion`.

## Why #36 didn't catch it

PR #36 (ca4dd09) extended `WrappedArgument.typeCarriesFalseDefault` to treat a function-TYPE **template argument** as a false default, but gated it on `referent is WrappedTemplateType`. At Clang scale the callback param frequently does **not** surface structured: when libclang doesn't report the template args, `WrappedType.createForType` reconstructs the instantiation via `invoke(String)`, collapsing the whole type into a bare `WrappedTypeReference` whose spelling carries the parenthesized callback signature (`llvm::function_ref<QualType (QualType)>`). This is the same Clang-scale fallback `CollectInheritedProtocols`'s `SmallPtrSetImpl<...>&` already hits. The `referent is WrappedTemplateType` guard returned false, so the misread `hasDefault` cursor heuristic made the param look omittable and it was trimmed.

## Fix

Key the callback false-default signal on a `(` in the **referent's own spelling** (`isFunctionType`), which holds for both the structured `WrappedTemplateType` and the bare-string fallback — instead of only inspecting structured template args. This subsumes #36's per-template-arg check (the referent's `toString()` includes its args), so that branch is reduced to the `UNRESOLVABLE` / non-type-arg cases.

Since the callback param genuinely can't resolve under `IGNORE_MISSING`, the existing skip-not-crash path then drops the **whole method** (ledgered) — same intended behavior as #36.

### Why it can't regress legitimate defaults
`isOmittableDefault` is consulted **only** for a param that already failed to resolve. Legitimate omittable defaults — `const Alloc& = Alloc()`, `shared_ptr<X>`, `buildASTFromCode`'s defaulted trailing params — resolve fine and never reach this gate; and none of their **type** spellings contain `(` (the `()` lives in the default *value*, not the type). They stay omittable.

## Test

`FalseDefaultTest.callback_param_is_not_omittable` covers three shapes: the structured function-type template arg, the bare-string by-value `function_ref`, and the const-reference `adjustType` shape. The two bare-string asserts **fail pre-fix** (wrongly omittable) and pass post-fix; verified by reverting the fix and running just this test (`callback_param_is_not_omittable FAILED`).

## Verify (JDK 17)

`./gradlew :krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck` → **BUILD SUCCESSFUL**. krapper_gen 311/0, featuregen sync byte-identical (zero `krapped/` git drift, `:featuregen:nativeTest` UP-TO-DATE), ktlintCheck clean. INCLUDE_MISSING (featuregen) behavior unchanged.

## Follow-up

This makes clangwalk's `fixup { removeMethod("clang_ASTContext_adjust_type") }` workaround removable in a later clangwalk pass (not touched here — concurrent agent owns clangwalk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)