### PR TITLE
clangwalk: TRAVERSE a record — iterate methods() (name + return type) and bases() (#8)

### DIFF
--- a/clangwalk/build.gradle.kts
+++ b/clangwalk/build.gradle.kts
@@ -90,6 +90,12 @@ kplusplus {
         "clang::TagDecl",
         "clang::RecordDecl",
         "clang::CXXRecordDecl",
+        // FunctionDecl is CXXMethodDecl's direct base: it carries getReturnType() (the
+        // method's return QualType — the signature payload the reducer extracts) and bridges
+        // the CXXMethodDecl -> NamedDecl upcast chain (getNameAsString). Without it bound the
+        // chain breaks at FunctionDecl and a walked CXXMethodDecl exposes neither name nor
+        // return type.
+        "clang::FunctionDecl",
         "clang::CXXMethodDecl",
         "clang::FieldDecl",
         "clang::ValueDecl",

--- a/clangwalk/build.gradle.kts
+++ b/clangwalk/build.gradle.kts
@@ -112,13 +112,4 @@ kplusplus {
     instantiate("std::vector<clang::Decl*>")
     instantiate("std::vector<clang::CXXMethodDecl*>")
     instantiate("std::vector<clang::CXXBaseSpecifier*>")
-    // ASTContext::adjustType(QualType, llvm::function_ref<QualType(QualType)>) has an
-    // un-modelable function_ref second arg. With QualType now bound its return resolves, so
-    // the method is no longer dropped-by-unresolved-return — and the function_ref param is
-    // mis-flagged omittable-default (the cursor-children default heuristic fires on the
-    // function_ref's type tokens), emitting an under-arity `adjustType(Old)` call that won't
-    // compile. Drop it explicitly until that heuristic is tightened (a krapper_gen follow-up).
-    fixup {
-        removeMethod("clang_ASTContext_adjust_type")
-    }
 }

--- a/clangwalk/src/nativeMain/kotlin/AstWalk.kt
+++ b/clangwalk/src/nativeMain/kotlin/AstWalk.kt
@@ -22,7 +22,13 @@ import kotlinx.cinterop.memScoped
 fun main(args: Array<String>) = memScoped {
     val source = """
         struct Point { int x; int y; };
-        class Shape { public: virtual double area(); };
+        class Shape {
+        public:
+            int area() const;
+            const char* name() const;
+            double scale(double factor) const;
+        };
+        struct Circle : Shape { double radius() const; };
         void freeFunction(int n);
         int globalVar;
     """.trimIndent()
@@ -51,6 +57,28 @@ fun main(args: Array<String>) = memScoped {
         // second by-value std::string EXTRACT primitive — the type spelling as Clang reports.
         val typeStr = decl.asValueDecl()?.getType()?.getAsString()?.let { " : $it" } ?: ""
         println("  [$kind] $name$typeStr")
+
+        // TRAVERSE: for a record, descend into its members. dyn_cast Decl -> CXXRecordDecl
+        // (null for non-records). #40's cumulative-forcing fix is what lets BOTH range
+        // accessors survive together: bases() materializes std::vector<CXXBaseSpecifier*>
+        // and methods() materializes std::vector<CXXMethodDecl*> off the SAME owning class.
+        val record = decl.asCXXRecordDecl() ?: continue
+        // Each CXXBaseSpecifier carries the base class as a QualType (getType()); its
+        // getAsString() spells the base — the inheritance edge the reducer flattens over.
+        for (base in record.bases()) {
+            if (base == null) continue
+            println("      <base> ${base.getType().getAsString()}")
+        }
+        // Each CXXMethodDecl: its name comes from NamedDecl (upcast getNameAsString) and its
+        // return type from FunctionDecl (upcast getReturnType -> QualType -> getAsString).
+        // This is the reducer's core per-record operation: enumerate methods, extract each
+        // signature's name + return type.
+        for (method in record.methods()) {
+            if (method == null) continue
+            val mName = method.asNamedDecl()?.getNameAsString() ?: "<unnamed>"
+            val mRet = method.asFunctionDecl()?.getReturnType()?.getAsString() ?: "?"
+            println("      <method> $mName : $mRet")
+        }
     }
     println("clangwalk: walked $count top-level declarations via real libclang-cpp")
 }


### PR DESCRIPTION
## What

Combines the two halves of the self-bootstrap front-end's core loop that already landed on main — **EXTRACT** (#39: `getNameAsString()`/`getAsString()`) and **TRAVERSE** (#40: `methods()`/`bases()` survive multi-instantiation) — into the reducer's core per-record operation: walk a `CXXRecordDecl`, enumerate its methods, and extract each signature's name + return type, plus enumerate its bases.

For each walked `CXXRecordDecl` the stage1 walk now:
- iterates `bases()` and prints each base's `CXXBaseSpecifier::getType().getAsString()`;
- iterates `methods()` and prints each method's `NamedDecl::getNameAsString()` + `FunctionDecl::getReturnType().getAsString()`.

## Changes

- **Fixture** (`AstWalk.kt`): `Shape` gains methods of distinct return types (`int area()`, `const char* name()`, `double scale(double)`) and a derived `struct Circle : Shape` so `bases()` has content.
- **Bind `clang::FunctionDecl`**: it carries `getReturnType()` and bridges the `CXXMethodDecl -> NamedDecl` upcast chain. Without it the chain breaks at the unbound `FunctionDecl` and a walked `CXXMethodDecl` exposes neither name nor return type.
- **Drop the `clang_ASTContext_adjust_type` fixup**: PR #41 (drop callback-param methods when `function_ref`/`std::function` collapses to a bare type spelling) is the underlying cause this fixup papered over. Verified the release walk builds + runs byte-identical without it, and `clang_ASTContext_adjust_type` is now absent from the generated bindings (only the `function_ref`-free `adjust*` overloads remain).

## Verify (JDK 17, `:clangwalk:runReleaseExecutableKlinker -PenableClang`)

```
  [CXXRecord] Point
  [CXXRecord] Shape
      <method> area : int
      <method> name : const char *
      <method> scale : double
  [CXXRecord] Circle
      <base> Shape
      <method> radius : double
  [Function] freeFunction : void (int)
  [Var] globalVar : int
```

Names + return types + base match exactly what Clang reports for the fixture. **#40 delivered**: `methods()` and `bases()` both surfaced and survived together off the same owning class.

Gated behind `-PenableClang` (RELEASE only); the default LLVM-absent build is unaffected. Addresses #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)