### PR TITLE
krapper_gen: emit a plain method when an operator's idiomatic name collides (operator fun _get → fun _get)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/Scope.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/Scope.kt
@@ -26,6 +26,14 @@ class Scope<T : LangFactory>(internal val parent: Scope<T>? = null) {
 
     private fun isUsed(name: String): Boolean = names.contains(name) || parent?.isUsed(name) == true
 
+    /**
+     * Whether [name] is already claimed in this scope (or an enclosing one) — i.e. a later
+     * [allocateName] of it would be uniquified to `_$name`. Lets a caller decide NOT to emit
+     * a construct that requires the exact name (e.g. the `operator` modifier, which is only
+     * legal on the canonical operator identifier — `operator fun _get` does not parse).
+     */
+    fun isNameUsed(name: String): Boolean = isUsed(name)
+
     fun allocateName(desiredName: String): String {
         if (desiredName.isEmpty()) return allocateName("v")
         if (isUsed(desiredName)) {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -71,6 +71,7 @@ import com.monkopedia.krapper.generator.builders.pkg
 import com.monkopedia.krapper.generator.builders.property
 import com.monkopedia.krapper.generator.builders.qdot
 import com.monkopedia.krapper.generator.builders.reference
+import com.monkopedia.krapper.generator.builders.scope
 import com.monkopedia.krapper.generator.builders.setter
 import com.monkopedia.krapper.generator.builders.symbol
 import com.monkopedia.krapper.generator.builders.type
@@ -2134,14 +2135,23 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
         when (val kotlinType = operator.kotlinOperatorType) {
             is KotlinOperator -> {
+                // When the idiomatic operator name is already claimed by another member of
+                // this class (e.g. a class exposing BOTH `operator[]` and a named `get(idx)`
+                // — clang::TemplateArgumentList does), the scope uniquifier renames THIS one
+                // to `_<name>`, and `operator fun _get` is illegal Kotlin. Drop the `operator`
+                // modifier and emit it as a plain (uniquified) method; the `[]`/`+`/... call
+                // syntax falls back to the named sibling that owns the canonical name, and any
+                // index-iterator wiring already targets that sibling by name.
+                val nameTaken = scope.isNameUsed(kotlinType.name)
+                val emit: KotlinCodeBuilder.() -> Unit = {
+                    generateBasicMethod(
+                        method,
+                        extensionMethod(pkg, method.uniqueCName!!),
+                        kotlinType.name
+                    )
+                }
                 inline {
-                    operator {
-                        generateBasicMethod(
-                            method,
-                            extensionMethod(pkg, method.uniqueCName!!),
-                            kotlinType.name
-                        )
-                    }
+                    if (nameTaken) emit() else operator(emit)
                 }
             }
 


### PR DESCRIPTION
## Root cause

When a class exposes BOTH a symbolic operator and a named sibling that owns the operator's idiomatic Kotlin name — e.g. `clang::TemplateArgumentList` has both `operator[](unsigned)` and a named `get(unsigned)` — the scope uniquifier allocates the canonical name (`get`) to the named sibling first, then renames the colliding `operator[]` to `_get`. But `generateOperator` still wrapped the emission in the `operator { }` modifier, producing `operator fun _get`, which is **illegal Kotlin** (the `operator` modifier is only legal on the canonical operator identifier). The K/N compile of the generated bindings then fails.

This was surfaced by binding `clang::TemplateArgumentList` during the self-bootstrap **type-decode probe** (P5, template arguments), where it blocked the front-end type-decode surface from compiling.

## Fix

When the operator's idiomatic name is already claimed in the current scope, emit a **plain (uniquified) method** instead of an `operator fun`:

- `Scope.kt`: add `isNameUsed(name)` so a caller can detect that a later `allocateName` of that name would be uniquified to `_<name>`.
- `KotlinWriter.kt` (`generateOperator`): gate the `operator { }` wrapper on the name not being a uniquified collision. When it is taken, drop the modifier.

The operator-call syntax (`a[i]`, `a + b`, ...) still works because it falls back to the named sibling that owns the canonical name, and index-iterator wiring already targets that sibling by name — so nothing observable is lost.

## Verification (JDK 17, foreground)

- `:krapper_gen:nativeTest` — **311/0** green
- `:featuregen:kplusplusSync` + `:featuregen:nativeTest` — **188/0** green, `featuregen/krapped/` **byte-identical** (zero git drift, full `--rerun-tasks`)
- `:krapper_gen:ktlintCheck` — clean

Generator-only change; clears a codegen blocker for the front-end type-decode surface in the Clang self-bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
