### PR TITLE
cppfrontend: structural type construction — decode the QualType tree into TypeFactories' WrappedType shapes (#44 brick 4)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -117,8 +117,32 @@ kplusplus {
         "clang::ParmVarDecl",
         "clang::VarDecl",
         // QualType is the carrier for a decl's type; getAsString() (by-value std::string,
-        // normalized to a Kotlin String by #37) feeds the WrappedType(spelling) factory.
-        "clang::QualType"
+        // normalized to a Kotlin String by #37) spells the leaves.
+        "clang::QualType",
+        // NEW for brick 4 (structural type construction, TypeBuilder.kt): clang::Type
+        // carries the shape-classification predicates (isPointerType/isReferenceType/
+        // isRValueReferenceType/isFunctionPointerType/isConstantArrayType/isEnumeralType),
+        // getPointeeType(), and the record recovery (getAsCXXRecordDecl) — the decode
+        // surface proven on clangwalk/type-decode-probe (59ebf04).
+        "clang::Type",
+        // Typedef/alias decode: a sugared QualType's Type dyn-casts to TypedefType, whose
+        // getDecl() (a TypedefNameDecl — covers both `typedef` and `using`) provides the
+        // alias NAME (the size_t/size_type preservation rules) and getUnderlyingType()
+        // (the canonical-collapse recursion). TypeDecl (already bound) bridges the
+        // TypedefNameDecl -> NamedDecl upcast chain.
+        "clang::TypedefType",
+        "clang::TypedefNameDecl",
+        // Constant-array decode: ConstantArrayType::getZExtSize() is the extent and
+        // ArrayType (its direct base) carries getElementType() — together they reconstruct
+        // the libclang "elem [N]" array leaf structurally.
+        "clang::ArrayType",
+        "clang::ConstantArrayType",
+        // Template-specialization decode (probe-proven): a template-typed field/param's
+        // canonical record dyn-casts to ClassTemplateSpecializationDecl ->
+        // getTemplateArgs() -> TemplateArgument::getAsType() per argument.
+        "clang::ClassTemplateSpecializationDecl",
+        "clang::TemplateArgument",
+        "clang::TemplateArgumentList"
     )
     // Materialize the range returns the walk iterates. Brick 3 walks members through
     // DeclContext::decls() (source order, all member kinds) instead of methods(), so the

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -1,4 +1,6 @@
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/AST/DeclCXX.h>
+#include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ASTContext.h>
+#include <clang/AST/Type.h>
 #include <clang/Tooling/Tooling.h>

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -22,6 +22,10 @@ import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.type.WrappedModifiedType
+import com.monkopedia.krapper.generator.model.type.WrappedPrefixedType
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
+import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import kotlin.system.exitProcess
 import kotlinx.cinterop.memScoped
@@ -33,6 +37,11 @@ import kotlinx.serialization.json.Json
 // with metadata), ctors (default + copy) and a virtual dtor, a deleted copy assignment,
 // a static method, public/private fields (incl. the const-field metadata rules), an
 // abstract class, namespace nesting with block merging, and a derived class's bases.
+// Brick 4 grows it with the STRUCTURAL type surface (Scene + the aliases + Holder): a
+// `const Shape&` param, `Shape*` returns (one through the G8 const-method rule), a
+// constant-array field, size_t/size_type preservation, typedef/`using` collapse, and a
+// template-typed field. Holder is defined in-fixture rather than using std::vector so the
+// case carries no std-header weight and the decoded shape is byte-deterministic.
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -68,7 +77,28 @@ private val FIXTURE_HEADER = """
 
     namespace geo {
         bool enabled();
+        Circle* makeCircle();
     }
+
+    typedef unsigned long size_t;
+    typedef int MyInt;
+    using Real = double;
+
+    template <typename T>
+    struct Holder { T value; };
+
+    struct Scene {
+        typedef unsigned long size_type;
+        Shape* current();
+        Shape* cloneShape() const;
+        void describe(const Shape& shape);
+        void reserve(size_t capacity);
+        void setId(MyInt id);
+        void setScale(Real scale);
+        size_type size() const;
+        int corners[4];
+        Holder<Shape*> shapes;
+    };
 """.trimIndent()
 
 private var failures = 0
@@ -78,10 +108,10 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
     println("  [${if (pass) "PASS" else "FAIL"}] $name${if (detail.isEmpty()) "" else " — $detail"}")
 }
 
-// #44 brick 3, construction depth: parse the fixture with Clang's C++ AST (on the
-// kplusplus-generated libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU
-// mirroring ModelFactories' full decl/class/member contract, and self-check every
-// constructed shape against the model.
+// #44 bricks 3+4: parse the fixture with Clang's C++ AST (on the kplusplus-generated
+// libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU mirroring ModelFactories'
+// full decl/class/member contract — with every type decoded STRUCTURALLY from the QualType
+// tree (TypeBuilder.kt) — and self-check each constructed shape against the model.
 @Suppress("UNUSED_PARAMETER")
 fun main(args: Array<String>): Unit = memScoped {
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
@@ -184,8 +214,8 @@ fun main(args: Array<String>): Unit = memScoped {
     val geo = geos.firstOrNull()
     val geoFns = geo?.children?.filterIsInstance<WrappedMethod>().orEmpty()
     check(
-        "geo holds add+enabled (from both blocks) as STATIC free functions",
-        geoFns.map { it.name }.sorted() == listOf("add", "enabled") &&
+        "geo holds add+enabled+makeCircle (from both blocks) as STATIC free functions",
+        geoFns.map { it.name }.sorted() == listOf("add", "enabled", "makeCircle") &&
             geoFns.all { it.methodType == MethodType.STATIC },
         "got $geoFns"
     )
@@ -254,6 +284,151 @@ fun main(args: Array<String>): Unit = memScoped {
         freeFn?.args?.firstOrNull()?.usr?.startsWith("cpp:") == true,
         "got '${freeFn?.args?.firstOrNull()?.usr}'"
     )
+
+    // -- Brick 4: STRUCTURAL type construction (TypeBuilder.kt mirroring TypeFactories.kt).
+    // Each check asserts the constructed WrappedType TREE (not just its spelling) AND that
+    // toString() round-trips to the libclang path's spelling, citing the mirrored rule.
+    val scene = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Scene" }
+    check("TU contains class Scene", scene != null)
+    val sceneMethods = scene?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+    val sceneFields = scene?.children?.filterIsInstance<WrappedField>().orEmpty()
+
+    // Builtin leaf (createForType `else -> WrappedType(spelling)`) + the PrintingPolicy
+    // bridge: getAsString()'s default policy spells C's `_Bool`; the libclang path (the
+    // TU's C++ LangOpts) spells `bool` — normalized in TypeBuilder.spellingOf.
+    val enabled = geoFns.find { it.name == "enabled" }
+    check(
+        "bool return: builtin leaf normalizes _Bool -> WrappedTypeReference(\"bool\")",
+        (enabled?.returnType as? WrappedTypeReference)?.name == "bool",
+        "got ${enabled?.returnType}"
+    )
+
+    // Record leaf: createForType's ClassDecl/StructDecl -> WrappedType(fullyQualified) —
+    // a namespaced record spells its "::"-joined semantic-parent chain.
+    val makeCircle = geoFns.find { it.name == "makeCircle" }
+    check(
+        "makeCircle return spells the QUALIFIED record leaf: 'geo::Circle*'",
+        makeCircle?.returnType?.toString() == "geo::Circle*",
+        "got ${makeCircle?.returnType}"
+    )
+
+    // Pointer shape: invoke's `spelling.endsWith("*") -> pointerTo(invoke(pointee))`.
+    val currentRet = sceneMethods.find { it.name == "current" }?.returnType
+    check(
+        "Shape* return: WrappedModifiedType(\"*\") over record leaf WrappedTypeReference(\"Shape\")",
+        currentRet is WrappedModifiedType && currentRet.modifier == "*" &&
+            (currentRet.baseType as? WrappedTypeReference)?.name == "Shape",
+        "got $currentRet"
+    )
+    check("Shape* round-trips to 'Shape*'", currentRet?.toString() == "Shape*")
+
+    // G8 const-method rule (ModelFactories.WrappedMethod): a const method's constness
+    // carries to a pointer return as an OUTER const — const(pointerTo(Shape)).
+    val cloneRet = sceneMethods.find { it.name == "cloneShape" }?.returnType
+    check(
+        "const method's Shape* return gains OUTER const: WrappedPrefixedType(const, Shape*)",
+        cloneRet is WrappedPrefixedType && cloneRet.modifier == "const" &&
+            (cloneRet.baseType as? WrappedModifiedType)?.modifier == "*",
+        "got $cloneRet"
+    )
+
+    // Reference shape: invoke's `spelling.endsWith("&") -> referenceTo(invoke(pointee))`;
+    // the const is the POINTEE's qualifier, so it nests INSIDE: &(const(Shape)).
+    val describeArg = sceneMethods.find { it.name == "describe" }?.args?.singleOrNull()?.type
+    val describeBase = (describeArg as? WrappedModifiedType)?.baseType
+    check(
+        "const Shape& param: WrappedModifiedType(\"&\") over WrappedPrefixedType(const) over Shape",
+        describeArg is WrappedModifiedType && describeArg.modifier == "&" &&
+            describeBase is WrappedPrefixedType && describeBase.modifier == "const" &&
+            (describeBase.baseType as? WrappedTypeReference)?.name == "Shape",
+        "got $describeArg"
+    )
+    check(
+        "const Shape& round-trips to 'const Shape&'",
+        describeArg?.toString() == "const Shape&"
+    )
+    // The same shape now backs Shape's copy-ctor arg (brick 3 parsed it from a spelling).
+    val copyArg = copyCtor?.args?.singleOrNull()?.type
+    check(
+        "copy-ctor's const Shape& arg decodes to the same structural shape",
+        copyArg is WrappedModifiedType && copyArg.modifier == "&" &&
+            (copyArg.baseType as? WrappedPrefixedType)?.modifier == "const",
+        "got $copyArg"
+    )
+    // ...and name()'s return is the pointer flavor: *(const(char)).
+    val nameRet = name?.returnType
+    check(
+        "const char* return: WrappedModifiedType(\"*\") over WrappedPrefixedType(const) over char",
+        nameRet is WrappedModifiedType && nameRet.modifier == "*" &&
+            ((nameRet.baseType as? WrappedPrefixedType)?.baseType as? WrappedTypeReference)
+                ?.name == "char",
+        "got $nameRet"
+    )
+
+    // size_t param: cAliasTypedefElement preserves the alias NAME (not the canonical
+    // 'unsigned long'), so the Kotlin side surfaces platform.posix.size_t.
+    val reserveArg = sceneMethods.find { it.name == "reserve" }?.args?.singleOrNull()?.type
+    check(
+        "size_t param preserved as the NATIVE alias leaf WrappedTypeReference(\"size_t\")",
+        (reserveArg as? WrappedTypeReference)?.name == "size_t" && reserveArg?.isNative == true,
+        "got $reserveArg"
+    )
+    // size_type return: sizeTypedefElement always normalizes size_type -> size_t.
+    val sizeRet = sceneMethods.find { it.name == "size" }?.returnType
+    check(
+        "size_type return normalizes to WrappedTypeReference(\"size_t\")",
+        (sizeRet as? WrappedTypeReference)?.name == "size_t",
+        "got $sizeRet"
+    )
+    // Ordinary typedef collapse (ResolverBuilderImpl.visit's CXCursor_TypedefDecl branch).
+    val setIdArg = sceneMethods.find { it.name == "setId" }?.args?.singleOrNull()?.type
+    check(
+        "typedef'd MyInt param collapses to the underlying builtin 'int'",
+        (setIdArg as? WrappedTypeReference)?.name == "int",
+        "got $setIdArg"
+    )
+    // `using` alias collapse — deterministic here; ORDER-DEPENDENT on the libclang path
+    // (the documented Phase C divergence, see TypeBuilder.kt's typedef branch).
+    val setScaleArg = sceneMethods.find { it.name == "setScale" }?.args?.singleOrNull()?.type
+    check(
+        "`using Real` param collapses to the underlying builtin 'double'",
+        (setScaleArg as? WrappedTypeReference)?.name == "double",
+        "got $setScaleArg"
+    )
+
+    // Constant array: the libclang leaf spelling is "int [4]" (krapper_gen TestData
+    // golden "int [5]"); WrappedTypeReference parses element/extent off that name.
+    val corners = sceneFields.find { it.name == "corners" }?.type
+    check(
+        "int[4] field: WrappedTypeReference(\"int [4]\") with isArray, size 4, element int",
+        (corners as? WrappedTypeReference)?.let {
+            it.name == "int [4]" && it.isArray && it.arraySize == 4 && it.arrayType.name == "int"
+        } == true,
+        "got $corners"
+    )
+
+    // Template-typed reference: WrappedTemplateType(base ref, decoded args) — base from
+    // the specialization decl's qualified name, each arg structurally decoded.
+    val shapes = sceneFields.find { it.name == "shapes" }?.type
+    val shapesArg = (shapes as? WrappedTemplateType)?.templateArgs?.singleOrNull()
+    check(
+        "Holder<Shape*> field: WrappedTemplateType(base WrappedTypeReference(\"Holder\"), 1 arg)",
+        shapes is WrappedTemplateType &&
+            (shapes.baseType as? WrappedTypeReference)?.name == "Holder" &&
+            shapes.templateArgs.size == 1,
+        "got $shapes"
+    )
+    check(
+        "Holder's template arg decodes structurally to *(Shape)",
+        shapesArg is WrappedModifiedType && shapesArg.modifier == "*" &&
+            (shapesArg.baseType as? WrappedTypeReference)?.name == "Shape",
+        "got $shapesArg"
+    )
+    check(
+        "Holder<Shape*> round-trips to 'Holder<Shape*>'",
+        shapes?.toString() == "Holder<Shape*>"
+    )
+
     check("JSON is non-empty", json.length > 2)
 
     if (failures > 0) fail("$failures self-check(s) failed")

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -38,10 +38,11 @@ import com.monkopedia.krapper.generator.model.WrappedTU
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 
-// The C++-AST front-end's model construction (#44 bricks 2+3): walk a parsed Clang AST on
+// The C++-AST front-end's model construction (#44 bricks 2-4): walk a parsed Clang AST on
 // the kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output
 // model — the same WrappedTU shape the libclang-C front-end (ModelFactories.kt) produces.
-// Every construction rule cites the ModelFactories source it mirrors.
+// Every construction rule cites the ModelFactories source it mirrors; types are decoded
+// STRUCTURALLY from the QualType tree (TypeBuilder.kt, mirroring TypeFactories.kt).
 
 // IDENTITY CONVENTION: the libclang front-end keys identity fields (WrappedArgument.usr and
 // the reducer's lookup maps) on libclang's USR string. This front-end's equivalent is the
@@ -105,8 +106,9 @@ private class ModelBuilder {
                 // STATIC when the semantic parent is not a class).
                 parent.addChild(buildFunction(function))
             }
-            // brick-4+: typedefs, enums, global variables, class templates, and
+            // brick-5+: typedef ELEMENTS, enums, global variables, class templates, and
             // forward-declaration redecl-collapse for classes (elementLookup's other use).
+            // (Typedefs/aliases used as TYPES already resolve — TypeBuilder.kt.)
         }
     }
 
@@ -131,12 +133,12 @@ private class ModelBuilder {
         val cls = WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
         for (base in record.bases()) {
             if (base == null) continue
-            val spelling = base.getType().getAsString() ?: continue
-            // ModelFactories.map's CXCursor_CXXBaseSpecifier branch: isPublic from the
-            // base's access specifier, isVirtualBase from `virtual` inheritance.
+            // ModelFactories.map's CXCursor_CXXBaseSpecifier branch: the base's type built
+            // through the CXType factory (structural buildWrappedType here, brick 4),
+            // isPublic from the access specifier, isVirtualBase from `virtual` inheritance.
             cls.addChild(
                 WrappedBase(
-                    WrappedType(spelling),
+                    buildWrappedType(base.getType()),
                     isPublic = base.getAccessSpecifier() == AccessSpecifier.AS_public,
                     isVirtualBase = base.isVirtual()
                 )
@@ -187,7 +189,7 @@ private class ModelBuilder {
         }
         // Anything else (static data members, member typedefs, nested enums) falls
         // through ModelFactories.map's `else -> return null` and is dropped; nested
-        // record decls are brick-4+ (together with the nested-in-class-template skip).
+        // record decls are brick-5+ (together with the nested-in-class-template skip).
     }
 
     // Mirror of the metadata side-effects ModelFactories.map records for a member it
@@ -224,8 +226,7 @@ private class ModelBuilder {
         if (field != null) {
             // A private/protected CONST field (ModelFactories' CXCursor_FieldDecl filter
             // branch) blocks the generated default-assignment paths.
-            val spelling = field.getType().getAsString() ?: return
-            if (WrappedType(spelling).isConst) {
+            if (buildWrappedType(field.getType()).isConst) {
                 metadata.hasPrivateConstField = true
             }
         }
@@ -235,8 +236,7 @@ private class ModelBuilder {
         // Anonymous data members (bitfield padding `int :3;`, anon union/struct members)
         // have a blank spelling and are dropped (ModelFactories' FieldDecl branch).
         val name = field.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() } ?: return
-        val spelling = field.getType().getAsString() ?: return
-        val type = WrappedType(spelling)
+        val type = buildWrappedType(field.getType())
         // A public REFERENCE or CONST member implicitly deletes the enclosing class's
         // copy assignment, and a reference member also deletes the implicit default
         // constructor — recorded structurally because the implicit special members are
@@ -276,11 +276,10 @@ private class ModelBuilder {
     private fun buildMethod(method: CXXMethodDecl): WrappedMethod {
         val name = method.asNamedDecl().getNameAsString() ?: error("method without a name")
         val isConst = method.isConst()
-        val spelling = method.getReturnType().getAsString() ?: error("method without a return")
         // Mirror the libclang front-end's return-const rule (ModelFactories.WrappedMethod):
         // a `const` method's constness only carries to a pointer/reference return; const on
         // a by-value return is meaningless for the temporary and breaks the Holder path (G8).
-        val returnType = WrappedType(spelling).let {
+        val returnType = buildWrappedType(method.getReturnType()).let {
             if (isConst && (it.isPointer || it.isReference)) WrappedType.const(it) else it
         }
         // ModelFactories.WrappedMethod: STATIC for a static member (or a non-class-parent
@@ -295,7 +294,7 @@ private class ModelBuilder {
 
     private fun buildFunction(function: FunctionDecl): WrappedMethod {
         val name = function.asNamedDecl().getNameAsString() ?: error("function without a name")
-        val returnType = WrappedType(function.getReturnType().getAsString() ?: error("no return"))
+        val returnType = buildWrappedType(function.getReturnType())
         return WrappedMethod(name, returnType, MethodType.STATIC).also {
             it.addArgs(function)
         }
@@ -311,9 +310,14 @@ private class ModelBuilder {
             // positional name the libclang front-end synthesizes.
             val name = param.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() }
                 ?: "_arg_$i"
-            val spelling = param.asValueDecl().getType().getAsString() ?: continue
-            // brick-4+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
-            addChild(WrappedArgument(name, WrappedType(spelling), param.asDecl().cppUsr()))
+            // brick-5+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
+            addChild(
+                WrappedArgument(
+                    name,
+                    buildWrappedType(param.asValueDecl().getType()),
+                    param.asDecl().cppUsr()
+                )
+            )
         }
     }
 }

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import clang.CXXRecordDecl
+import clang.QualType
+import clang.Type
+import clang.TypedefNameDecl
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.UNRESOLVABLE
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.const
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.pointerTo
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referenceTo
+import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
+
+// STRUCTURAL type construction (#44 brick 4): decode a clang::QualType's type tree into the
+// same WrappedType shapes the libclang-C front-end produces, rule-for-rule against
+// krapper_gen's TypeFactories.kt (`WrappedType.Companion.invoke(CValue<CXType>)` +
+// `createForType`). Each branch cites the TypeFactories rule it mirrors; every deliberate
+// divergence is documented in place as a Phase C normalizer entry.
+
+// QualType::getTypePtrOrNull() is declared to return the TypeApi *interface* (the generated
+// related-object-getter convention); re-wrap to the concrete Type so the shape predicates
+// (which live on the concrete class) resolve. Same pattern as the type-decode probe.
+private fun QualType.typePtr(): Type? = getTypePtrOrNull()?.let { Type(it.ptr, memScope) }
+
+// Type::getAsCXXRecordDecl() likewise returns the Api interface; re-wrap so the
+// dyn-cast helpers + NamedDecl upcasts resolve.
+private fun Type.asRecord(): CXXRecordDecl? =
+    getAsCXXRecordDecl()?.let { CXXRecordDecl(it.ptr, memScope) }
+
+// TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
+// after construction (a pointee's qualifier instead nests inside, via the recursion).
+private fun WrappedType.maybeConst(isConst: Boolean): WrappedType =
+    if (isConst) const(this) else this
+
+// cAliasTypedefElement's alias set (TypeFactories.C_ALIAS_TYPEDEFS): C typedefs whose
+// Kotlin form is the platform-correct `platform.posix.<name>`, preserved by NAME instead
+// of being collapsed to their underlying integer.
+private val C_ALIAS_TYPEDEFS = setOf("size_t", "ssize_t", "ptrdiff_t", "intptr_t", "wchar_t")
+
+/**
+ * Decode [type]'s structure into a WrappedType, mirroring the libclang front-end's
+ * TypeFactories dispatch (`WrappedType(CValue<CXType>, resolverBuilder)`):
+ * pointer/reference recursion, template-specialization detection, the typedef reducers
+ * and canonical collapse, then the record/builtin leaf — with const re-applied per level.
+ */
+fun buildWrappedType(type: QualType): WrappedType {
+    // invoke: CXType_Invalid throws; the model-construction call sites all use
+    // throwOnError=false, so an unmodelable type lands as UNRESOLVABLE (skip-not-crash).
+    val ty = type.typePtr() ?: return UNRESOLVABLE
+    val isConst = type.isConstQualified()
+
+    // Alias sugar detection must come FIRST: clang's shape predicates (isPointerType & co)
+    // classify the CANONICAL type, while TypeFactories' pointer/reference dispatch keys on
+    // the SUGARED spelling (`endsWith("*")`/`endsWith("&")`) — and an alias spells its own
+    // name, never taking those branches. TypedefType covers both `typedef` and `using`
+    // (both are TypedefNameDecls).
+    val typedef = ty.asTypedefType()?.getDecl()?.let { TypedefNameDecl(it.ptr, type.memScope) }
+    if (typedef == null) {
+        // invoke: CXType_RValueReference throws "RValues unsupported" -> UNRESOLVABLE
+        // under the call sites' throwOnError=false.
+        if (ty.isRValueReferenceType()) return UNRESOLVABLE
+        if (ty.isFunctionPointerType()) {
+            // A BARE function-pointer (`int (*)(int)`) spells with a trailing ')' on the
+            // libclang path, so it falls through every special case to createForType's
+            // `else -> WrappedType(spelling)` — an opaque named leaf. Mirror that shape.
+            // brick-6: the rich WrappedFunctionPointer only exists for a TYPEDEF over a
+            // fn-pointer (functionPointerTypedefElement) — that reducer needs the
+            // underlying-proto decode + the isCFunctionPointerCompatible recursion, so it
+            // (and a fn-pointer fixture case) is deferred to the callbacks brick.
+            val spelling = type.getAsString()?.trim() ?: return UNRESOLVABLE
+            return WrappedTypeReference(spelling).maybeConst(isConst)
+        }
+        if (ty.isPointerType()) {
+            // invoke: spelling.endsWith("*") -> pointerTo(invoke(pointeeType)).maybeConst.
+            // A `const Shape*`'s const belongs to the POINTEE QualType, so it nests inside
+            // through the recursion — `isConst` here is only a `T* const` top-level const,
+            // exactly libclang's clang_isConstQualifiedType semantics.
+            return pointerTo(buildWrappedType(ty.getPointeeType())).maybeConst(isConst)
+        }
+        if (ty.isReferenceType()) {
+            // invoke: spelling.endsWith("&") -> referenceTo(invoke(pointeeType)).maybeConst.
+            // Only lvalue refs reach here (rvalue refs returned UNRESOLVABLE above), so a
+            // `const Shape&` decodes as &(const(Shape)) — const INSIDE the reference.
+            return referenceTo(buildWrappedType(ty.getPointeeType())).maybeConst(isConst)
+        }
+    }
+
+    // invoke lines 80-104: template arguments detected on the type itself OR its canonical
+    // form (alias/elaborated sugar hides them) -> WrappedTemplateType(baseRef, args).
+    // Structurally, every template-specialization TYPE's canonical form is a record whose
+    // decl dyn-casts to ClassTemplateSpecializationDecl (type-decode probe, P5). Checked
+    // BEFORE the typedef handling for the same reason invoke checks it before
+    // createForType: an alias over a template type still collapses to the template shape.
+    val canonical = type.getCanonicalType()
+    val canonTy = canonical.typePtr()
+    val spec = canonTy?.asRecord()?.asClassTemplateSpecializationDecl()
+    if (spec != null) {
+        // Base ref: createForType(forTemplateBase=true) resolves the specialization decl
+        // (surfaced as a ClassDecl/StructDecl cursor) -> WrappedType(referencedDecl
+        // .fullyQualified); NamedDecl::getQualifiedNameAsString() is the Decl-side spelling
+        // of that same semantic-parent walk (template args are not part of either).
+        val baseName = spec.asNamedDecl().getQualifiedNameAsString() ?: return UNRESOLVABLE
+        val argList = spec.getTemplateArgs()
+        val args = (0u until argList.size()).mapNotNull { i ->
+            // TypeFactories keeps only TYPE arguments (getTemplateArgumentType yields
+            // CXType_Invalid for value args -> filterNotNull). Mirroring that filter needs
+            // TemplateArgument::getKind()'s ArgKind enum surface; the fixture's templates
+            // are type-arg-only, so non-type-arg filtering is a brick-5 residual here.
+            argList.get(i)?.getAsType()?.let { buildWrappedType(it) }
+        }
+        return WrappedTemplateType(WrappedTypeReference(baseName), args).maybeConst(isConst)
+    }
+
+    if (typedef != null) {
+        val name = typedef.asNamedDecl().getNameAsString() ?: ""
+        // sizeTypedefElement: `size_type`/`difference_type` ALWAYS normalize to the
+        // `size_t`/`ptrdiff_t` aliases (so they surface as platform.posix.<name>).
+        when (name) {
+            "size_type" -> return WrappedTypeReference("size_t").maybeConst(isConst)
+            "difference_type" -> return WrappedTypeReference("ptrdiff_t").maybeConst(isConst)
+        }
+        // cAliasTypedefElement: the C platform aliases are preserved as the alias NAME
+        // itself instead of collapsing to the underlying integer. (TypeFactories keys this
+        // on a CXCursor_TypedefDecl only; here it applies to either alias kind — a `using
+        // size_t = ...` is vanishingly rare and the name is the contract either way.)
+        if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name).maybeConst(isConst)
+        // referenceTypedefElement / pointerTypedefElement / assocTypedefElement reduce
+        // std-container member aliases whose underlyings are DEPENDENT trait expressions;
+        // those only arise inside template decls — brick 5's template-DECL construction.
+        //
+        // Everything else collapses to the underlying type, mirroring ResolverBuilderImpl
+        // .visit()'s CXCursor_TypedefDecl branch (recursive typedefDeclUnderlyingType walk).
+        // DIVERGENCE (Phase C normalizer entry): for a C++ `using` alias (TypeAliasDecl)
+        // the libclang path is ORDER-DEPENDENT — visit() leaves the alias un-collapsed
+        // (createForType's `else` then emits the alias NAME as a leaf) unless the
+        // underlying's canonical spelling was already in visit()'s seenNames cache, in
+        // which case the cached record type collapses it anyway. This front-end always
+        // collapses both alias kinds — deterministic, never the order-dependent name leaf.
+        return buildWrappedType(typedef.getUnderlyingType()).maybeConst(isConst)
+    }
+
+    // ---- createForType leaf dispatch (post-visit, i.e. against the canonical type) ----
+
+    if (canonTy != null && canonTy.isConstantArrayType()) {
+        // A constant array falls through createForType to `else -> WrappedType(spelling)`,
+        // and libclang's TypePrinter spells it "elem [N]" (krapper_gen TestData golden:
+        // "int [5]") — WrappedTypeReference models the array parsing on that exact name.
+        // Reconstruct the same spelling structurally from element + extent.
+        val array = canonTy.asConstantArrayType() ?: return UNRESOLVABLE
+        val element = buildWrappedType(array.asArrayType().getElementType())
+        return WrappedTypeReference("$element [${array.getZExtSize()}]").maybeConst(isConst)
+    }
+    canonTy?.asRecord()?.let { record ->
+        // Record leaf: createForType's CXCursor_ClassDecl/StructDecl branches ->
+        // WrappedType(referencedDecl.fullyQualified) — the "::"-joined semantic-parent
+        // chain, which is exactly NamedDecl::getQualifiedNameAsString().
+        val qualified = record.asNamedDecl().getQualifiedNameAsString() ?: return UNRESOLVABLE
+        return WrappedTypeReference(qualified).maybeConst(isConst)
+    }
+    if (canonTy != null && canonTy.isEnumeralType()) {
+        // DIVERGENCE (Phase C normalizer entry): an enum leaf is a WrappedEnumType on the
+        // libclang path (fullyQualified + underlying integer + the constants, createForType
+        // CXCursor_EnumDecl). The constants' VALUES need llvm::APSInt
+        // (EnumConstantDecl::getInitVal), which has no bound surface yet — so the
+        // structural decode emits the named reference WITHOUT the enum payload. brick-5:
+        // bind EnumType/EnumDecl + an APSInt value bridge and emit the real WrappedEnumType.
+        return WrappedTypeReference(spellingOf(canonical) ?: return UNRESOLVABLE)
+            .maybeConst(isConst)
+    }
+    // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,
+    // spelled from the canonical type — the structural equivalent of visit()'s collapse.
+    val spelling = spellingOf(canonical) ?: return UNRESOLVABLE
+    return WrappedTypeReference(spelling).maybeConst(isConst)
+}
+
+// Leaf spelling, mirroring createForType's const-stripped spelling read (the constness is
+// re-applied by maybeConst — here the unqualified type is read instead of string-stripping).
+// PrintingPolicy bridge (brick-3 finding): QualType::getAsString()'s no-policy overload
+// prints with PrintingPolicy(LangOptions()) — C, not the TU's C++ LangOpts that libclang
+// uses — whose one divergent builtin spelling on this slice is `_Bool` for `bool`. Binding
+// ASTContext::getPrintingPolicy() + the policy-taking getAsString overload is a whole extra
+// class surface for one token, so the spelling is normalized instead — documented bridge.
+private fun spellingOf(type: QualType): String? {
+    val spelling = type.getUnqualifiedType().getAsString()?.trim() ?: return null
+    return if (spelling == "_Bool") "bool" else spelling
+}

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -16,7 +16,8 @@
 import clang.CXXRecordDecl
 import clang.QualType
 import clang.Type
-import clang.TypedefNameDecl
+import clang.TypedefType
+import clang.templateArgument.ArgKind
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.UNRESOLVABLE
@@ -40,6 +41,18 @@ private fun QualType.typePtr(): Type? = getTypePtrOrNull()?.let { Type(it.ptr, m
 // dyn-cast helpers + NamedDecl upcasts resolve.
 private fun Type.asRecord(): CXXRecordDecl? =
     getAsCXXRecordDecl()?.let { CXXRecordDecl(it.ptr, memScope) }
+
+// BRIDGE: the generated down-cast helper `Type.asTypedefType()` is missing — TypedefType's
+// base list doesn't survive resolution (`class TypedefType final : public Type, ...,
+// private llvm::TrailingObjects<...>`), so CastTargets never records Type as its base and
+// emits neither TypedefType.asType() nor the inverse dyn-cast (binding gap to fix in
+// krapper_gen). Bridge with the exact mechanism the generated `B_dyncast_D` helper uses:
+// TypedefType's static llvm `classof` (bound on its companion), then re-view the SAME
+// pointer as the derived class (Type is TypedefType's primary base, so the address is
+// identical — precisely what the generated llvm::dyn_cast helper compiles to).
+private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companion) {
+    if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
+}
 
 // TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
 // after construction (a pointee's qualifier instead nests inside, via the recursion).
@@ -68,7 +81,7 @@ fun buildWrappedType(type: QualType): WrappedType {
     // the SUGARED spelling (`endsWith("*")`/`endsWith("&")`) — and an alias spells its own
     // name, never taking those branches. TypedefType covers both `typedef` and `using`
     // (both are TypedefNameDecls).
-    val typedef = ty.asTypedefType()?.getDecl()?.let { TypedefNameDecl(it.ptr, type.memScope) }
+    val typedef = ty.asTypedefTypeOrNull()?.getDecl()
     if (typedef == null) {
         // invoke: CXType_RValueReference throws "RValues unsupported" -> UNRESOLVABLE
         // under the call sites' throwOnError=false.
@@ -113,20 +126,21 @@ fun buildWrappedType(type: QualType): WrappedType {
         // (surfaced as a ClassDecl/StructDecl cursor) -> WrappedType(referencedDecl
         // .fullyQualified); NamedDecl::getQualifiedNameAsString() is the Decl-side spelling
         // of that same semantic-parent walk (template args are not part of either).
-        val baseName = spec.asNamedDecl().getQualifiedNameAsString() ?: return UNRESOLVABLE
-        val argList = spec.getTemplateArgs()
+        val baseName = spec.getQualifiedNameAsString() ?: return UNRESOLVABLE
+        val argList = spec.getTemplateArgs() ?: return UNRESOLVABLE
         val args = (0u until argList.size()).mapNotNull { i ->
-            // TypeFactories keeps only TYPE arguments (getTemplateArgumentType yields
-            // CXType_Invalid for value args -> filterNotNull). Mirroring that filter needs
-            // TemplateArgument::getKind()'s ArgKind enum surface; the fixture's templates
-            // are type-arg-only, so non-type-arg filtering is a brick-5 residual here.
-            argList.get(i)?.getAsType()?.let { buildWrappedType(it) }
+            // TypeFactories keeps only TYPE arguments: getTemplateArgumentType yields
+            // CXType_Invalid for a value arg, and the invalid slot is dropped
+            // (filterNotNull) — the ArgKind.Type filter is that same rule decl-side.
+            val arg = argList.get(i) ?: return@mapNotNull null
+            if (arg.getKind() != ArgKind.Type) return@mapNotNull null
+            buildWrappedType(arg.getAsType())
         }
         return WrappedTemplateType(WrappedTypeReference(baseName), args).maybeConst(isConst)
     }
 
     if (typedef != null) {
-        val name = typedef.asNamedDecl().getNameAsString() ?: ""
+        val name = typedef.getNameAsString() ?: ""
         // sizeTypedefElement: `size_type`/`difference_type` ALWAYS normalize to the
         // `size_t`/`ptrdiff_t` aliases (so they surface as platform.posix.<name>).
         when (name) {
@@ -161,14 +175,14 @@ fun buildWrappedType(type: QualType): WrappedType {
         // "int [5]") — WrappedTypeReference models the array parsing on that exact name.
         // Reconstruct the same spelling structurally from element + extent.
         val array = canonTy.asConstantArrayType() ?: return UNRESOLVABLE
-        val element = buildWrappedType(array.asArrayType().getElementType())
+        val element = buildWrappedType(array.getElementType())
         return WrappedTypeReference("$element [${array.getZExtSize()}]").maybeConst(isConst)
     }
     canonTy?.asRecord()?.let { record ->
         // Record leaf: createForType's CXCursor_ClassDecl/StructDecl branches ->
         // WrappedType(referencedDecl.fullyQualified) — the "::"-joined semantic-parent
         // chain, which is exactly NamedDecl::getQualifiedNameAsString().
-        val qualified = record.asNamedDecl().getQualifiedNameAsString() ?: return UNRESOLVABLE
+        val qualified = record.getQualifiedNameAsString() ?: return UNRESOLVABLE
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -43,13 +43,15 @@ private fun Type.asRecord(): CXXRecordDecl? =
     getAsCXXRecordDecl()?.let { CXXRecordDecl(it.ptr, memScope) }
 
 // BRIDGE: the generated down-cast helper `Type.asTypedefType()` is missing — TypedefType's
-// base list doesn't survive resolution (`class TypedefType final : public Type, ...,
-// private llvm::TrailingObjects<...>`), so CastTargets never records Type as its base and
-// emits neither TypedefType.asType() nor the inverse dyn-cast (binding gap to fix in
-// krapper_gen). Bridge with the exact mechanism the generated `B_dyncast_D` helper uses:
+// base list doesn't survive resolution (TypeBase.h: `class TypedefType final : public
+// TypeWithKeyword, private llvm::TrailingObjects<...>`; the chain is TypedefType ->
+// TypeWithKeyword -> KeywordWrapper<Type> -> Type), so CastTargets never records Type as a
+// base and emits neither TypedefType.asType() nor the inverse dyn-cast (binding gap to fix
+// in krapper_gen). Bridge with the exact mechanism the generated `B_dyncast_D` helper uses:
 // TypedefType's static llvm `classof` (bound on its companion), then re-view the SAME
-// pointer as the derived class (Type is TypedefType's primary base, so the address is
-// identical — precisely what the generated llvm::dyn_cast helper compiles to).
+// pointer as the derived class — safe because Type is the address-identical primary base
+// through that whole chain (KeywordHelpers contributes no state, so EBO applies) —
+// precisely what the generated llvm::dyn_cast helper compiles to.
 private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companion) {
     if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
 }


### PR DESCRIPTION
Phase B brick 4 of #44: `cppfrontend`'s `QualType -> WrappedType` mapping is now STRUCTURAL — the type tree is decoded (qualifiers, pointee recursion, template args, array extents, typedef decls) instead of parsed back out of `getAsString()` spellings, mirroring `TypeFactories.createForType`/`invoke(CValue<CXType>)` rule-for-rule with in-code citations.

## Mirrored rules (each cited in TypeBuilder.kt)
- **Pointer / lvalue-reference** → `pointerTo`/`referenceTo(decode(pointee)).maybeConst` — invoke's `endsWith("*"/"&")` dispatch; a pointee's `const` nests INSIDE through the recursion (libclang `clang_isConstQualifiedType` semantics match `QualType::isConstQualified` exactly).
- **Rvalue refs** → `UNRESOLVABLE` (invoke's `RValueReference` throw under the call sites' `throwOnError=false`).
- **Template-specialization types** → `WrappedTemplateType(WrappedTypeReference(qualifiedName), args)` via `ClassTemplateSpecializationDecl::getTemplateArgs()`; non-type args dropped by `ArgKind.Type` — the bindings DID surface the nested `TemplateArgument::ArgKind` enum, so this mirrors the `getTemplateArgumentType -> CXType_Invalid -> filterNotNull` drop exactly (no residual).
- **Constant arrays** → the libclang `"elem [N]"` leaf (TestData golden `"int [5]"`), rebuilt from `ArrayType::getElementType()` + `ConstantArrayType::getZExtSize()`.
- **Record leaves** → `WrappedTypeReference(getQualifiedNameAsString())` — the Decl-side spelling of `fullyQualified`'s semantic-parent walk (`geo::Circle*` asserted).
- **Typedefs**: `size_type`/`difference_type` → `size_t`/`ptrdiff_t` (sizeTypedefElement); `size_t`/`ssize_t`/`ptrdiff_t`/`intptr_t`/`wchar_t` preserved as the alias NAME (cAliasTypedefElement — a `size_t` param emits `WrappedTypeReference("size_t")`, same as the libclang path); every other alias collapses to its underlying type (`ResolverBuilderImpl.visit`'s TypedefDecl branch).
- **G8 const-method rule** (ModelFactories.WrappedMethod) now applies over structural types: a const method's `Shape*` return decodes as `WrappedPrefixedType(const, WrappedModifiedType(*, Shape))` — OUTER const, asserted structurally.

## Bridges + documented divergences (Phase C normalizer entries)
- **`_Bool` vs `bool` (brick-3 finding)**: `QualType::getAsString()`'s no-policy overload prints with `PrintingPolicy(LangOptions())` (C mode). Resolution: **normalize the spelling** (`_Bool` → `bool`) rather than bind `PrintingPolicy` + `ASTContext::getPrintingPolicy()` — a whole class surface for one token; documented at `spellingOf()`.
- **`using`-alias order-dependence**: the libclang path collapses a `using` alias only if `visit()`'s `seenNames` cache already saw the underlying's canonical spelling — otherwise the alias NAME survives as a leaf. This front-end always collapses both alias kinds (deterministic); divergence documented in the typedef branch.
- **Enum leaves**: libclang emits `WrappedEnumType` (name + underlying int + constants); the constants' values need an `llvm::APSInt` bridge — structural decode emits the named reference, brick-5 note in place (no enum in fixture).
- **Bare fn-pointers**: opaque spelling leaf, same as libclang's `else` fall-through; the rich `WrappedFunctionPointer` only exists for fn-pointer TYPEDEFS (`functionPointerTypedefElement`) — `// brick-6:` comment, fixture case dropped as disproportionate (needs the underlying-proto decode + `isCFunctionPointerCompatible` recursion).
- **Missing generated down-cast** `Type.asTypedefType()`: TypedefType's base list doesn't survive resolution (`final` + private `TrailingObjects` base) so CastTargets never emits the helper — bridged via the bound static llvm `classof` + same-pointer re-view (exactly what the generated `B_dyncast_D` compiles to); krapper_gen gap noted in code.

## Fixture / checks delta
- Fixture grows `Scene` + in-fixture `Holder<T>` (chosen over `std::vector` to avoid std-header weight and keep the decoded shape byte-deterministic) + `typedef size_t`/`MyInt`/`using Real` + `geo::makeCircle()`.
- Self-checks **34 → 51**, all green — structural asserts (`is WrappedModifiedType && baseType is WrappedPrefixedType && ...`) plus toString round-trips per rule.
- `only()` grows by the probe-proven decode slice: `clang::Type`, `TypedefType`/`TypedefNameDecl`, `ArrayType`/`ConstantArrayType`, `ClassTemplateSpecializationDecl`/`TemplateArgument(List)`. No `:krapper_model` changes (featuregen gate not required).

## Verify
- Default unaffected: `:krapper_gen:nativeTest :krapper_model:build :krapper_gen:ktlintCheck` — BUILD SUCCESSFUL.
- Gated: `:cppfrontend:runReleaseExecutableKlinker -PenableClang` — BUILD SUCCESSFUL, **ALL 51 SELF-CHECKS PASSED**.

```
[PASS] bool return: builtin leaf normalizes _Bool -> WrappedTypeReference("bool") — got bool
[PASS] makeCircle return spells the QUALIFIED record leaf: 'geo::Circle*' — got geo::Circle*
[PASS] Shape* return: WrappedModifiedType("*") over record leaf WrappedTypeReference("Shape") — got Shape*
[PASS] const method's Shape* return gains OUTER const: WrappedPrefixedType(const, Shape*) — got const Shape*
[PASS] const Shape& param: WrappedModifiedType("&") over WrappedPrefixedType(const) over Shape — got const Shape&
[PASS] size_t param preserved as the NATIVE alias leaf WrappedTypeReference("size_t") — got size_t
[PASS] size_type return normalizes to WrappedTypeReference("size_t") — got size_t
[PASS] typedef'd MyInt param collapses to the underlying builtin 'int' — got int
[PASS] `using Real` param collapses to the underlying builtin 'double' — got double
[PASS] int[4] field: WrappedTypeReference("int [4]") with isArray, size 4, element int — got int [4]
[PASS] Holder<Shape*> field: WrappedTemplateType(base WrappedTypeReference("Holder"), 1 arg) — got Holder<Shape*>
[PASS] Holder's template arg decodes structurally to *(Shape) — got Shape*
cppfrontend: ALL SELF-CHECKS PASSED
```

Decoded-structure sample (serialized WrappedTU, Scene):

```json
{ "kind": "method", "name": "cloneShape", "returnType": "const Shape*", "isConst": true },
{ "kind": "method", "name": "describe",
  "children": [ { "kind": "arg", "name": "shape", "type": "const Shape&", "usr": "cpp:3104" } ] },
{ "kind": "method", "name": "reserve",
  "children": [ { "kind": "arg", "name": "capacity", "type": "size_t", "usr": "cpp:3159" } ] },
{ "kind": "field", "name": "corners", "type": "int [4]" },
{ "kind": "field", "name": "shapes", "type": "Holder<Shape*>" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
