### PR TITLE
cppfrontend: front-end module scaffold — construct WrappedTU from libclang-cpp bindings (#44 brick 2)

### DIFF
--- a/cppfrontend/.gitignore
+++ b/cppfrontend/.gitignore
@@ -1,0 +1,1 @@
+/krapped/

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.klinker.klinkedExecutable
+
+plugins {
+    kotlin("multiplatform")
+    alias(libs.plugins.kotlin.serialization)
+    id("com.monkopedia.kplusplus.compiler")
+    id("com.monkopedia.klinker.plugin") version "0.2.0"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+kotlin {
+    linuxX64("native") {
+        binaries {
+            klinkedExecutable {
+                // Same wiring as :clangwalk (see its build.gradle.kts for the full
+                // rationale): system clang++ link for modern glibc/libstdc++ symbol
+                // versions, --gc-sections so DEBUG dead-strips the stale platform.linux
+                // cinterop cache, and libclang-cpp + LLVM for the Clang C++ AST API.
+                linkerOpts("--gc-sections")
+                compilerOpts(
+                    "-L/usr/lib",
+                    "-lclang-cpp",
+                    "-lLLVM-22",
+                    "-lstdc++",
+                    "-lm",
+                    "-lpthread"
+                )
+                runTask()
+            }
+        }
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    optIn.add("kotlinx.cinterop.ExperimentalForeignApi")
+                    freeCompilerArgs.add("-g")
+                }
+            }
+        }
+    }
+    sourceSets["nativeMain"].dependencies {
+        // The whole point of this module (#44 brick 2): construct :krapper_model's pure
+        // parse-output model (WrappedTU/WrappedClass/WrappedMethod/WrappedType) from the
+        // kplusplus-generated libclang-cpp bindings instead of libclang-C cursors.
+        implementation(project(":krapper_model"))
+        implementation(libs.serialization.json)
+    }
+}
+
+// Stage1 front-end scaffold (#44 brick 2): bind the same Clang C++ AST slice :clangwalk
+// proved out (EXTRACT/TRAVERSE/IDENTITY), parse a fixture, and CONSTRUCT a WrappedTU from
+// the walk. Scoped import (only + IGNORE_MISSING) keeps the bound surface to the allowlist.
+kplusplus {
+    header("include/clang_slice.h")
+    // Clang's AST headers must be compiled with clang++, NOT the konan-bundled GCC-8.3
+    // (resolveDefaultCompiler's default) — GCC-8.3/libstdc++ aborts on them (exit 134).
+    compiler = "clang++"
+    cppStandard = "c++17"
+    referencePolicy = "IGNORE_MISSING"
+    only(
+        // Entry point: build an AST from a code string, reach the TU.
+        "clang::tooling::buildASTFromCode",
+        "clang::ASTUnit",
+        "clang::ASTContext",
+        // The Decl hierarchy the construction walks (clangwalk's proven slice).
+        "clang::Decl",
+        "clang::NamedDecl",
+        "clang::DeclContext",
+        "clang::TranslationUnitDecl",
+        "clang::TagDecl",
+        "clang::RecordDecl",
+        "clang::CXXRecordDecl",
+        // FunctionDecl bridges the CXXMethodDecl -> NamedDecl upcast chain and carries
+        // getReturnType()/getNumParams()/getParamDecl() — the signature payload.
+        "clang::FunctionDecl",
+        "clang::CXXMethodDecl",
+        "clang::FieldDecl",
+        "clang::ValueDecl",
+        "clang::DeclaratorDecl",
+        "clang::TypeDecl",
+        "clang::CXXBaseSpecifier",
+        // NEW over clangwalk's slice: parameters. FunctionDecl::getParamDecl(i) returns a
+        // ParmVarDecl* — without ParmVarDecl bound, IGNORE_MISSING drops getParamDecl and
+        // arguments are unreachable (clangwalk never bound it; the walk didn't need args).
+        // VarDecl is ParmVarDecl's direct base: it bridges the ParmVarDecl ->
+        // DeclaratorDecl/ValueDecl/NamedDecl upcast chain (same reason FunctionDecl is
+        // bound for CXXMethodDecl), so a parameter exposes its name + QualType.
+        "clang::ParmVarDecl",
+        "clang::VarDecl",
+        // QualType is the carrier for a decl's type; getAsString() (by-value std::string,
+        // normalized to a Kotlin String by #37) feeds the WrappedType(spelling) factory.
+        "clang::QualType"
+    )
+    // Materialize the range returns the walk iterates (decls()/methods()/bases()).
+    instantiate("std::vector<clang::Decl*>")
+    instantiate("std::vector<clang::CXXMethodDecl*>")
+    instantiate("std::vector<clang::CXXBaseSpecifier*>")
+}

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -1,0 +1,4 @@
+#include <clang/Frontend/ASTUnit.h>
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/Tooling/Tooling.h>

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -43,7 +43,8 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
 // #44 brick 2, the front-end scaffold: parse the fixture with Clang's C++ AST (on the
 // kplusplus-generated libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU from
 // the walk, and serialize it to JSON — the end-to-end skeleton the next bricks fill in.
-fun main(): Unit = memScoped {
+@Suppress("UNUSED_PARAMETER")
+fun main(args: Array<String>): Unit = memScoped {
     val unit = buildASTFromCode(FIXTURE_HEADER, "fixture.h")
         ?: return@memScoped fail("buildASTFromCode returned null")
     val context = unit.getASTContext()

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import clang.tooling.buildASTFromCode
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+import kotlin.system.exitProcess
+import kotlinx.cinterop.memScoped
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+// The brick-2 fixture "header": deliberately minimal (one free function + one plain class)
+// — later bricks grow it, not this one. Fed to buildASTFromCode as an in-memory source,
+// the same way :clangwalk feeds its fixture.
+private val FIXTURE_HEADER = """
+    void freeFunction(int);
+    struct Shape {
+        int area() const;
+        const char* name() const;
+    };
+""".trimIndent()
+
+private var failures = 0
+
+private fun check(name: String, pass: Boolean, detail: String = "") {
+    if (!pass) failures++
+    println("  [${if (pass) "PASS" else "FAIL"}] $name${if (detail.isEmpty()) "" else " — $detail"}")
+}
+
+// #44 brick 2, the front-end scaffold: parse the fixture with Clang's C++ AST (on the
+// kplusplus-generated libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU from
+// the walk, and serialize it to JSON — the end-to-end skeleton the next bricks fill in.
+fun main(): Unit = memScoped {
+    val unit = buildASTFromCode(FIXTURE_HEADER, "fixture.h")
+        ?: return@memScoped fail("buildASTFromCode returned null")
+    val context = unit.getASTContext()
+        ?: return@memScoped fail("no ASTContext")
+    val tuDecl = context.getTranslationUnitDecl()
+        ?: return@memScoped fail("no TranslationUnitDecl")
+
+    val tu = buildWrappedTU(tuDecl)
+
+    // ---- Structural summary ----
+    println("cppfrontend: constructed WrappedTU from the Clang C++ AST")
+    for (child in tu.children) {
+        when (child) {
+            is WrappedClass -> {
+                println("  class ${child.name} (${child.children.size} members)")
+                child.children.filterIsInstance<WrappedMethod>().forEach {
+                    println("    $it${if (it.isConst) " const" else ""}")
+                }
+            }
+            is WrappedMethod -> println("  free fn $child [${child.methodType}]")
+            else -> println("  ${child::class.simpleName}")
+        }
+    }
+
+    // ---- Serialize ----
+    val json = Json { prettyPrint = true }.encodeToString(tu.serialized())
+    println("\ncppfrontend: serialized WrappedTU")
+    println(json)
+
+    // ---- Self-checks ----
+    println("\ncppfrontend: self-checks")
+    val shape = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Shape" }
+    val methods = shape?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+    check("TU contains class Shape", shape != null)
+    check("Shape has 2 methods", methods.size == 2, "got ${methods.size}")
+    val area = methods.find { it.name == "area" }
+    check(
+        "area return type spelling is 'int'",
+        area?.returnType?.toString() == "int",
+        "got ${area?.returnType}"
+    )
+    check("area is const", area?.isConst == true)
+    val name = methods.find { it.name == "name" }
+    check(
+        "name return type spelling is 'const char*'",
+        name?.returnType?.toString() == "const char*",
+        "got ${name?.returnType}"
+    )
+    val freeFn = tu.children.filterIsInstance<WrappedMethod>().find { it.name == "freeFunction" }
+    check(
+        "freeFunction is a TU-level STATIC method",
+        freeFn != null && freeFn.methodType == MethodType.STATIC
+    )
+    check(
+        "freeFunction has 1 arg of type 'int'",
+        freeFn?.args?.singleOrNull()?.type?.toString() == "int",
+        "got ${freeFn?.args}"
+    )
+    check(
+        "freeFunction arg carries cpp:<canonical-id> identity",
+        freeFn?.args?.firstOrNull()?.usr?.startsWith("cpp:") == true,
+        "got '${freeFn?.args?.firstOrNull()?.usr}'"
+    )
+    check("JSON is non-empty", json.length > 2)
+
+    if (failures > 0) fail("$failures self-check(s) failed")
+    println("cppfrontend: ALL SELF-CHECKS PASSED")
+}
+
+private fun fail(message: String): Nothing {
+    println("cppfrontend: FAIL — $message")
+    exitProcess(1)
+}

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -45,7 +45,10 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
 // the walk, and serialize it to JSON — the end-to-end skeleton the next bricks fill in.
 @Suppress("UNUSED_PARAMETER")
 fun main(args: Array<String>): Unit = memScoped {
-    val unit = buildASTFromCode(FIXTURE_HEADER, "fixture.h")
+    // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
+    // from it, and a ".h" parses as C (where `int area() const` is ill-formed and Shape is a
+    // plain RecordDecl the CXXRecordDecl walk never sees).
+    val unit = buildASTFromCode(FIXTURE_HEADER, "fixture.cc")
         ?: return@memScoped fail("buildASTFromCode returned null")
     val context = unit.getASTContext()
         ?: return@memScoped fail("no ASTContext")

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import clang.CXXMethodDecl
+import clang.CXXRecordDecl
+import clang.Decl
+import clang.FunctionDecl
+import clang.ParmVarDecl
+import clang.TranslationUnitDecl
+import com.monkopedia.krapper.generator.model.WrappedArgument
+import com.monkopedia.krapper.generator.model.WrappedBase
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+
+// The C++-AST front-end's model construction (#44 brick 2): walk a parsed Clang AST on the
+// kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output model —
+// the same WrappedTU shape the libclang-C front-end (ModelFactories.kt) produces.
+
+// IDENTITY CONVENTION: the libclang front-end keys identity fields (WrappedArgument.usr and
+// the reducer's lookup maps) on libclang's USR string. This front-end's equivalent is the
+// canonical-Decl id proven on clangwalk/decl-identity-probe (b9e19dc): normalize any decl to
+// its canonical clang::Decl* (redeclaration-collapse) and read Decl::getID(), spelled
+// "cpp:<id>". The two front-ends therefore NEVER agree on the literal identity string —
+// Phase C's tree-diff treats identity fields as maskable and compares structure only.
+private fun Decl.canonical(): Decl = (getCanonicalDecl() as? Decl) ?: this
+
+private fun Decl.cppUsr(): String = "cpp:${canonical().getID()}"
+
+// Construct a WrappedTU from the parsed translation unit. Top-level shape matches the
+// libclang front-end (ModelFactories.mapAll): a WrappedClass per record and a
+// MethodType.STATIC WrappedMethod per free function, both direct children of the TU.
+fun buildWrappedTU(tuDecl: TranslationUnitDecl): WrappedTU {
+    val tu = WrappedTU()
+    for (decl in tuDecl.asDeclContext().decls()) {
+        if (decl == null) continue
+        // Skip the implicit builtin TU members (__int128_t, __builtin_va_list, ...) —
+        // they aren't part of the parsed fixture.
+        if (decl.isImplicit()) continue
+        val record = decl.asCXXRecordDecl()
+        if (record != null) {
+            tu.addChild(buildClass(record))
+            continue
+        }
+        val function = decl.asFunctionDecl()
+        if (function != null && decl.asCXXMethodDecl() == null) {
+            // A free function is a STATIC WrappedMethod with no parent class — the model's
+            // namespace-level-function convention (see freeFunctionQualifiedName).
+            tu.addChild(buildFunction(function))
+        }
+        // brick-3+: namespaces, typedefs, enums, global fields, class templates.
+    }
+    return tu
+}
+
+private fun buildClass(record: CXXRecordDecl): WrappedClass {
+    val name = record.asNamedDecl().getNameAsString() ?: error("record without a name")
+    // brick-3+: isAbstract + ClassMetadata (hasConstructor/hasCopyConstructor/...) — left at
+    // the model's defaults until the ctor/dtor walk lands.
+    val cls = WrappedClass(name)
+    for (base in record.bases()) {
+        if (base == null) continue
+        val spelling = base.getType().getAsString() ?: continue
+        // brick-3+: isPublic/isVirtualBase need the access-specifier accessors bound.
+        cls.addChild(WrappedBase(WrappedType(spelling)))
+    }
+    for (method in record.methods()) {
+        if (method == null) continue
+        // Implicit members (Sema-injected copy ctor/assignment) aren't fixture surface.
+        if (method.isImplicit()) continue
+        // brick-3+: CXXConstructor/CXXDestructor/CXXConversion kinds map to
+        // WrappedConstructor/WrappedDestructor/conversion methods; only plain methods now.
+        if (method.getDeclKindName() != "CXXMethod") continue
+        cls.addChild(buildMethod(method))
+    }
+    // brick-3+: FieldDecl children -> WrappedField.
+    return cls
+}
+
+private fun buildMethod(method: CXXMethodDecl): WrappedMethod {
+    val name = method.asNamedDecl().getNameAsString() ?: error("method without a name")
+    val isConst = method.isConst()
+    val spelling = method.getReturnType().getAsString() ?: error("method without a return")
+    // Mirror the libclang front-end's return-const rule (ModelFactories.WrappedMethod):
+    // a `const` method's constness only carries to a pointer/reference return; const on a
+    // by-value return is meaningless for the temporary and breaks the Holder path (G8).
+    val returnType = WrappedType(spelling).let {
+        if (isConst && (it.isPointer || it.isReference)) WrappedType.const(it) else it
+    }
+    val methodType = if (method.isStatic()) MethodType.STATIC else MethodType.METHOD
+    return WrappedMethod(name, returnType, methodType).also {
+        it.isConst = isConst
+        it.isVirtual = method.isVirtual()
+        it.addArgs(method.asFunctionDecl())
+    }
+}
+
+private fun buildFunction(function: FunctionDecl): WrappedMethod {
+    val name = function.asNamedDecl().getNameAsString() ?: error("function without a name")
+    val returnType = WrappedType(function.getReturnType().getAsString() ?: error("no return"))
+    return WrappedMethod(name, returnType, MethodType.STATIC).also {
+        it.addArgs(function)
+    }
+}
+
+private fun WrappedMethod.addArgs(function: FunctionDecl) {
+    for (i in 0u until function.getNumParams()) {
+        // getParamDecl returns the Api interface (the generated related-object-getter
+        // convention); re-wrap to the concrete ParmVarDecl so the upcast chain resolves.
+        val param = function.getParamDecl(i)?.let { ParmVarDecl(it.ptr, function.memScope) }
+            ?: continue
+        // Unnamed parameter (e.g. `void freeFunction(int)`) falls back to the same
+        // positional name the libclang front-end synthesizes.
+        val name = param.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() }
+            ?: "_arg_$i"
+        val spelling = param.asValueDecl().getType().getAsString() ?: continue
+        // brick-3+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
+        addChild(WrappedArgument(name, WrappedType(spelling), param.asDecl().cppUsr()))
+    }
+}

--- a/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.krapper.generator.model.WrappedArgument
+import com.monkopedia.krapper.generator.model.WrappedBase
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedElement
+import com.monkopedia.krapper.generator.model.WrappedField
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedTU
+import kotlinx.serialization.Serializable
+
+// JSON projection of the parse-output model (#44 brick 2). The WrappedElement hierarchy
+// itself is NOT @Serializable (parent back-links + non-data classes), so the front-end
+// serializes a one-way structural DTO: kind + per-kind payload + children, types spelled
+// via WrappedType.toString(). Phase C's tree-diff wants ONE canonical projection emitted by
+// BOTH front-ends, so the durable home for this is :krapper_model — kept frontend-side for
+// the scaffold to leave the model module untouched (finding recorded on #44).
+@Serializable
+data class SerializedElement(
+    val kind: String,
+    val name: String? = null,
+    val type: String? = null,
+    val returnType: String? = null,
+    val methodType: String? = null,
+    val isConst: Boolean? = null,
+    val isVirtual: Boolean? = null,
+    val isAbstract: Boolean? = null,
+    // Identity field — "cpp:<canonical Decl id>" here vs a libclang USR string from the
+    // libclang front-end; maskable in the Phase C tree-diff (see ModelBuilder.kt).
+    val usr: String? = null,
+    val children: List<SerializedElement> = emptyList()
+)
+
+fun WrappedElement.serialized(): SerializedElement {
+    val kids = children.map { it.serialized() }
+    return when (this) {
+        is WrappedTU -> SerializedElement("tu", children = kids)
+        is WrappedClass -> SerializedElement(
+            "class",
+            name = name,
+            isAbstract = isAbstract,
+            children = kids
+        )
+        is WrappedBase -> SerializedElement("base", type = type?.toString(), children = kids)
+        // Before WrappedMethod: WrappedArgument/WrappedField are sibling element kinds, and
+        // a WrappedConstructor/WrappedDestructor IS-A WrappedMethod (kind via methodType).
+        is WrappedArgument -> SerializedElement(
+            "arg",
+            name = name,
+            type = type.toString(),
+            usr = usr,
+            children = kids
+        )
+        is WrappedField -> SerializedElement(
+            "field",
+            name = name,
+            type = type.toString(),
+            children = kids
+        )
+        is WrappedMethod -> SerializedElement(
+            "method",
+            name = name,
+            returnType = returnType.toString(),
+            methodType = methodType.name,
+            isConst = isConst,
+            isVirtual = isVirtual,
+            children = kids
+        )
+        else -> SerializedElement(this::class.simpleName ?: "element", children = kids)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,4 +31,7 @@ val clangEnabled = (enableClang != null && enableClang != "false") ||
     settings.providers.gradleProperty("llvmConfig").orNull?.let { File(it).canExecute() } == true
 if (clangEnabled) {
     include(":clangwalk")
+    // :cppfrontend is the stage1 front-end scaffold (#44 brick 2): it constructs
+    // :krapper_model's parse-output model from the same gated libclang-cpp bindings.
+    include(":cppfrontend")
 }


### PR DESCRIPTION
Phase B brick 2 of #44: the front-end module scaffold — the first code that CONSTRUCTS `:krapper_model`'s parse-output model from kplusplus-generated libclang-cpp bindings.

## What this adds

New gated module **`cppfrontend/`** (sibling of `:clangwalk`, same `-PenableClang` gate in settings.gradle.kts, same klinker/clang++/`-lclang-cpp -lLLVM-22` release wiring) that:

- **Depends on `:krapper_model`** — the first non-libclang consumer of the split-out model (bricks 1/1b).
- Parses a minimal fixture (`void freeFunction(int);` + `struct Shape { int area() const; const char* name() const; };`) via `clang::tooling::buildASTFromCode`.
- Walks the TU and **constructs a real `WrappedTU`** matching the libclang front-end's shape (`ModelFactories.mapAll`): a `WrappedClass` for Shape with `WrappedMethod`s (string-factory `WrappedType`s from QualType spellings, `isConst`/`isVirtual` carried, the return-const-only-on-ptr/ref rule mirrored), and the free function as a TU-level `MethodType.STATIC` `WrappedMethod` with `WrappedArgument`s (unnamed-param `_arg_N` fallback mirrored).
- **Identity:** `WrappedArgument.usr` is populated as `"cpp:" + canonical Decl getID()` (the convention proven on `clangwalk/decl-identity-probe`, b9e19dc). The two front-ends never agree on the literal identity string — Phase C's tree-diff treats identity fields as maskable.
- **Serializes the WrappedTU to JSON** through a frontend-side `@Serializable` structural DTO (`SerializedElement`), prints a structural summary + the JSON, and runs self-check assertions (non-zero exit on failure).

## Bindings delta over clangwalk's slice

Added `clang::ParmVarDecl` + `clang::VarDecl` to `only(...)`: without ParmVarDecl bound, IGNORE_MISSING drops `FunctionDecl::getParamDecl` and parameters are unreachable; VarDecl bridges the ParmVarDecl → DeclaratorDecl/ValueDecl/NamedDecl upcast chain (same reason clangwalk binds FunctionDecl for CXXMethodDecl). No fixups needed — everything bound cleanly.

## Findings (model-side)

- The `WrappedElement` hierarchy is **not** `@Serializable` (only `WrappedTypeReference` is); parent back-links + non-data classes make direct serialization non-trivial. The scaffold serializes via a frontend-side one-way DTO. Phase C wants ONE canonical projection emitted by BOTH front-ends, so the durable home for that projection is `:krapper_model` — deferred to keep this PR from touching the model module (and triggering the featuregen byte-identical gate).
- No model constructor demanded cursor-derived data — pure construction works as-is post-#48/#49 (`WrappedClass(name)`, `WrappedMethod(name, type, methodType)`, `WrappedArgument(name, type, usr)`, `WrappedType(spelling)`).
- Gotcha worth recording: `buildASTFromCode`'s virtual filename determines the language — a `.h` parses as **C** (Shape becomes a plain RecordDecl the CXXRecordDecl walk never sees). The fixture parses under `fixture.cc`.

## Verify

**Default build unaffected** (no `-PenableClang`): `./gradlew :krapper_gen:nativeTest :krapper_model:build :krapper_gen:ktlintCheck` → BUILD SUCCESSFUL; `:cppfrontend`/`:clangwalk` absent from the default project graph. `:krapper_model` untouched (no featuregen gate needed).

**Gated run**: `./gradlew :cppfrontend:runReleaseExecutableKlinker -PenableClang` →

```
cppfrontend: constructed WrappedTU from the Clang C++ AST
  free fn fun freeFunction(_arg_0: int): void [STATIC]
  class Shape (2 members)
    fun area(): int const
    fun name(): const char* const

cppfrontend: serialized WrappedTU
{
    "kind": "tu",
    "children": [
        {
            "kind": "method",
            "name": "freeFunction",
            "returnType": "void",
            "methodType": "STATIC",
            "isConst": false,
            "isVirtual": false,
            "children": [
                { "kind": "arg", "name": "_arg_0", "type": "int", "usr": "cpp:553" }
            ]
        },
        {
            "kind": "class",
            "name": "Shape",
            "isAbstract": false,
            "children": [
                { "kind": "method", "name": "area", "returnType": "int", "methodType": "METHOD", "isConst": true, "isVirtual": false },
                { "kind": "method", "name": "name", "returnType": "const char*", "methodType": "METHOD", "isConst": true, "isVirtual": false }
            ]
        }
    ]
}

cppfrontend: self-checks
  [PASS] TU contains class Shape
  [PASS] Shape has 2 methods — got 2
  [PASS] area return type spelling is 'int' — got int
  [PASS] area is const
  [PASS] name return type spelling is 'const char*' — got const char*
  [PASS] freeFunction is a TU-level STATIC method
  [PASS] freeFunction has 1 arg of type 'int' — got [_arg_0: int]
  [PASS] freeFunction arg carries cpp:<canonical-id> identity — got 'cpp:553'
  [PASS] JSON is non-empty
cppfrontend: ALL SELF-CHECKS PASSED
BUILD SUCCESSFUL
```

(JSON trimmed to one-line children for readability; the binary emits it pretty-printed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
