### PR TITLE
cppfrontend: construction depth — fields/ctors/dtors/access/statics/namespaces/bases mirrored from ModelFactories (#44 brick 3)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -85,6 +85,12 @@ kplusplus {
         "clang::NamedDecl",
         "clang::DeclContext",
         "clang::TranslationUnitDecl",
+        // NEW for brick 3 (construction depth): namespace nesting. NamespaceBaseDecl is
+        // NamespaceDecl's direct base (the Clang 22 NamespaceDecl/alias split); it bridges
+        // the NamespaceDecl -> NamedDecl upcast chain the same way FunctionDecl bridges
+        // CXXMethodDecl's.
+        "clang::NamespaceBaseDecl",
+        "clang::NamespaceDecl",
         "clang::TagDecl",
         "clang::RecordDecl",
         "clang::CXXRecordDecl",
@@ -92,6 +98,11 @@ kplusplus {
         // getReturnType()/getNumParams()/getParamDecl() — the signature payload.
         "clang::FunctionDecl",
         "clang::CXXMethodDecl",
+        // NEW for brick 3: real Decl classes for ctors/dtors (libclang only has cursor
+        // kinds) — CXXConstructorDecl carries is{Copy,Default}Constructor, the C++-AST
+        // equivalents of clang_CXXConstructor_is{Copy,Default}Constructor.
+        "clang::CXXConstructorDecl",
+        "clang::CXXDestructorDecl",
         "clang::FieldDecl",
         "clang::ValueDecl",
         "clang::DeclaratorDecl",
@@ -109,8 +120,9 @@ kplusplus {
         // normalized to a Kotlin String by #37) feeds the WrappedType(spelling) factory.
         "clang::QualType"
     )
-    // Materialize the range returns the walk iterates (decls()/methods()/bases()).
+    // Materialize the range returns the walk iterates. Brick 3 walks members through
+    // DeclContext::decls() (source order, all member kinds) instead of methods(), so the
+    // CXXMethodDecl vector instantiation is gone.
     instantiate("std::vector<clang::Decl*>")
-    instantiate("std::vector<clang::CXXMethodDecl*>")
     instantiate("std::vector<clang::CXXBaseSpecifier*>")
 }

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -18,6 +18,7 @@ import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.model.WrappedConstructor
 import com.monkopedia.krapper.generator.model.WrappedDestructor
+import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
@@ -259,10 +260,7 @@ fun main(args: Array<String>): Unit = memScoped {
     println("cppfrontend: ALL SELF-CHECKS PASSED")
 }
 
-private fun printElements(
-    elements: List<com.monkopedia.krapper.generator.model.WrappedElement>,
-    indent: String
-) {
+private fun printElements(elements: List<WrappedElement>, indent: String) {
     for (child in elements) {
         when (child) {
             is WrappedNamespace -> {

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -14,23 +14,60 @@
  * limitations under the License.
  */
 import clang.tooling.buildASTFromCode
+import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
+import com.monkopedia.krapper.generator.model.WrappedDestructor
+import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import kotlin.system.exitProcess
 import kotlinx.cinterop.memScoped
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-// The brick-2 fixture "header": deliberately minimal (one free function + one plain class)
-// — later bricks grow it, not this one. Fed to buildASTFromCode as an in-memory source,
-// the same way :clangwalk feeds its fixture.
+// The brick-3 fixture "header" (#44 construction depth): exercises the full decl/class/
+// member construction contract — access filtering (public kept, private/protected filtered
+// with metadata), ctors (default + copy) and a virtual dtor, a deleted copy assignment,
+// a static method, public/private fields (incl. the const-field metadata rules), an
+// abstract class, namespace nesting with block merging, and a derived class's bases.
 private val FIXTURE_HEADER = """
     void freeFunction(int);
+
     struct Shape {
-        int area() const;
+        Shape();
+        Shape(const Shape& other);
+        virtual ~Shape();
+        Shape& operator=(const Shape& other) = delete;
+        virtual int area() const = 0;
         const char* name() const;
+        static int count();
+        int id;
+    private:
+        int secret;
+        const int cache;
     };
+
+    namespace geo {
+        int add(int a, int b);
+
+        class Circle : public Shape {
+        public:
+            Circle(double r);
+            int area() const override;
+            double radius() const;
+            double r;
+            const int version;
+        private:
+            Circle();
+            double cached;
+        };
+    }
+
+    namespace geo {
+        bool enabled();
+    }
 """.trimIndent()
 
 private var failures = 0
@@ -40,9 +77,10 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
     println("  [${if (pass) "PASS" else "FAIL"}] $name${if (detail.isEmpty()) "" else " — $detail"}")
 }
 
-// #44 brick 2, the front-end scaffold: parse the fixture with Clang's C++ AST (on the
-// kplusplus-generated libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU from
-// the walk, and serialize it to JSON — the end-to-end skeleton the next bricks fill in.
+// #44 brick 3, construction depth: parse the fixture with Clang's C++ AST (on the
+// kplusplus-generated libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU
+// mirroring ModelFactories' full decl/class/member contract, and self-check every
+// constructed shape against the model.
 @Suppress("UNUSED_PARAMETER")
 fun main(args: Array<String>): Unit = memScoped {
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
@@ -59,18 +97,7 @@ fun main(args: Array<String>): Unit = memScoped {
 
     // ---- Structural summary ----
     println("cppfrontend: constructed WrappedTU from the Clang C++ AST")
-    for (child in tu.children) {
-        when (child) {
-            is WrappedClass -> {
-                println("  class ${child.name} (${child.children.size} members)")
-                child.children.filterIsInstance<WrappedMethod>().forEach {
-                    println("    $it${if (it.isConst) " const" else ""}")
-                }
-            }
-            is WrappedMethod -> println("  free fn $child [${child.methodType}]")
-            else -> println("  ${child::class.simpleName}")
-        }
-    }
+    printElements(tu.children, indent = "  ")
 
     // ---- Serialize ----
     val json = Json { prettyPrint = true }.encodeToString(tu.serialized())
@@ -79,23 +106,138 @@ fun main(args: Array<String>): Unit = memScoped {
 
     // ---- Self-checks ----
     println("\ncppfrontend: self-checks")
+
+    // -- Shape: TU-level abstract class with ctors/dtor/methods/fields + metadata.
     val shape = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Shape" }
-    val methods = shape?.children?.filterIsInstance<WrappedMethod>().orEmpty()
     check("TU contains class Shape", shape != null)
-    check("Shape has 2 methods", methods.size == 2, "got ${methods.size}")
-    val area = methods.find { it.name == "area" }
+    check("Shape is abstract (pure-virtual area)", shape?.isAbstract == true)
+
+    val shapeMethods = shape?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+        .filter { it !is WrappedConstructor && it !is WrappedDestructor }
+    check(
+        "Shape has 3 plain methods (area, name, count)",
+        shapeMethods.map { it.name }.sorted() == listOf("area", "count", "name"),
+        "got ${shapeMethods.map { it.name }}"
+    )
+    val area = shapeMethods.find { it.name == "area" }
     check(
         "area return type spelling is 'int'",
         area?.returnType?.toString() == "int",
         "got ${area?.returnType}"
     )
     check("area is const", area?.isConst == true)
-    val name = methods.find { it.name == "name" }
+    check("area is virtual", area?.isVirtual == true)
+    check("area is an instance METHOD", area?.methodType == MethodType.METHOD)
+    val name = shapeMethods.find { it.name == "name" }
     check(
         "name return type spelling is 'const char*'",
         name?.returnType?.toString() == "const char*",
         "got ${name?.returnType}"
     )
+    val count = shapeMethods.find { it.name == "count" }
+    check("static count() maps to MethodType.STATIC", count?.methodType == MethodType.STATIC)
+
+    val shapeCtors = shape?.children?.filterIsInstance<WrappedConstructor>().orEmpty()
+    check("Shape has 2 constructors", shapeCtors.size == 2, "got ${shapeCtors.size}")
+    val defaultCtor = shapeCtors.find { it.isDefaultConstructor }
+    check(
+        "default ctor: isDefaultConstructor, not copy, 0 args",
+        defaultCtor != null && !defaultCtor.isCopyConstructor && defaultCtor.args.isEmpty()
+    )
+    val copyCtor = shapeCtors.find { it.isCopyConstructor }
+    check(
+        "copy ctor: isCopyConstructor with 1 reference arg",
+        copyCtor != null && copyCtor.args.singleOrNull()?.type?.isReference == true,
+        "got ${copyCtor?.args}"
+    )
+    val dtor = shape?.children?.filterIsInstance<WrappedDestructor>()?.singleOrNull()
+    check("Shape has a destructor and it is virtual", dtor?.isVirtual == true)
+
+    check(
+        "deleted operator= is filtered out",
+        shapeMethods.none { it.name == "operator=" }
+    )
+    check(
+        "Shape metadata: hasDeletedCopyAssignment (deleted operator=)",
+        shape?.metadata?.hasDeletedCopyAssignment == true
+    )
+    check(
+        "Shape metadata: hasPrivateConstField (private 'const int cache')",
+        shape?.metadata?.hasPrivateConstField == true
+    )
+    // ModelFactories only sets hasConstructor for a FILTERED ctor; Shape's are public.
+    check(
+        "Shape metadata: hasConstructor stays false for public-only ctors",
+        shape?.metadata?.hasConstructor == false
+    )
+    val shapeFields = shape?.children?.filterIsInstance<WrappedField>().orEmpty()
+    check(
+        "Shape public field 'id: int' is the only field (private ones filtered)",
+        shapeFields.singleOrNull()?.let { it.name == "id" && it.type.toString() == "int" } == true,
+        "got $shapeFields"
+    )
+
+    // -- geo: namespace nesting, block merging, members landing inside it.
+    val geos = tu.children.filterIsInstance<WrappedNamespace>().filter { it.namespace == "geo" }
+    check("both 'namespace geo' blocks merge into ONE WrappedNamespace", geos.size == 1)
+    val geo = geos.firstOrNull()
+    val geoFns = geo?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+    check(
+        "geo holds add+enabled (from both blocks) as STATIC free functions",
+        geoFns.map { it.name }.sorted() == listOf("add", "enabled") &&
+            geoFns.all { it.methodType == MethodType.STATIC },
+        "got $geoFns"
+    )
+    val add = geoFns.find { it.name == "add" }
+    check(
+        "add(int a, int b) carries real parameter names",
+        add?.args?.map { it.name } == listOf("a", "b"),
+        "got ${add?.args}"
+    )
+
+    // -- Circle: derived class inside the namespace.
+    val circle = geo?.children?.filterIsInstance<WrappedClass>()?.find { it.name == "Circle" }
+    check("geo contains class Circle", circle != null)
+    check("Circle is not abstract (area overridden)", circle?.isAbstract == false)
+    val base = circle?.children?.filterIsInstance<WrappedBase>()?.singleOrNull()
+    check(
+        "Circle base: public, non-virtual, type Shape",
+        base != null && base.isPublic && !base.isVirtualBase && base.type?.toString() == "Shape",
+        "got ${base?.type} public=${base?.isPublic} virtual=${base?.isVirtualBase}"
+    )
+    val circleCtors = circle?.children?.filterIsInstance<WrappedConstructor>().orEmpty()
+    check(
+        "Circle keeps 1 public ctor (the private one is filtered)",
+        circleCtors.size == 1,
+        "got ${circleCtors.size}"
+    )
+    val circleCtor = circleCtors.firstOrNull()
+    check(
+        "Circle(double r): not copy, not default, 1 double arg named r",
+        circleCtor != null && !circleCtor.isCopyConstructor && !circleCtor.isDefaultConstructor &&
+            circleCtor.args.singleOrNull()
+                ?.let { it.name == "r" && it.type.toString() == "double" } == true,
+        "got ${circleCtor?.args}"
+    )
+    check(
+        "Circle metadata: hasConstructor (private ctor recorded)",
+        circle?.metadata?.hasConstructor == true
+    )
+    val circleFields = circle?.children?.filterIsInstance<WrappedField>().orEmpty()
+    check(
+        "Circle public fields are r + version (private 'cached' filtered)",
+        circleFields.map { it.name } == listOf("r", "version"),
+        "got $circleFields"
+    )
+    check(
+        "Circle metadata: hasDeletedCopyAssignment (public 'const int version')",
+        circle?.metadata?.hasDeletedCopyAssignment == true
+    )
+    val circleArea = circle?.children?.filterIsInstance<WrappedMethod>()
+        ?.find { it.name == "area" && it !is WrappedConstructor }
+    check("Circle's area override is virtual", circleArea?.isVirtual == true)
+
+    // -- TU-level free function (unchanged from brick 2).
     val freeFn = tu.children.filterIsInstance<WrappedMethod>().find { it.name == "freeFunction" }
     check(
         "freeFunction is a TU-level STATIC method",
@@ -115,6 +257,36 @@ fun main(args: Array<String>): Unit = memScoped {
 
     if (failures > 0) fail("$failures self-check(s) failed")
     println("cppfrontend: ALL SELF-CHECKS PASSED")
+}
+
+private fun printElements(
+    elements: List<com.monkopedia.krapper.generator.model.WrappedElement>,
+    indent: String
+) {
+    for (child in elements) {
+        when (child) {
+            is WrappedNamespace -> {
+                println("${indent}namespace ${child.namespace}")
+                printElements(child.children, "$indent  ")
+            }
+            is WrappedClass -> {
+                println(
+                    "${indent}class ${child.name}" +
+                        (if (child.isAbstract) " (abstract)" else "") +
+                        " (${child.children.size} members)"
+                )
+                printElements(child.children, "$indent  ")
+            }
+            is WrappedBase -> println("$indent: ${child.type} (public=${child.isPublic})")
+            is WrappedField -> println("${indent}val $child")
+            is WrappedMethod -> println(
+                "$indent$child [${child.methodType}]" +
+                    (if (child.isConst) " const" else "") +
+                    (if (child.isVirtual) " virtual" else "")
+            )
+            else -> println("$indent${child::class.simpleName}")
+        }
+    }
 }
 
 private fun fail(message: String): Nothing {

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -13,23 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import clang.AccessSpecifier
+import clang.CXXConstructorDecl
+import clang.CXXDestructorDecl
 import clang.CXXMethodDecl
 import clang.CXXRecordDecl
 import clang.Decl
+import clang.DeclContext
+import clang.FieldDecl
 import clang.FunctionDecl
+import clang.NamespaceDecl
 import clang.ParmVarDecl
 import clang.TranslationUnitDecl
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
+import com.monkopedia.krapper.generator.model.WrappedDestructor
+import com.monkopedia.krapper.generator.model.WrappedElement
+import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.model.WrappedTU
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 
-// The C++-AST front-end's model construction (#44 brick 2): walk a parsed Clang AST on the
-// kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output model —
-// the same WrappedTU shape the libclang-C front-end (ModelFactories.kt) produces.
+// The C++-AST front-end's model construction (#44 bricks 2+3): walk a parsed Clang AST on
+// the kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output
+// model — the same WrappedTU shape the libclang-C front-end (ModelFactories.kt) produces.
+// Every construction rule cites the ModelFactories source it mirrors.
 
 // IDENTITY CONVENTION: the libclang front-end keys identity fields (WrappedArgument.usr and
 // the reducer's lookup maps) on libclang's USR string. This front-end's equivalent is the
@@ -41,94 +53,267 @@ private fun Decl.canonical(): Decl = (getCanonicalDecl() as? Decl) ?: this
 
 private fun Decl.cppUsr(): String = "cpp:${canonical().getID()}"
 
-// Construct a WrappedTU from the parsed translation unit. Top-level shape matches the
-// libclang front-end (ModelFactories.mapAll): a WrappedClass per record and a
-// MethodType.STATIC WrappedMethod per free function, both direct children of the TU.
-fun buildWrappedTU(tuDecl: TranslationUnitDecl): WrappedTU {
-    val tu = WrappedTU()
-    for (decl in tuDecl.asDeclContext().decls()) {
-        if (decl == null) continue
-        // Skip the implicit builtin TU members (__int128_t, __builtin_va_list, ...) —
-        // they aren't part of the parsed fixture.
-        if (decl.isImplicit()) continue
-        val record = decl.asCXXRecordDecl()
-        if (record != null) {
-            tu.addChild(buildClass(record))
-            continue
+// operator new/delete are never bound — neither as members nor as free functions
+// (ModelFactories.map's CXXMethod/FunctionDecl branch filters these names).
+private val NEW_DELETE_OPERATORS = listOf(
+    "operator new",
+    "operator new[]",
+    "operator delete",
+    "operator delete[]"
+)
+
+/**
+ * Construct a WrappedTU from the parsed translation unit. Top-level shape matches the
+ * libclang front-end (ModelFactories.mapAll): a WrappedNamespace per (named) namespace, a
+ * WrappedClass per record, and a MethodType.STATIC WrappedMethod per free function.
+ */
+fun buildWrappedTU(tuDecl: TranslationUnitDecl): WrappedTU =
+    WrappedTU().also { ModelBuilder().addContextDecls(tuDecl.asDeclContext(), it) }
+
+private class ModelBuilder {
+    // Mirrors ModelFactories' USR-keyed elementLookup memo for namespaces: every block of
+    // `namespace geo { }` shares one libclang USR, so they all collapse into ONE
+    // WrappedNamespace that accumulates all the blocks' members. The canonical-Decl
+    // identity (cppUsr) collapses namespace redeclarations the same way.
+    private val namespaces = mutableMapOf<String, WrappedNamespace>()
+
+    // Walk one DeclContext (the TU or a namespace) and add its children to [parent].
+    fun addContextDecls(context: DeclContext, parent: WrappedElement) {
+        for (decl in context.decls()) {
+            if (decl == null) continue
+            // Skip implicit decls (the builtin TU members like __int128_t,
+            // __builtin_va_list) — libclang's cursor walk never surfaces them.
+            if (decl.isImplicit()) continue
+            val namespace = decl.asNamespaceDecl()
+            if (namespace != null) {
+                addNamespace(namespace, parent)
+                continue
+            }
+            val record = decl.asCXXRecordDecl()
+            if (record != null) {
+                parent.addChild(buildClass(record))
+                continue
+            }
+            val function = decl.asFunctionDecl()
+            if (function != null && decl.asCXXMethodDecl() == null) {
+                // A deleted free function: libclang surfaces `= delete` as
+                // CXAvailability_NotAvailable and filters the decl out
+                // (ModelFactories.map's availability check).
+                if (function.isDeleted()) continue
+                if (function.asNamedDecl().getNameAsString() in NEW_DELETE_OPERATORS) continue
+                // A free function is a STATIC WrappedMethod (ModelFactories.WrappedMethod:
+                // STATIC when the semantic parent is not a class).
+                parent.addChild(buildFunction(function))
+            }
+            // brick-4+: typedefs, enums, global variables, class templates, and
+            // forward-declaration redecl-collapse for classes (elementLookup's other use).
         }
-        val function = decl.asFunctionDecl()
-        if (function != null && decl.asCXXMethodDecl() == null) {
-            // A free function is a STATIC WrappedMethod with no parent class — the model's
-            // namespace-level-function convention (see freeFunctionQualifiedName).
-            tu.addChild(buildFunction(function))
+    }
+
+    private fun addNamespace(decl: NamespaceDecl, parent: WrappedElement) {
+        val name = decl.asNamedDecl().getNameAsString() ?: error("namespace without a name")
+        // An anonymous namespace has an empty spelling; its members have TU-internal
+        // linkage and can't cross the C ABI, so it is skipped transitively
+        // (ModelFactories.map's CXCursor_Namespace branch).
+        if (name.isEmpty()) return
+        val namespace = namespaces.getOrPut(decl.asDecl().cppUsr()) {
+            WrappedNamespace(name).also { parent.addChild(it) }
         }
-        // brick-3+: namespaces, typedefs, enums, global fields, class templates.
+        addContextDecls(decl.asDeclContext(), namespace)
     }
-    return tu
-}
 
-private fun buildClass(record: CXXRecordDecl): WrappedClass {
-    val name = record.asNamedDecl().getNameAsString() ?: error("record without a name")
-    // brick-3+: isAbstract + ClassMetadata (hasConstructor/hasCopyConstructor/...) — left at
-    // the model's defaults until the ctor/dtor walk lands.
-    val cls = WrappedClass(name)
-    for (base in record.bases()) {
-        if (base == null) continue
-        val spelling = base.getType().getAsString() ?: continue
-        // brick-3+: isPublic/isVirtualBase need the access-specifier accessors bound.
-        cls.addChild(WrappedBase(WrappedType(spelling)))
+    private fun buildClass(record: CXXRecordDecl): WrappedClass {
+        val name = record.asNamedDecl().getNameAsString() ?: error("record without a name")
+        // ModelFactories' WrappedClass factory: name via wrapName (= the bare name for a
+        // non-template class; template-args spelling is brick-4+) + the isAbstract flag.
+        // hasDefinition() guards a forward-declared record, whose definition-data
+        // accessors may not be read (libclang's isAbstract reads the definition too).
+        val cls = WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
+        for (base in record.bases()) {
+            if (base == null) continue
+            val spelling = base.getType().getAsString() ?: continue
+            // ModelFactories.map's CXCursor_CXXBaseSpecifier branch: isPublic from the
+            // base's access specifier, isVirtualBase from `virtual` inheritance.
+            cls.addChild(
+                WrappedBase(
+                    WrappedType(spelling),
+                    isPublic = base.getAccessSpecifier() == AccessSpecifier.AS_public,
+                    isVirtualBase = base.isVirtual()
+                )
+            )
+        }
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            // Implicit members (the injected class name, Sema-injected copy ctor/
+            // assignment) are never visited by libclang's cursor walk; mirror that.
+            if (decl.isImplicit()) continue
+            addMember(decl, cls)
+        }
+        return cls
     }
-    for (method in record.methods()) {
-        if (method == null) continue
-        // Implicit members (Sema-injected copy ctor/assignment) aren't fixture surface.
-        if (method.isImplicit()) continue
-        // brick-3+: CXXConstructor/CXXDestructor/CXXConversion kinds map to
-        // WrappedConstructor/WrappedDestructor/conversion methods; only plain methods now.
-        if (method.getDeclKindName() != "CXXMethod") continue
-        cls.addChild(buildMethod(method))
-    }
-    // brick-3+: FieldDecl children -> WrappedField.
-    return cls
-}
 
-private fun buildMethod(method: CXXMethodDecl): WrappedMethod {
-    val name = method.asNamedDecl().getNameAsString() ?: error("method without a name")
-    val isConst = method.isConst()
-    val spelling = method.getReturnType().getAsString() ?: error("method without a return")
-    // Mirror the libclang front-end's return-const rule (ModelFactories.WrappedMethod):
-    // a `const` method's constness only carries to a pointer/reference return; const on a
-    // by-value return is meaningless for the temporary and breaks the Holder path (G8).
-    val returnType = WrappedType(spelling).let {
-        if (isConst && (it.isPointer || it.isReference)) WrappedType.const(it) else it
+    private fun addMember(decl: Decl, cls: WrappedClass) {
+        val access = decl.getAccess()
+        // ModelFactories.map's top filter: a private/protected member — or one libclang
+        // marks CXAvailability_NotAvailable, which is how `= delete` surfaces (bridged
+        // here as FunctionDecl::isDeleted()) — is dropped, after recording the metadata
+        // the resolver needs about the member's absence.
+        if (access == AccessSpecifier.AS_private ||
+            access == AccessSpecifier.AS_protected ||
+            decl.asFunctionDecl()?.isDeleted() == true
+        ) {
+            recordFilteredMember(decl, cls)
+            return
+        }
+        val constructor = decl.asCXXConstructorDecl()
+        if (constructor != null) {
+            cls.addChild(buildConstructor(constructor))
+            return
+        }
+        val destructor = decl.asCXXDestructorDecl()
+        if (destructor != null) {
+            cls.addChild(buildDestructor(destructor))
+            return
+        }
+        val method = decl.asCXXMethodDecl()
+        if (method != null) {
+            if (method.asNamedDecl().getNameAsString() in NEW_DELETE_OPERATORS) return
+            cls.addChild(buildMethod(method))
+            return
+        }
+        val field = decl.asFieldDecl()
+        if (field != null) {
+            addField(field, cls)
+        }
+        // Anything else (static data members, member typedefs, nested enums) falls
+        // through ModelFactories.map's `else -> return null` and is dropped; nested
+        // record decls are brick-4+ (together with the nested-in-class-template skip).
     }
-    val methodType = if (method.isStatic()) MethodType.STATIC else MethodType.METHOD
-    return WrappedMethod(name, returnType, methodType).also {
-        it.isConst = isConst
-        it.isVirtual = method.isVirtual()
-        it.addArgs(method.asFunctionDecl())
-    }
-}
 
-private fun buildFunction(function: FunctionDecl): WrappedMethod {
-    val name = function.asNamedDecl().getNameAsString() ?: error("function without a name")
-    val returnType = WrappedType(function.getReturnType().getAsString() ?: error("no return"))
-    return WrappedMethod(name, returnType, MethodType.STATIC).also {
-        it.addArgs(function)
+    // Mirror of the metadata side-effects ModelFactories.map records for a member it
+    // filters out (private/protected/deleted), keyed by the member's kind and name.
+    private fun recordFilteredMember(decl: Decl, cls: WrappedClass) {
+        val metadata = cls.metadata
+        val constructor = decl.asCXXConstructorDecl()
+        if (constructor != null) {
+            metadata.hasConstructor = true
+            // A deleted or non-public COPY constructor makes the type non-copyable for
+            // the by-value Holder placement-new (T-skip); isCopyConstructor is the
+            // C++-AST equivalent of clang_CXXConstructor_isCopyConstructor.
+            if (constructor.isCopyConstructor()) {
+                metadata.hasDeletedCopyConstructor = true
+            }
+            return
+        }
+        // ModelFactories' filter only inspects CXCursor_CXXMethod here — a filtered
+        // destructor records nothing — so exclude destructors from this branch.
+        val method = decl.asCXXMethodDecl()
+        if (method != null && decl.asCXXDestructorDecl() == null) {
+            when (method.asNamedDecl().getNameAsString()) {
+                "operator new" -> metadata.hasHiddenNew = true
+                "operator delete" -> metadata.hasHiddenDelete = true
+                // ModelFactories' isCopyAssignmentOf (single non-move lvalue-ref param of
+                // the same class) is exactly CXXMethodDecl::isCopyAssignmentOperator().
+                "operator=" -> if (method.isCopyAssignmentOperator()) {
+                    metadata.hasDeletedCopyAssignment = true
+                }
+            }
+            return
+        }
+        val field = decl.asFieldDecl()
+        if (field != null) {
+            // A private/protected CONST field (ModelFactories' CXCursor_FieldDecl filter
+            // branch) blocks the generated default-assignment paths.
+            val spelling = field.getType().getAsString() ?: return
+            if (WrappedType(spelling).isConst) {
+                metadata.hasPrivateConstField = true
+            }
+        }
     }
-}
 
-private fun WrappedMethod.addArgs(function: FunctionDecl) {
-    for (i in 0u until function.getNumParams()) {
-        // getParamDecl returns the Api interface (the generated related-object-getter
-        // convention); re-wrap to the concrete ParmVarDecl so the upcast chain resolves.
-        val param = function.getParamDecl(i)?.let { ParmVarDecl(it.ptr, function.memScope) }
-            ?: continue
-        // Unnamed parameter (e.g. `void freeFunction(int)`) falls back to the same
-        // positional name the libclang front-end synthesizes.
-        val name = param.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() }
-            ?: "_arg_$i"
-        val spelling = param.asValueDecl().getType().getAsString() ?: continue
-        // brick-3+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
-        addChild(WrappedArgument(name, WrappedType(spelling), param.asDecl().cppUsr()))
+    private fun addField(field: FieldDecl, cls: WrappedClass) {
+        // Anonymous data members (bitfield padding `int :3;`, anon union/struct members)
+        // have a blank spelling and are dropped (ModelFactories' FieldDecl branch).
+        val name = field.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() } ?: return
+        val spelling = field.getType().getAsString() ?: return
+        val type = WrappedType(spelling)
+        // A public REFERENCE or CONST member implicitly deletes the enclosing class's
+        // copy assignment, and a reference member also deletes the implicit default
+        // constructor — recorded structurally because the implicit special members are
+        // never emitted as decls (ModelFactories' FieldDecl branch, T-skip residuals).
+        if (type.isReference || type.isConst) {
+            cls.metadata.hasDeletedCopyAssignment = true
+        }
+        if (type.isReference) {
+            cls.metadata.hasDeletedDefaultConstructor = true
+        }
+        cls.addChild(WrappedField(name, type))
+    }
+
+    // ModelFactories.map's CXCursor_Constructor branch: name from the spelling (the class
+    // name), VOID return, copy/default flags from the dedicated predicates
+    // (clang_CXXConstructor_is{Copy,Default}Constructor ⇒
+    // CXXConstructorDecl::is{Copy,Default}Constructor()); allocationStyle stays DIRECT.
+    private fun buildConstructor(constructor: CXXConstructorDecl): WrappedConstructor =
+        WrappedConstructor(
+            constructor.asNamedDecl().getNameAsString() ?: "constructor",
+            WrappedType.VOID,
+            constructor.isCopyConstructor(),
+            constructor.isDefaultConstructor()
+        ).also { it.addArgs(constructor.asFunctionDecl()) }
+
+    // ModelFactories.map's CXCursor_Destructor branch: name from the spelling ("~Shape"),
+    // VOID return, virtuality threaded for the non-virtual-destructor diagnostic.
+    private fun buildDestructor(destructor: CXXDestructorDecl): WrappedDestructor =
+        WrappedDestructor(
+            destructor.asNamedDecl().getNameAsString() ?: "destructor",
+            WrappedType.VOID
+        ).also {
+            it.isVirtual = destructor.isVirtual()
+            it.addArgs(destructor.asFunctionDecl())
+        }
+
+    private fun buildMethod(method: CXXMethodDecl): WrappedMethod {
+        val name = method.asNamedDecl().getNameAsString() ?: error("method without a name")
+        val isConst = method.isConst()
+        val spelling = method.getReturnType().getAsString() ?: error("method without a return")
+        // Mirror the libclang front-end's return-const rule (ModelFactories.WrappedMethod):
+        // a `const` method's constness only carries to a pointer/reference return; const on
+        // a by-value return is meaningless for the temporary and breaks the Holder path (G8).
+        val returnType = WrappedType(spelling).let {
+            if (isConst && (it.isPointer || it.isReference)) WrappedType.const(it) else it
+        }
+        // ModelFactories.WrappedMethod: STATIC for a static member (or a non-class-parent
+        // function — the buildFunction path here).
+        val methodType = if (method.isStatic()) MethodType.STATIC else MethodType.METHOD
+        return WrappedMethod(name, returnType, methodType).also {
+            it.isConst = isConst
+            it.isVirtual = method.isVirtual()
+            it.addArgs(method.asFunctionDecl())
+        }
+    }
+
+    private fun buildFunction(function: FunctionDecl): WrappedMethod {
+        val name = function.asNamedDecl().getNameAsString() ?: error("function without a name")
+        val returnType = WrappedType(function.getReturnType().getAsString() ?: error("no return"))
+        return WrappedMethod(name, returnType, MethodType.STATIC).also {
+            it.addArgs(function)
+        }
+    }
+
+    private fun WrappedMethod.addArgs(function: FunctionDecl) {
+        for (i in 0u until function.getNumParams()) {
+            // getParamDecl returns the Api interface (the generated related-object-getter
+            // convention); re-wrap to the concrete ParmVarDecl so the upcast chain resolves.
+            val param = function.getParamDecl(i)?.let { ParmVarDecl(it.ptr, function.memScope) }
+                ?: continue
+            // Unnamed parameter (e.g. `void freeFunction(int)`) falls back to the same
+            // positional name the libclang front-end synthesizes.
+            val name = param.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() }
+                ?: "_arg_$i"
+            val spelling = param.asValueDecl().getType().getAsString() ?: continue
+            // brick-4+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
+            addChild(WrappedArgument(name, WrappedType(spelling), param.asDecl().cppUsr()))
+        }
     }
 }

--- a/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
@@ -16,9 +16,11 @@
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
 import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.model.WrappedTU
 import kotlinx.serialization.Serializable
 
@@ -38,6 +40,15 @@ data class SerializedElement(
     val isConst: Boolean? = null,
     val isVirtual: Boolean? = null,
     val isAbstract: Boolean? = null,
+    // Base-specifier payload (WrappedBase).
+    val isPublic: Boolean? = null,
+    val isVirtualBase: Boolean? = null,
+    // Constructor payload (WrappedConstructor).
+    val isCopyConstructor: Boolean? = null,
+    val isDefaultConstructor: Boolean? = null,
+    // The names of the ClassMetadata flags set on a class (parse-time records about
+    // FILTERED members — deleted/non-public ctors, hidden new/delete, const fields).
+    val metadata: List<String>? = null,
     // Identity field — "cpp:<canonical Decl id>" here vs a libclang USR string from the
     // libclang front-end; maskable in the Phase C tree-diff (see ModelBuilder.kt).
     val usr: String? = null,
@@ -52,11 +63,29 @@ fun WrappedElement.serialized(): SerializedElement {
             "class",
             name = name,
             isAbstract = isAbstract,
+            metadata = metadataFlags().takeIf { it.isNotEmpty() },
             children = kids
         )
-        is WrappedBase -> SerializedElement("base", type = type?.toString(), children = kids)
-        // Before WrappedMethod: WrappedArgument/WrappedField are sibling element kinds, and
-        // a WrappedConstructor/WrappedDestructor IS-A WrappedMethod (kind via methodType).
+        is WrappedNamespace -> SerializedElement("namespace", name = namespace, children = kids)
+        is WrappedBase -> SerializedElement(
+            "base",
+            type = type?.toString(),
+            isPublic = isPublic,
+            isVirtualBase = isVirtualBase,
+            children = kids
+        )
+        // Before WrappedMethod: WrappedArgument/WrappedField are sibling element kinds, a
+        // WrappedConstructor IS-A WrappedMethod with extra flags, and a WrappedDestructor
+        // IS-A WrappedMethod distinguished by methodType alone.
+        is WrappedConstructor -> SerializedElement(
+            "method",
+            name = name,
+            returnType = returnType.toString(),
+            methodType = methodType.name,
+            isCopyConstructor = isCopyConstructor,
+            isDefaultConstructor = isDefaultConstructor,
+            children = kids
+        )
         is WrappedArgument -> SerializedElement(
             "arg",
             name = name,
@@ -81,4 +110,16 @@ fun WrappedElement.serialized(): SerializedElement {
         )
         else -> SerializedElement(this::class.simpleName ?: "element", children = kids)
     }
+}
+
+private fun WrappedClass.metadataFlags(): List<String> = buildList {
+    if (metadata.hasHiddenNew) add("hasHiddenNew")
+    if (metadata.hasHiddenDelete) add("hasHiddenDelete")
+    if (metadata.hasConstructor) add("hasConstructor")
+    if (metadata.hasPrivateConstField) add("hasPrivateConstField")
+    if (metadata.hasDefaultConstructor) add("hasDefaultConstructor")
+    if (metadata.hasCopyConstructor) add("hasCopyConstructor")
+    if (metadata.hasDeletedCopyConstructor) add("hasDeletedCopyConstructor")
+    if (metadata.hasDeletedCopyAssignment) add("hasDeletedCopyAssignment")
+    if (metadata.hasDeletedDefaultConstructor) add("hasDeletedDefaultConstructor")
 }


### PR DESCRIPTION
Part of #44 (Phase B brick 3 — construction depth).

Extends the `cppfrontend/` C++-AST front-end's WrappedTU construction to the full decl/class/member contract the libclang front-end implements, mirroring `ModelFactories.kt` rule-for-rule (each construction site cites the ModelFactories branch it matches):

- **WrappedField** — public fields with their WrappedType; blank-name (anon bitfield) drop; public const/reference field records `hasDeletedCopyAssignment` / `hasDeletedDefaultConstructor` (FieldDecl branch).
- **WrappedConstructor / WrappedDestructor** — name from the decl spelling, VOID return, `isCopyConstructor`/`isDefaultConstructor` from `CXXConstructorDecl`'s real predicates (the C++-AST form of `clang_CXXConstructor_is{Copy,Default}Constructor`), dtor virtuality threaded; `allocationStyle` stays DIRECT.
- **Access specifiers** — private/protected members, and deleted ones (libclang's `CXAvailability_NotAvailable` bridged as `FunctionDecl::isDeleted()`), are filtered after recording the same metadata: `hasConstructor` + `hasDeletedCopyConstructor` (filtered ctors), `hasHiddenNew`/`hasHiddenDelete`, `hasDeletedCopyAssignment` (`operator=` via `isCopyAssignmentOperator()`, exactly ModelFactories' `isCopyAssignmentOf` semantics), `hasPrivateConstField`.
- **Static methods** — `CXXMethodDecl::isStatic()` → `MethodType.STATIC`.
- **WrappedNamespace** — namespace nesting with redecl merge: one WrappedNamespace per canonical NamespaceDecl (mirrors the USR-keyed `elementLookup` memo — both `namespace geo { }` blocks land in ONE node); anonymous namespaces skipped transitively.
- **Bases** — `WrappedBase(type, isPublic, isVirtualBase)` from `CXXBaseSpecifier::getAccessSpecifier()`/`isVirtual()`; `WrappedClass.isAbstract` populated (guarded by `hasDefinition()`).
- Class members now walk `DeclContext::decls()` in source order (the cursor-visitation order), replacing the methods()-only walk.

**only()/instantiate delta:** + `clang::NamespaceBaseDecl` (bridges NamespaceDecl→NamedDecl on Clang 22), `clang::NamespaceDecl`, `clang::CXXConstructorDecl`, `clang::CXXDestructorDecl`; − `instantiate("std::vector<clang::CXXMethodDecl*>")` (methods() no longer iterated). No fixups. No `:krapper_model` changes — serialization stays in the frontend-side DTO (grown with base/ctor flags + class metadata + namespace kind).

**Cursor-vs-Decl bridges:** `= delete` ⇒ `isDeleted()` (libclang folds it into availability); `isCopyAssignmentOf` ⇒ `isCopyAssignmentOperator()`; ctor flags ⇒ `CXXConstructorDecl` predicates; namespace USR-merge ⇒ canonical-Decl id.

**Finding (Phase C note):** `QualType::getAsString()` with the default printing policy spells C++ `bool` as `_Bool` (see `enabled()` below) where libclang spells `bool` — a type-spelling divergence to normalize when the tree-diff lands (pass the ASTContext's PrintingPolicy).

### Verify
- Default unaffected: `:krapper_gen:nativeTest :krapper_model:build :krapper_gen:ktlintCheck` — BUILD SUCCESSFUL (modules untouched).
- Gated: `:cppfrontend:runReleaseExecutableKlinker -PenableClang` — BUILD SUCCESSFUL, **all 34 self-checks PASS** (9 brick-2 checks carried + 25 new), fixture grown to a namespace (2 blocks), an abstract base with default+copy ctor / virtual dtor / deleted `operator=` / static method / public+private fields, and a derived class with a private ctor and a public const field.

```
  [PASS] Shape is abstract (pure-virtual area)
  [PASS] Shape has 2 constructors — got 2
  [PASS] default ctor: isDefaultConstructor, not copy, 0 args
  [PASS] copy ctor: isCopyConstructor with 1 reference arg — got [other: const Shape&]
  [PASS] Shape has a destructor and it is virtual
  [PASS] deleted operator= is filtered out
  [PASS] Shape metadata: hasDeletedCopyAssignment (deleted operator=)
  [PASS] Shape metadata: hasPrivateConstField (private 'const int cache')
  [PASS] Shape metadata: hasConstructor stays false for public-only ctors
  [PASS] Shape public field 'id: int' is the only field (private ones filtered) — got [id: int]
  [PASS] both 'namespace geo' blocks merge into ONE WrappedNamespace
  [PASS] geo holds add+enabled (from both blocks) as STATIC free functions
  [PASS] Circle base: public, non-virtual, type Shape — got Shape public=true virtual=false
  [PASS] Circle keeps 1 public ctor (the private one is filtered) — got 1
  [PASS] Circle metadata: hasConstructor (private ctor recorded)
  [PASS] Circle public fields are r + version (private 'cached' filtered)
cppfrontend: ALL SELF-CHECKS PASSED
```

New serialized shapes (trimmed):
```json
{
  "kind": "class", "name": "Circle", "isAbstract": false,
  "metadata": ["hasConstructor", "hasDeletedCopyAssignment"],
  "children": [
    { "kind": "base", "type": "Shape", "isPublic": true, "isVirtualBase": false },
    { "kind": "method", "name": "Circle", "returnType": "void", "methodType": "CONSTRUCTOR",
      "isCopyConstructor": false, "isDefaultConstructor": false,
      "children": [ { "kind": "arg", "name": "r", "type": "double", "usr": "cpp:1215" } ] },
    { "kind": "field", "name": "r", "type": "double" },
    { "kind": "field", "name": "version", "type": "const int" }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
