### PR TITLE
cppfrontend: template declarations + enum construction (#44 brick 5)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -155,16 +155,19 @@ kplusplus {
         "clang::TemplateParameterList",
         "clang::TemplateTypeParmDecl",
         "clang::TemplateTypeParmType",
-        // NEW for brick 5 (enums): an enum-typed leaf reaches its EnumDecl through
-        // EnumType::getDecl() (the Type-side dyn-cast is bridged by TypeClass check —
-        // TypeBuilder); EnumDecl carries getIntegerType() (the underlying type,
+        // NEW for brick 5 (enums): an enum-typed leaf reaches its EnumDecl through the
+        // already-bound Type::getAsTagDecl() + a kind-gated re-view (TypeBuilder).
+        // clang::EnumType is deliberately NOT bound: it declares no constructors of its
+        // own (only inherited `using TagType::TagType`), so no ctor cursor ever marks
+        // hasConstructor and krapper synthesizes a `new clang::EnumType()` default-
+        // construct wrapper that C++ rejects (implicitly deleted — generator gap noted
+        // on #44). EnumDecl carries getIntegerType() (the underlying type,
         // clang_getEnumDeclIntegerType's source) and its DeclContext holds the
         // EnumConstantDecls. llvm::APSInt is EnumConstantDecl::getInitVal()'s carrier;
         // only its OWN surface is needed (getExtValue — see TypeBuilder's value bridge),
         // so the heavy llvm::APInt base stays unbound.
         "clang::EnumDecl",
         "clang::EnumConstantDecl",
-        "clang::EnumType",
         "llvm::APSInt"
     )
     // Materialize the range returns the walk iterates. Brick 3 walks members through

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -142,7 +142,30 @@ kplusplus {
         // getTemplateArgs() -> TemplateArgument::getAsType() per argument.
         "clang::ClassTemplateSpecializationDecl",
         "clang::TemplateArgument",
-        "clang::TemplateArgumentList"
+        "clang::TemplateArgumentList",
+        // NEW for brick 5 (template DECLARATIONS): a `template <typename T> class` is a
+        // ClassTemplateDecl whose getTemplatedDecl() is the pattern CXXRecordDecl;
+        // getTemplateParameters() lives on TemplateDecl (the primary base, reached by
+        // re-view — see ModelBuilder) and yields a TemplateParameterList (size/getParam).
+        // TemplateTypeParmDecl is each type param's decl; TemplateTypeParmType is the
+        // DEPENDENT `T` in member signatures, whose getDecl() keys the WrappedTemplateRef
+        // back to the matching WrappedTemplateParam.
+        "clang::TemplateDecl",
+        "clang::ClassTemplateDecl",
+        "clang::TemplateParameterList",
+        "clang::TemplateTypeParmDecl",
+        "clang::TemplateTypeParmType",
+        // NEW for brick 5 (enums): an enum-typed leaf reaches its EnumDecl through
+        // EnumType::getDecl() (the Type-side dyn-cast is bridged by TypeClass check —
+        // TypeBuilder); EnumDecl carries getIntegerType() (the underlying type,
+        // clang_getEnumDeclIntegerType's source) and its DeclContext holds the
+        // EnumConstantDecls. llvm::APSInt is EnumConstantDecl::getInitVal()'s carrier;
+        // only its OWN surface is needed (getExtValue — see TypeBuilder's value bridge),
+        // so the heavy llvm::APInt base stays unbound.
+        "clang::EnumDecl",
+        "clang::EnumConstantDecl",
+        "clang::EnumType",
+        "llvm::APSInt"
     )
     // Materialize the range returns the walk iterates. Brick 3 walks members through
     // DeclContext::decls() (source order, all member kinds) instead of methods(), so the

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -170,6 +170,23 @@ kplusplus {
         "clang::EnumConstantDecl",
         "llvm::APSInt"
     )
+    // FIXUPS (documented generator gaps, #44 brick 5): krapper's operator generation
+    // emits invalid Kotlin for four of llvm::APSInt's C++ operators —
+    //  * operator==(int64_t) / operator<(int64_t): the Long overloads of operators whose
+    //    APSInt overload already claimed the idiomatic name (equals/compareTo) are
+    //    emitted as `override fun _equals` / `override operator fun _compareTo`
+    //    (override-nothing + illegal operator name + pointer-vs-Long argument mixups);
+    //  * prefix operator++/operator--: emitted as `operator fun inc(): APSInt?` whose
+    //    NULLABLE return violates Kotlin's inc/dec operator convention.
+    // None of the four is needed here (the enum value bridge is APSInt::getExtValue(),
+    // TypeBuilder.buildEnumType); remove them by uniqueCName until krapper_gen learns
+    // mixed-argument operator overloads (generator gap recorded on #44).
+    fixup {
+        removeMethod("llvm_APSInt_op_eq__long")
+        removeMethod("llvm_APSInt_op_lt__long")
+        removeMethod("llvm_APSInt_op_increment")
+        removeMethod("llvm_APSInt_op_decrement")
+    }
     // Materialize the range returns the walk iterates. Brick 3 walks members through
     // DeclContext::decls() (source order, all member kinds) instead of methods(), so the
     // CXXMethodDecl vector instantiation is gone.

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -22,8 +22,13 @@ import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTemplate
+import com.monkopedia.krapper.generator.model.WrappedTypedef
+import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
+import com.monkopedia.krapper.generator.model.type.WrappedEnumType
 import com.monkopedia.krapper.generator.model.type.WrappedModifiedType
 import com.monkopedia.krapper.generator.model.type.WrappedPrefixedType
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
@@ -42,6 +47,14 @@ import kotlinx.serialization.json.Json
 // constant-array field, size_t/size_type preservation, typedef/`using` collapse, and a
 // template-typed field. Holder is defined in-fixture rather than using std::vector so the
 // case carries no std-header weight and the decoded shape is byte-deterministic.
+// Brick 5 grows it with template DECLARATIONS and enums: Holder gains a T field, a
+// T-returning const method, a `const T&` param and an in-template typedef (the dependent
+// WrappedTemplateRef surface); the enums cover unscoped-implicit (Color: computed
+// `unsigned int`), scoped-explicit (Mode: `unsigned char`), unscoped-explicit with a
+// SIGNED constant (Status: `long`, OK=-2) and class-nested (Palette::Flavor); Palette
+// exercises enum-typed fields, params and returns. Expected underlyings/values are pinned
+// against the libclang oracle (clang_getEnumDeclIntegerType/clang_getEnumConstantDeclValue
+// run on this exact fixture).
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -84,8 +97,17 @@ private val FIXTURE_HEADER = """
     typedef int MyInt;
     using Real = double;
 
+    enum Color { RED, GREEN = 5 };
+    enum class Mode : unsigned char { A, B };
+    enum Status : long { OK = -2 };
+
     template <typename T>
-    struct Holder { T value; };
+    struct Holder {
+        typedef T value_type;
+        T value;
+        T get() const;
+        void set(const T& v);
+    };
 
     struct Scene {
         typedef unsigned long size_type;
@@ -99,6 +121,17 @@ private val FIXTURE_HEADER = """
         int corners[4];
         Holder<Shape*> shapes;
     };
+
+    struct Palette {
+        enum Flavor { MILD, BOLD };
+        Color primary;
+        Mode mode;
+        Color cycle(Color from);
+        void setMode(Mode m);
+        Mode currentMode() const;
+        Status status() const;
+        Flavor flavor() const;
+    };
 """.trimIndent()
 
 private var failures = 0
@@ -108,10 +141,11 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
     println("  [${if (pass) "PASS" else "FAIL"}] $name${if (detail.isEmpty()) "" else " — $detail"}")
 }
 
-// #44 bricks 3+4: parse the fixture with Clang's C++ AST (on the kplusplus-generated
+// #44 bricks 3-5: parse the fixture with Clang's C++ AST (on the kplusplus-generated
 // libclang-cpp bindings), CONSTRUCT :krapper_model's WrappedTU mirroring ModelFactories'
 // full decl/class/member contract — with every type decoded STRUCTURALLY from the QualType
-// tree (TypeBuilder.kt) — and self-check each constructed shape against the model.
+// tree (TypeBuilder.kt), template declarations as WrappedTemplate, and enums as
+// WrappedEnumType leaves — and self-check each constructed shape against the model.
 @Suppress("UNUSED_PARAMETER")
 fun main(args: Array<String>): Unit = memScoped {
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
@@ -429,6 +463,148 @@ fun main(args: Array<String>): Unit = memScoped {
         shapes?.toString() == "Holder<Shape*>"
     )
 
+    // -- Brick 5: template DECLARATION construction (ModelFactories' ClassTemplate branch).
+    val holders = tu.children.filterIsInstance<WrappedTemplate>()
+    val holder = holders.find { it.name == "Holder" }
+    check(
+        "TU contains exactly one WrappedTemplate: Holder",
+        holders.size == 1 && holder != null,
+        "got ${holders.map { it.name }}"
+    )
+    check(
+        "no WrappedClass shadows Holder (implicit specialization never surfaced)",
+        tu.children.filterIsInstance<WrappedClass>().map { it.name }.sorted() ==
+            listOf("Palette", "Scene", "Shape"),
+        "got ${tu.children.filterIsInstance<WrappedClass>().map { it.name }}"
+    )
+    val tParam = holder?.templateArgs?.singleOrNull()
+    check(
+        "Holder has ONE type param 'T' carrying cpp:<canonical-id> identity",
+        tParam != null && tParam.name == "T" && tParam.usr.startsWith("cpp:"),
+        "got ${holder?.templateArgs}"
+    )
+    val valueField = holder?.fields?.singleOrNull()
+    check(
+        "field 'T value': WrappedTemplateRef keyed to the param's usr (substitution contract)",
+        valueField != null && valueField.name == "value" &&
+            (valueField.type as? WrappedTemplateRef)?.target == tParam?.usr,
+        "got $valueField"
+    )
+    val getMethod = holder?.methods?.find { it.name == "get" }
+    check(
+        "T get() const: BARE WrappedTemplateRef return (G8: no const wrap on by-value)",
+        getMethod != null && getMethod.isConst &&
+            (getMethod.returnType as? WrappedTemplateRef)?.target == tParam?.usr,
+        "got ${getMethod?.returnType}"
+    )
+    val setArg = holder?.methods?.find { it.name == "set" }?.args?.singleOrNull()?.type
+    val setBase = (setArg as? WrappedModifiedType)?.baseType as? WrappedPrefixedType
+    check(
+        "set(const T&): the dependent type nests structurally — &(const(WrappedTemplateRef))",
+        setArg is WrappedModifiedType && setArg.modifier == "&" &&
+            setBase?.modifier == "const" &&
+            (setBase?.baseType as? WrappedTemplateRef)?.target == tParam?.usr,
+        "got $setArg"
+    )
+    val valueTypedef = holder?.children?.filterIsInstance<WrappedTypedef>()?.singleOrNull()
+    check(
+        "in-template `typedef T value_type`: WrappedTypedef -> WrappedTemplateRef(param usr)",
+        valueTypedef != null && valueTypedef.name == "value_type" &&
+            (valueTypedef.targetType as? WrappedTemplateRef)?.target == tParam?.usr,
+        "got $valueTypedef"
+    )
+
+    // -- Brick 5: typedef ELEMENTS (map's CXCursor_TypedefDecl branch — and the absence of
+    // a CXCursor_TypeAliasDecl branch, so `using Real` produces NO element).
+    val tuTypedefs = tu.children.filterIsInstance<WrappedTypedef>()
+    check(
+        "TU typedef elements are size_t + MyInt only (`using Real` has no element)",
+        tuTypedefs.map { it.name } == listOf("size_t", "MyInt"),
+        "got ${tuTypedefs.map { it.name }}"
+    )
+    check(
+        "typedef targets run the reducer stack: size_t keeps the C-alias NAME, MyInt -> int",
+        tuTypedefs.find { it.name == "size_t" }?.targetType?.toString() == "size_t" &&
+            tuTypedefs.find { it.name == "MyInt" }?.targetType?.toString() == "int",
+        "got ${tuTypedefs.map { "${it.name}=${it.targetType}" }}"
+    )
+    val sizeTypedef = scene?.children?.filterIsInstance<WrappedTypedef>()?.singleOrNull()
+    check(
+        "Scene's member `typedef ... size_type` element normalizes to size_t",
+        sizeTypedef != null && sizeTypedef.name == "size_type" &&
+            sizeTypedef.targetType.toString() == "size_t",
+        "got $sizeTypedef"
+    )
+
+    // -- Brick 5: enum construction. NO top-level element (ModelFactories.map has no
+    // EnumDecl branch — `else -> null`); the payload rides on every enum-typed LEAF as
+    // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
+    // pinned against the libclang oracle for this fixture.
+    check(
+        "TU has exactly 8 children (the 3 enum DECLs contribute NO elements)",
+        tu.children.size == 8,
+        "got ${tu.children.size}"
+    )
+    val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }
+    check("TU contains class Palette", palette != null)
+    val paletteMethods = palette?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+    val paletteFields = palette?.children?.filterIsInstance<WrappedField>().orEmpty()
+    val primary = paletteFields.find { it.name == "primary" }?.type as? WrappedEnumType
+    check(
+        "Color field: WrappedEnumType 'Color' with the COMPUTED underlying 'unsigned int'",
+        primary != null && primary.cppName == "Color" && primary.toString() == "Color" &&
+            primary.underlying.toString() == "unsigned int",
+        "got $primary underlying=${primary?.underlying}"
+    )
+    check(
+        "Color constants mirror the oracle: RED=0, GREEN=5",
+        primary?.constants ==
+            listOf(WrappedEnumConstant("RED", 0L), WrappedEnumConstant("GREEN", 5L)),
+        "got ${primary?.constants}"
+    )
+    check(
+        "enum leaf flags: isEnum, NOT native (boundary casts), cType = the underlying",
+        primary != null && primary.isEnum && !primary.isNative &&
+            primary.cType == primary.underlying
+    )
+    val modeArg =
+        paletteMethods.find { it.name == "setMode" }?.args?.singleOrNull()?.type as? WrappedEnumType
+    check(
+        "scoped `enum class Mode : unsigned char` arg: EXPLICIT underlying + A=0, B=1",
+        modeArg != null && modeArg.cppName == "Mode" &&
+            modeArg.underlying.toString() == "unsigned char" &&
+            modeArg.constants ==
+            listOf(WrappedEnumConstant("A", 0L), WrappedEnumConstant("B", 1L)),
+        "got $modeArg underlying=${modeArg?.underlying} constants=${modeArg?.constants}"
+    )
+    val modeRet = paletteMethods.find { it.name == "currentMode" }?.returnType
+    check(
+        "Mode return on a const method: bare WrappedEnumType (G8: by-value, no const wrap)",
+        (modeRet as? WrappedEnumType)?.cppName == "Mode",
+        "got $modeRet"
+    )
+    val cycle = paletteMethods.find { it.name == "cycle" }
+    check(
+        "Color cycle(Color): the enum decodes as BOTH return and argument",
+        (cycle?.returnType as? WrappedEnumType)?.cppName == "Color" &&
+            (cycle?.args?.singleOrNull()?.type as? WrappedEnumType)?.cppName == "Color",
+        "got ret=${cycle?.returnType} args=${cycle?.args}"
+    )
+    val statusRet = paletteMethods.find { it.name == "status" }?.returnType as? WrappedEnumType
+    check(
+        "unscoped-explicit `enum Status : long`: underlying 'long', SIGNED value OK=-2",
+        statusRet != null && statusRet.underlying.toString() == "long" &&
+            statusRet.constants == listOf(WrappedEnumConstant("OK", -2L)),
+        "got $statusRet underlying=${statusRet?.underlying} constants=${statusRet?.constants}"
+    )
+    val flavorRet = paletteMethods.find { it.name == "flavor" }?.returnType as? WrappedEnumType
+    check(
+        "nested enum spells QUALIFIED: 'Palette::Flavor' (fullyQualified rule), MILD+BOLD",
+        flavorRet != null && flavorRet.cppName == "Palette::Flavor" &&
+            flavorRet.constants.map { it.name } == listOf("MILD", "BOLD"),
+        "got $flavorRet constants=${flavorRet?.constants}"
+    )
+
     check("JSON is non-empty", json.length > 2)
 
     if (failures > 0) fail("$failures self-check(s) failed")
@@ -450,6 +626,14 @@ private fun printElements(elements: List<WrappedElement>, indent: String) {
                 )
                 printElements(child.children, "$indent  ")
             }
+            is WrappedTemplate -> {
+                println(
+                    "${indent}template<${child.templateArgs.joinToString(", ") { it.name }}> " +
+                        "class ${child.name} (${child.children.size} children)"
+                )
+                printElements(child.children, "$indent  ")
+            }
+            is WrappedTypedef -> println("${indent}typedef ${child.name} = ${child.targetType}")
             is WrappedBase -> println("$indent: ${child.type} (public=${child.isPublic})")
             is WrappedField -> println("${indent}val $child")
             is WrappedMethod -> println(

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -66,17 +66,20 @@ private fun Decl.canonical(): Decl = (getCanonicalDecl() as? Decl) ?: this
 // identity string as the WrappedTemplateParam it refers to).
 internal fun Decl.cppUsr(): String = "cpp:${canonical().getID()}"
 
-// BRIDGE: kind-gated down-casts for the brick-5 Decl classes, in case CastTargets skips
-// their dyn-cast helpers (multi/unbound base lists — the TypedefType gap, see
-// TypeBuilder.asTypedefTypeOrNull). Each gate is EXACTLY the class's static `classof`
-// (`getKind() == ClassTemplate` / `== Typedef`), and each target's Decl is its
-// address-identical primary base, so the same-pointer re-view is the generated dyn-cast's
-// semantics. The Typedef gate is also load-bearing mirroring: ModelFactories.map only has
-// a CXCursor_TypedefDecl branch — a C++ `using` alias (CXCursor_TypeAliasDecl, here
-// Kind.TypeAlias) produces NO element on the libclang path, so it must not here either.
+// BRIDGE: the generated `Decl.asClassTemplateDecl()` dyn-cast is missing — the
+// ClassTemplateDecl -> RedeclarableTemplateDecl -> TemplateDecl chain doesn't survive
+// resolution (RedeclarableTemplateDecl is unbound), the same CastTargets gap as
+// TypedefType (TypeBuilder.asTypedefTypeOrNull; probe-confirmed on the brick-5
+// generation run). The gate is EXACTLY the class's static `classof`
+// (`getKind() == ClassTemplate`), and Decl is ClassTemplateDecl's address-identical
+// primary base, so the same-pointer re-view is the generated dyn-cast's semantics.
 private fun Decl.asClassTemplateDeclOrNull(): ClassTemplateDecl? =
     if (getKind() == Kind.ClassTemplate) ClassTemplateDecl(ptr, memScope) else null
 
+// Load-bearing mirroring, not a gap workaround: ModelFactories.map only has a
+// CXCursor_TypedefDecl branch — a C++ `using` alias (CXCursor_TypeAliasDecl, here
+// Kind.TypeAlias) produces NO element on the libclang path, so the kind gate must
+// exclude it (the generated asTypedefNameDecl() alone would catch both alias kinds).
 private fun Decl.asTypedefDeclOrNull(): TypedefNameDecl? =
     if (getKind() == Kind.Typedef) asTypedefNameDecl() else null
 

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -18,13 +18,20 @@ import clang.CXXConstructorDecl
 import clang.CXXDestructorDecl
 import clang.CXXMethodDecl
 import clang.CXXRecordDecl
+import clang.ClassTemplateDecl
 import clang.Decl
 import clang.DeclContext
 import clang.FieldDecl
 import clang.FunctionDecl
+import clang.NamedDecl
 import clang.NamespaceDecl
 import clang.ParmVarDecl
+import clang.TemplateDecl
+import clang.TemplateParameterList
 import clang.TranslationUnitDecl
+import clang.TypedefNameDecl
+import clang.decl.Kind
+import com.monkopedia.krapper.generator.model.ClassMetadata
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
@@ -35,10 +42,13 @@ import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.WrappedTemplate
+import com.monkopedia.krapper.generator.model.WrappedTemplateParam
+import com.monkopedia.krapper.generator.model.WrappedTypedef
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 
-// The C++-AST front-end's model construction (#44 bricks 2-4): walk a parsed Clang AST on
+// The C++-AST front-end's model construction (#44 bricks 2-5): walk a parsed Clang AST on
 // the kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output
 // model — the same WrappedTU shape the libclang-C front-end (ModelFactories.kt) produces.
 // Every construction rule cites the ModelFactories source it mirrors; types are decoded
@@ -52,7 +62,23 @@ import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 // Phase C's tree-diff treats identity fields as maskable and compares structure only.
 private fun Decl.canonical(): Decl = (getCanonicalDecl() as? Decl) ?: this
 
-private fun Decl.cppUsr(): String = "cpp:${canonical().getID()}"
+// Shared with TypeBuilder (the dependent-T WrappedTemplateRef must key on the SAME
+// identity string as the WrappedTemplateParam it refers to).
+internal fun Decl.cppUsr(): String = "cpp:${canonical().getID()}"
+
+// BRIDGE: kind-gated down-casts for the brick-5 Decl classes, in case CastTargets skips
+// their dyn-cast helpers (multi/unbound base lists — the TypedefType gap, see
+// TypeBuilder.asTypedefTypeOrNull). Each gate is EXACTLY the class's static `classof`
+// (`getKind() == ClassTemplate` / `== Typedef`), and each target's Decl is its
+// address-identical primary base, so the same-pointer re-view is the generated dyn-cast's
+// semantics. The Typedef gate is also load-bearing mirroring: ModelFactories.map only has
+// a CXCursor_TypedefDecl branch — a C++ `using` alias (CXCursor_TypeAliasDecl, here
+// Kind.TypeAlias) produces NO element on the libclang path, so it must not here either.
+private fun Decl.asClassTemplateDeclOrNull(): ClassTemplateDecl? =
+    if (getKind() == Kind.ClassTemplate) ClassTemplateDecl(ptr, memScope) else null
+
+private fun Decl.asTypedefDeclOrNull(): TypedefNameDecl? =
+    if (getKind() == Kind.Typedef) asTypedefNameDecl() else null
 
 // operator new/delete are never bound — neither as members nor as free functions
 // (ModelFactories.map's CXXMethod/FunctionDecl branch filters these names).
@@ -90,9 +116,35 @@ private class ModelBuilder {
                 addNamespace(namespace, parent)
                 continue
             }
+            // Brick 5: a `template <typename T> class` is a ClassTemplateDecl (NOT a
+            // CXXRecordDecl — the pattern record hangs off it), mirrored to
+            // WrappedTemplate (ModelFactories.map's CXCursor_ClassTemplate branch).
+            val classTemplate = decl.asClassTemplateDeclOrNull()
+            if (classTemplate != null) {
+                buildTemplate(classTemplate)?.let { parent.addChild(it) }
+                continue
+            }
+            // A ClassTemplateSpecializationDecl IS-A CXXRecordDecl, but libclang's cursor
+            // walk never surfaces IMPLICIT instantiations (they hang off the template's
+            // specialization set, not the TU) — guard so one is never mistaken for a
+            // plain record. Explicit specializations are brick-6+.
+            if (decl.getKind() == Kind.ClassTemplateSpecialization ||
+                decl.getKind() == Kind.ClassTemplatePartialSpecialization
+            ) {
+                continue
+            }
             val record = decl.asCXXRecordDecl()
             if (record != null) {
                 parent.addChild(buildClass(record))
+                continue
+            }
+            // Brick 5: a `typedef` is a WrappedTypedef element at ANY level — TU,
+            // namespace, class, template (ModelFactories.map's CXCursor_TypedefDecl
+            // branch is level-agnostic); a `using` alias produces no element (no
+            // CXCursor_TypeAliasDecl branch) — the Kind.Typedef gate mirrors that split.
+            val typedef = decl.asTypedefDeclOrNull()
+            if (typedef != null) {
+                buildTypedef(typedef)?.let { parent.addChild(it) }
                 continue
             }
             val function = decl.asFunctionDecl()
@@ -106,10 +158,63 @@ private class ModelBuilder {
                 // STATIC when the semantic parent is not a class).
                 parent.addChild(buildFunction(function))
             }
-            // brick-5+: typedef ELEMENTS, enums, global variables, class templates, and
-            // forward-declaration redecl-collapse for classes (elementLookup's other use).
-            // (Typedefs/aliases used as TYPES already resolve — TypeBuilder.kt.)
+            // An EnumDecl deliberately produces NO element: ModelFactories.map has no
+            // CXCursor_EnumDecl branch (`else -> return null`); the enum's payload —
+            // underlying type + constants — rides on every WrappedEnumType LEAF that
+            // references it (TypeBuilder.buildEnumType).
+            // brick-6+: global variables and forward-declaration redecl-collapse for
+            // classes (elementLookup's other use).
         }
+    }
+
+    // ModelFactories.map's CXCursor_TypedefDecl branch: WrappedTypedef(spelling, the
+    // reducer-stack target type). The libclang branch drops a typedef whose type can't be
+    // built (catch -> null); buildTypedefTargetType never throws (UNRESOLVABLE instead),
+    // so only a missing name drops here.
+    private fun buildTypedef(typedef: TypedefNameDecl): WrappedTypedef? {
+        val name = typedef.getNameAsString() ?: return null
+        return WrappedTypedef(name, buildTypedefTargetType(typedef))
+    }
+
+    // ModelFactories.map's CXCursor_ClassTemplate branch + the WrappedTemplate factory
+    // (WrappedTemplate(spelling)): the element is the template's bare name; its children
+    // are the WrappedTemplateParams followed by the templated record's bases + members
+    // built through the SAME paths as a plain class (mapAll's recursion reuses every
+    // member branch on template children; the metadata side-effects land on the
+    // WrappedTemplate via the shared `(parent as? WrappedTemplate)?.metadata` mirrors).
+    private fun buildTemplate(templateDecl: ClassTemplateDecl): WrappedTemplate? {
+        val record = templateDecl.getTemplatedDecl()
+            ?.let { CXXRecordDecl(it.ptr, templateDecl.memScope) } ?: return null
+        val name = record.asNamedDecl().getNameAsString() ?: error("template without a name")
+        val template = WrappedTemplate(name)
+        // getTemplateParameters() lives on TemplateDecl — ClassTemplateDecl's
+        // address-identical primary base chain, so the same-pointer re-view is exact.
+        // Each TYPE parameter mirrors ModelFactories' CXCursor_TemplateTypeParameter ->
+        // WrappedTemplateParam(spelling, usr); a non-type/template-template parameter has
+        // no map branch on the libclang path (`else -> null`) and is skipped the same way.
+        val params = TemplateDecl(templateDecl.ptr, templateDecl.memScope)
+            .getTemplateParameters()
+            ?.let { TemplateParameterList(it.ptr, templateDecl.memScope) }
+            ?: return null
+        for (i in 0u until params.size()) {
+            val param = params.getParam(i)
+                ?.let { NamedDecl(it.ptr, templateDecl.memScope) } ?: continue
+            if (param.getKind() != Kind.TemplateTypeParm) continue
+            template.addChild(
+                WrappedTemplateParam(
+                    param.getNameAsString() ?: error("template param without a name"),
+                    // The identity the dependent-T WrappedTemplateRef keys back to
+                    // (TypeBuilder's TemplateTypeParmType branch reads the same decl).
+                    Decl(param.ptr, templateDecl.memScope).cppUsr()
+                )
+            )
+        }
+        // The pattern record's bases/members go through the exact class construction
+        // path. hasDefinition guards a forward-declared template (definition-data reads).
+        if (record.hasDefinition()) {
+            addBasesAndMembers(record, template, template.metadata)
+        }
+        return template
     }
 
     private fun addNamespace(decl: NamespaceDecl, parent: WrappedElement) {
@@ -131,12 +236,24 @@ private class ModelBuilder {
         // hasDefinition() guards a forward-declared record, whose definition-data
         // accessors may not be read (libclang's isAbstract reads the definition too).
         val cls = WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
+        addBasesAndMembers(record, cls, cls.metadata)
+        return cls
+    }
+
+    // The shared class-body construction: bases + every member through the same branches,
+    // whether [parent] is a WrappedClass or a WrappedTemplate (mapAll's recursion makes no
+    // distinction either; ModelFactories' metadata side-effects mirror to both).
+    private fun addBasesAndMembers(
+        record: CXXRecordDecl,
+        parent: WrappedElement,
+        metadata: ClassMetadata
+    ) {
         for (base in record.bases()) {
             if (base == null) continue
             // ModelFactories.map's CXCursor_CXXBaseSpecifier branch: the base's type built
             // through the CXType factory (structural buildWrappedType here, brick 4),
             // isPublic from the access specifier, isVirtualBase from `virtual` inheritance.
-            cls.addChild(
+            parent.addChild(
                 WrappedBase(
                     buildWrappedType(base.getType()),
                     isPublic = base.getAccessSpecifier() == AccessSpecifier.AS_public,
@@ -149,12 +266,11 @@ private class ModelBuilder {
             // Implicit members (the injected class name, Sema-injected copy ctor/
             // assignment) are never visited by libclang's cursor walk; mirror that.
             if (decl.isImplicit()) continue
-            addMember(decl, cls)
+            addMember(decl, parent, metadata)
         }
-        return cls
     }
 
-    private fun addMember(decl: Decl, cls: WrappedClass) {
+    private fun addMember(decl: Decl, parent: WrappedElement, metadata: ClassMetadata) {
         val access = decl.getAccess()
         // ModelFactories.map's top filter: a private/protected member — or one libclang
         // marks CXAvailability_NotAvailable, which is how `= delete` surfaces (bridged
@@ -164,38 +280,46 @@ private class ModelBuilder {
             access == AccessSpecifier.AS_protected ||
             decl.asFunctionDecl()?.isDeleted() == true
         ) {
-            recordFilteredMember(decl, cls)
+            recordFilteredMember(decl, metadata)
             return
         }
         val constructor = decl.asCXXConstructorDecl()
         if (constructor != null) {
-            cls.addChild(buildConstructor(constructor))
+            parent.addChild(buildConstructor(constructor))
             return
         }
         val destructor = decl.asCXXDestructorDecl()
         if (destructor != null) {
-            cls.addChild(buildDestructor(destructor))
+            parent.addChild(buildDestructor(destructor))
             return
         }
         val method = decl.asCXXMethodDecl()
         if (method != null) {
             if (method.asNamedDecl().getNameAsString() in NEW_DELETE_OPERATORS) return
-            cls.addChild(buildMethod(method))
+            parent.addChild(buildMethod(method))
             return
         }
         val field = decl.asFieldDecl()
         if (field != null) {
-            addField(field, cls)
+            addField(field, parent, metadata)
+            return
         }
-        // Anything else (static data members, member typedefs, nested enums) falls
-        // through ModelFactories.map's `else -> return null` and is dropped; nested
-        // record decls are brick-5+ (together with the nested-in-class-template skip).
+        // Brick 5: a member `typedef` (incl. an in-template `typedef T value_type`) is a
+        // WrappedTypedef element, same map branch as the TU level; `using` aliases and
+        // member EnumDecls produce no element (see addContextDecls).
+        val typedef = decl.asTypedefDeclOrNull()
+        if (typedef != null) {
+            buildTypedef(typedef)?.let { parent.addChild(it) }
+            return
+        }
+        // Anything else (static data members, nested enums) falls through
+        // ModelFactories.map's `else -> return null` and is dropped; nested record decls
+        // are brick-6+ (together with the nested-in-class-template skip).
     }
 
     // Mirror of the metadata side-effects ModelFactories.map records for a member it
     // filters out (private/protected/deleted), keyed by the member's kind and name.
-    private fun recordFilteredMember(decl: Decl, cls: WrappedClass) {
-        val metadata = cls.metadata
+    private fun recordFilteredMember(decl: Decl, metadata: ClassMetadata) {
         val constructor = decl.asCXXConstructorDecl()
         if (constructor != null) {
             metadata.hasConstructor = true
@@ -232,7 +356,7 @@ private class ModelBuilder {
         }
     }
 
-    private fun addField(field: FieldDecl, cls: WrappedClass) {
+    private fun addField(field: FieldDecl, parent: WrappedElement, metadata: ClassMetadata) {
         // Anonymous data members (bitfield padding `int :3;`, anon union/struct members)
         // have a blank spelling and are dropped (ModelFactories' FieldDecl branch).
         val name = field.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() } ?: return
@@ -242,12 +366,12 @@ private class ModelBuilder {
         // constructor — recorded structurally because the implicit special members are
         // never emitted as decls (ModelFactories' FieldDecl branch, T-skip residuals).
         if (type.isReference || type.isConst) {
-            cls.metadata.hasDeletedCopyAssignment = true
+            metadata.hasDeletedCopyAssignment = true
         }
         if (type.isReference) {
-            cls.metadata.hasDeletedDefaultConstructor = true
+            metadata.hasDeletedDefaultConstructor = true
         }
-        cls.addChild(WrappedField(name, type))
+        parent.addChild(WrappedField(name, type))
     }
 
     // ModelFactories.map's CXCursor_Constructor branch: name from the spelling (the class

--- a/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.monkopedia.krapper.generator.model.ClassMetadata
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
@@ -22,6 +23,9 @@ import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.WrappedTemplate
+import com.monkopedia.krapper.generator.model.WrappedTemplateParam
+import com.monkopedia.krapper.generator.model.WrappedTypedef
 import kotlinx.serialization.Serializable
 
 // JSON projection of the parse-output model (#44 brick 2). The WrappedElement hierarchy
@@ -63,7 +67,26 @@ fun WrappedElement.serialized(): SerializedElement {
             "class",
             name = name,
             isAbstract = isAbstract,
-            metadata = metadataFlags().takeIf { it.isNotEmpty() },
+            metadata = metadata.flags().takeIf { it.isNotEmpty() },
+            children = kids
+        )
+        // Brick 5: template declarations + their params, and typedef elements.
+        is WrappedTemplate -> SerializedElement(
+            "template",
+            name = name,
+            metadata = metadata.flags().takeIf { it.isNotEmpty() },
+            children = kids
+        )
+        is WrappedTemplateParam -> SerializedElement(
+            "templateParam",
+            name = name,
+            usr = usr,
+            children = kids
+        )
+        is WrappedTypedef -> SerializedElement(
+            "typedef",
+            name = name,
+            type = targetType.toString(),
             children = kids
         )
         is WrappedNamespace -> SerializedElement("namespace", name = namespace, children = kids)
@@ -112,14 +135,14 @@ fun WrappedElement.serialized(): SerializedElement {
     }
 }
 
-private fun WrappedClass.metadataFlags(): List<String> = buildList {
-    if (metadata.hasHiddenNew) add("hasHiddenNew")
-    if (metadata.hasHiddenDelete) add("hasHiddenDelete")
-    if (metadata.hasConstructor) add("hasConstructor")
-    if (metadata.hasPrivateConstField) add("hasPrivateConstField")
-    if (metadata.hasDefaultConstructor) add("hasDefaultConstructor")
-    if (metadata.hasCopyConstructor) add("hasCopyConstructor")
-    if (metadata.hasDeletedCopyConstructor) add("hasDeletedCopyConstructor")
-    if (metadata.hasDeletedCopyAssignment) add("hasDeletedCopyAssignment")
-    if (metadata.hasDeletedDefaultConstructor) add("hasDeletedDefaultConstructor")
+private fun ClassMetadata.flags(): List<String> = buildList {
+    if (hasHiddenNew) add("hasHiddenNew")
+    if (hasHiddenDelete) add("hasHiddenDelete")
+    if (hasConstructor) add("hasConstructor")
+    if (hasPrivateConstField) add("hasPrivateConstField")
+    if (hasDefaultConstructor) add("hasDefaultConstructor")
+    if (hasCopyConstructor) add("hasCopyConstructor")
+    if (hasDeletedCopyConstructor) add("hasDeletedCopyConstructor")
+    if (hasDeletedCopyAssignment) add("hasDeletedCopyAssignment")
+    if (hasDeletedDefaultConstructor) add("hasDeletedDefaultConstructor")
 }

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -15,19 +15,12 @@
  */
 import clang.CXXRecordDecl
 import clang.Decl
-import clang.EnumConstantDecl
 import clang.EnumDecl
-import clang.EnumType
-import clang.NamedDecl
 import clang.QualType
-import clang.TagDecl
-import clang.TemplateTypeParmType
 import clang.Type
 import clang.TypedefNameDecl
 import clang.TypedefType
-import clang.decl.Kind
 import clang.templateArgument.ArgKind
-import clang.type.TypeClass
 import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
 import com.monkopedia.krapper.generator.model.type.WrappedEnumType
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
@@ -68,23 +61,6 @@ private fun Type.asRecord(): CXXRecordDecl? =
 private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companion) {
     if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
 }
-
-// BRIDGE: the same generated-helper gap as TypedefType above, for the brick-5 type
-// classes — EnumType (TypeBase.h: `class EnumType final : public TagType`, the same
-// TypeWithKeyword chain CastTargets can't resolve) and TemplateTypeParmType (TypeBase.h:
-// `: public Type, public llvm::FoldingSetNode`, the unbound second base). Each check is
-// EXACTLY what the class's static `classof` compiles to (`getTypeClass() == Enum` /
-// `== TemplateTypeParm`), and Type is the address-identical primary base of both, so the
-// kind check + same-pointer re-view is precisely the generated dyn-cast's semantics.
-private fun Type.asEnumTypeOrNull(): EnumType? =
-    if (getTypeClass() == TypeClass.Enum) EnumType(ptr, memScope) else null
-
-private fun Type.asTemplateTypeParmTypeOrNull(): TemplateTypeParmType? =
-    if (getTypeClass() == TypeClass.TemplateTypeParm) {
-        TemplateTypeParmType(ptr, memScope)
-    } else {
-        null
-    }
 
 // TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
 // after construction (a pointee's qualifier instead nests inside, via the recursion).
@@ -182,9 +158,9 @@ fun buildWrappedType(type: QualType): WrappedType {
     // front-end's identity is the same cpp:<canonical-id> convention (ModelBuilder.kt), so
     // the ref and the param agree. Read off the SUGARED type: the canonical
     // TemplateTypeParmType carries no decl (TypeBase.h: `assert(!TTPDecl == Canon.isNull())`).
-    ty.asTemplateTypeParmTypeOrNull()?.let { parm ->
+    ty.asTemplateTypeParmType()?.let { parm ->
         val decl = parm.getDecl() ?: return UNRESOLVABLE
-        return WrappedTemplateRef(Decl(decl.ptr, ty.memScope).cppUsr()).maybeConst(isConst)
+        return WrappedTemplateRef(decl.asDecl().cppUsr()).maybeConst(isConst)
     }
 
     // ---- createForType leaf dispatch (post-visit, i.e. against the canonical type) ----
@@ -215,8 +191,12 @@ fun buildWrappedType(type: QualType): WrappedType {
         // EnumConstantDecl children's (name, value) pairs. Scoped vs unscoped needs no
         // flag here: both spell their qualified name and both carry their underlying type
         // (the libclang path never consults clang_EnumDecl_isScoped in construction).
-        val enumDecl = canonTy.asEnumTypeOrNull()?.getDecl()
-            ?.let { EnumDecl(it.ptr, canonTy.memScope) } ?: return UNRESOLVABLE
+        // The decl is reached through Type::getAsTagDecl() + the generated asEnumDecl
+        // dyn-cast (clang::EnumType itself is unbindable — see build.gradle.kts); same
+        // decl clang_getTypeDeclaration reports.
+        val enumDecl = canonTy.getAsTagDecl()
+            ?.let { Decl(it.ptr, canonTy.memScope) }
+            ?.asEnumDecl() ?: return UNRESOLVABLE
         return buildEnumType(enumDecl).maybeConst(isConst)
     }
     // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,
@@ -262,18 +242,13 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
 
 // The WrappedEnumType payload for [enumDecl] (TypeFactories' CXCursor_EnumDecl branch).
 private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
-    val qualified = NamedDecl(enumDecl.ptr, enumDecl.memScope).getQualifiedNameAsString()
-        ?: return UNRESOLVABLE
+    val qualified = enumDecl.getQualifiedNameAsString() ?: return UNRESOLVABLE
     // Constants: the decl's EnumConstantDecl children as (spelling, value) pairs, a
-    // missing name dropping just that constant (TypeFactories' mapNotNull). The decl-side
-    // walk is the enum's DeclContext; TagDecl is EnumDecl's address-identical primary
-    // base, so the re-view + TagDecl's GENERATED asDeclContext() (a real pointer
-    // adjustment — DeclContext is a secondary base) reach it without new cast surface.
-    val constants = TagDecl(enumDecl.ptr, enumDecl.memScope).asDeclContext().decls()
-        .filterNotNull()
-        .filter { it.getKind() == Kind.EnumConstant }
+    // missing name dropping just that constant (TypeFactories' mapNotNull).
+    val constants = enumDecl.asDeclContext().decls()
+        .mapNotNull { it?.asEnumConstantDecl() }
         .mapNotNull { constant ->
-            val name = constant.asNamedDecl()?.getNameAsString() ?: return@mapNotNull null
+            val name = constant.getNameAsString() ?: return@mapNotNull null
             // VALUE BRIDGE (the documented extraction choice): libclang's
             // clang_getEnumConstantDeclValue is `getInitVal().getSExtValue()` (CIndex.cpp)
             // — a sign-extension through the constant's bit WIDTH even for an UNSIGNED
@@ -284,14 +259,8 @@ private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
             // constant below the top bit; for an unsigned constant WITH the top bit set
             // (e.g. `enum X : unsigned { M = 0x80000000 }`) libclang reports the
             // sign-mangled negative — a Phase C normalizer entry (mask: sign-extend the
-            // libclang value by the underlying width). EnumConstantDecl's Decl is the
-            // address-identical primary base (ValueDecl chain; Decl.h: `: public
-            // ValueDecl, public Mergeable<>, public APIntStorage`), so the kind-gated
-            // re-view mirrors its static classof (`getKind() == EnumConstant`).
-            val value = EnumConstantDecl(constant.ptr, constant.memScope)
-                .getInitVal()
-                .getExtValue()
-            WrappedEnumConstant(name, value)
+            // libclang value by the underlying width).
+            WrappedEnumConstant(name, constant.getInitVal().getExtValue())
         }
     return WrappedEnumType(
         qualified,

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 import clang.CXXRecordDecl
+import clang.Decl
+import clang.EnumConstantDecl
+import clang.EnumDecl
+import clang.EnumType
+import clang.NamedDecl
 import clang.QualType
+import clang.TagDecl
+import clang.TemplateTypeParmType
 import clang.Type
+import clang.TypedefNameDecl
 import clang.TypedefType
+import clang.decl.Kind
 import clang.templateArgument.ArgKind
+import clang.type.TypeClass
+import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
+import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.UNRESOLVABLE
@@ -55,6 +68,23 @@ private fun Type.asRecord(): CXXRecordDecl? =
 private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companion) {
     if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
 }
+
+// BRIDGE: the same generated-helper gap as TypedefType above, for the brick-5 type
+// classes — EnumType (TypeBase.h: `class EnumType final : public TagType`, the same
+// TypeWithKeyword chain CastTargets can't resolve) and TemplateTypeParmType (TypeBase.h:
+// `: public Type, public llvm::FoldingSetNode`, the unbound second base). Each check is
+// EXACTLY what the class's static `classof` compiles to (`getTypeClass() == Enum` /
+// `== TemplateTypeParm`), and Type is the address-identical primary base of both, so the
+// kind check + same-pointer re-view is precisely the generated dyn-cast's semantics.
+private fun Type.asEnumTypeOrNull(): EnumType? =
+    if (getTypeClass() == TypeClass.Enum) EnumType(ptr, memScope) else null
+
+private fun Type.asTemplateTypeParmTypeOrNull(): TemplateTypeParmType? =
+    if (getTypeClass() == TypeClass.TemplateTypeParm) {
+        TemplateTypeParmType(ptr, memScope)
+    } else {
+        null
+    }
 
 // TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
 // after construction (a pointee's qualifier instead nests inside, via the recursion).
@@ -142,31 +172,19 @@ fun buildWrappedType(type: QualType): WrappedType {
     }
 
     if (typedef != null) {
-        val name = typedef.getNameAsString() ?: ""
-        // sizeTypedefElement: `size_type`/`difference_type` ALWAYS normalize to the
-        // `size_t`/`ptrdiff_t` aliases (so they surface as platform.posix.<name>).
-        when (name) {
-            "size_type" -> return WrappedTypeReference("size_t").maybeConst(isConst)
-            "difference_type" -> return WrappedTypeReference("ptrdiff_t").maybeConst(isConst)
-        }
-        // cAliasTypedefElement: the C platform aliases are preserved as the alias NAME
-        // itself instead of collapsing to the underlying integer. (TypeFactories keys this
-        // on a CXCursor_TypedefDecl only; here it applies to either alias kind — a `using
-        // size_t = ...` is vanishingly rare and the name is the contract either way.)
-        if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name).maybeConst(isConst)
-        // referenceTypedefElement / pointerTypedefElement / assocTypedefElement reduce
-        // std-container member aliases whose underlyings are DEPENDENT trait expressions;
-        // those only arise inside template decls — brick 5's template-DECL construction.
-        //
-        // Everything else collapses to the underlying type, mirroring ResolverBuilderImpl
-        // .visit()'s CXCursor_TypedefDecl branch (recursive typedefDeclUnderlyingType walk).
-        // DIVERGENCE (Phase C normalizer entry): for a C++ `using` alias (TypeAliasDecl)
-        // the libclang path is ORDER-DEPENDENT — visit() leaves the alias un-collapsed
-        // (createForType's `else` then emits the alias NAME as a leaf) unless the
-        // underlying's canonical spelling was already in visit()'s seenNames cache, in
-        // which case the cached record type collapses it anyway. This front-end always
-        // collapses both alias kinds — deterministic, never the order-dependent name leaf.
-        return buildWrappedType(typedef.getUnderlyingType()).maybeConst(isConst)
+        return buildTypedefTargetType(typedef).maybeConst(isConst)
+    }
+
+    // Dependent template-parameter reference: createForType's CXCursor_TemplateTypeParameter
+    // branch (TypeFactories) -> WrappedTemplateRef(the param DECL's USR) — NOT the canonical
+    // `type-parameter-0-0` spelling and NOT the bare name `T`: the identity string ties the
+    // use back to the matching WrappedTemplateParam.usr so substitution can key on it. This
+    // front-end's identity is the same cpp:<canonical-id> convention (ModelBuilder.kt), so
+    // the ref and the param agree. Read off the SUGARED type: the canonical
+    // TemplateTypeParmType carries no decl (TypeBase.h: `assert(!TTPDecl == Canon.isNull())`).
+    ty.asTemplateTypeParmTypeOrNull()?.let { parm ->
+        val decl = parm.getDecl() ?: return UNRESOLVABLE
+        return WrappedTemplateRef(Decl(decl.ptr, ty.memScope).cppUsr()).maybeConst(isConst)
     }
 
     // ---- createForType leaf dispatch (post-visit, i.e. against the canonical type) ----
@@ -188,19 +206,98 @@ fun buildWrappedType(type: QualType): WrappedType {
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {
-        // DIVERGENCE (Phase C normalizer entry): an enum leaf is a WrappedEnumType on the
-        // libclang path (fullyQualified + underlying integer + the constants, createForType
-        // CXCursor_EnumDecl). The constants' VALUES need llvm::APSInt
-        // (EnumConstantDecl::getInitVal), which has no bound surface yet — so the
-        // structural decode emits the named reference WITHOUT the enum payload. brick-5:
-        // bind EnumType/EnumDecl + an APSInt value bridge and emit the real WrappedEnumType.
-        return WrappedTypeReference(spellingOf(canonical) ?: return UNRESOLVABLE)
-            .maybeConst(isConst)
+        // Enum leaf: createForType's CXCursor_EnumDecl branch (TypeFactories) — the
+        // dual-identity WrappedEnumType: cppName = the decl's fullyQualified (the
+        // "::"-joined semantic-parent chain ≡ getQualifiedNameAsString, so a nested enum
+        // spells `Palette::Flavor`), underlying = the decl's integer type
+        // (clang_getEnumDeclIntegerType ≡ EnumDecl::getIntegerType — the EXPLICIT
+        // underlying for a fixed enum, clang's COMPUTED one otherwise), constants = the
+        // EnumConstantDecl children's (name, value) pairs. Scoped vs unscoped needs no
+        // flag here: both spell their qualified name and both carry their underlying type
+        // (the libclang path never consults clang_EnumDecl_isScoped in construction).
+        val enumDecl = canonTy.asEnumTypeOrNull()?.getDecl()
+            ?.let { EnumDecl(it.ptr, canonTy.memScope) } ?: return UNRESOLVABLE
+        return buildEnumType(enumDecl).maybeConst(isConst)
     }
     // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,
     // spelled from the canonical type — the structural equivalent of visit()'s collapse.
     val spelling = spellingOf(canonical) ?: return UNRESOLVABLE
     return WrappedTypeReference(spelling).maybeConst(isConst)
+}
+
+/**
+ * The target type a typedef/alias DECL reduces to — shared between an alias used as a TYPE
+ * (buildWrappedType's TypedefType branch) and the WrappedTypedef ELEMENT
+ * (ModelBuilder.buildTypedef), both of which run the same TypeFactories reducer stack
+ * against the ORIGINAL declaration (createForType's originalDecl block):
+ *  - sizeTypedefElement: `size_type`/`difference_type` ALWAYS normalize to the
+ *    `size_t`/`ptrdiff_t` aliases (so they surface as platform.posix.<name>).
+ *  - cAliasTypedefElement: the C platform aliases are preserved as the alias NAME itself
+ *    instead of collapsing to the underlying integer. (TypeFactories keys these on a
+ *    CXCursor_TypedefDecl only; here they apply to either alias kind — a `using size_t =
+ *    ...` is vanishingly rare and the name is the contract either way.)
+ *  - referenceTypedefElement / pointerTypedefElement / assocTypedefElement reduce
+ *    std-container member aliases whose underlyings are DEPENDENT trait expressions; they
+ *    only fire on the std headers, so they ride with the std-scale brick (brick-6+).
+ *  - Everything else collapses to the underlying type, mirroring ResolverBuilderImpl
+ *    .visit()'s CXCursor_TypedefDecl branch (recursive typedefDeclUnderlyingType walk) —
+ *    which is also how an in-template `typedef T value_type` lands on the dependent
+ *    WrappedTemplateRef (the underlying TemplateTypeParmType branch above).
+ *    DIVERGENCE (Phase C normalizer entry): for a C++ `using` alias (TypeAliasDecl) the
+ *    libclang path is ORDER-DEPENDENT — visit() leaves the alias un-collapsed
+ *    (createForType's `else` then emits the alias NAME as a leaf) unless the underlying's
+ *    canonical spelling was already in visit()'s seenNames cache, in which case the cached
+ *    record type collapses it anyway. This front-end always collapses both alias kinds —
+ *    deterministic, never the order-dependent name leaf.
+ */
+fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
+    val name = typedef.getNameAsString() ?: ""
+    when (name) {
+        "size_type" -> return WrappedTypeReference("size_t")
+        "difference_type" -> return WrappedTypeReference("ptrdiff_t")
+    }
+    if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name)
+    return buildWrappedType(typedef.getUnderlyingType())
+}
+
+// The WrappedEnumType payload for [enumDecl] (TypeFactories' CXCursor_EnumDecl branch).
+private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
+    val qualified = NamedDecl(enumDecl.ptr, enumDecl.memScope).getQualifiedNameAsString()
+        ?: return UNRESOLVABLE
+    // Constants: the decl's EnumConstantDecl children as (spelling, value) pairs, a
+    // missing name dropping just that constant (TypeFactories' mapNotNull). The decl-side
+    // walk is the enum's DeclContext; TagDecl is EnumDecl's address-identical primary
+    // base, so the re-view + TagDecl's GENERATED asDeclContext() (a real pointer
+    // adjustment — DeclContext is a secondary base) reach it without new cast surface.
+    val constants = TagDecl(enumDecl.ptr, enumDecl.memScope).asDeclContext().decls()
+        .filterNotNull()
+        .filter { it.getKind() == Kind.EnumConstant }
+        .mapNotNull { constant ->
+            val name = constant.asNamedDecl()?.getNameAsString() ?: return@mapNotNull null
+            // VALUE BRIDGE (the documented extraction choice): libclang's
+            // clang_getEnumConstantDeclValue is `getInitVal().getSExtValue()` (CIndex.cpp)
+            // — a sign-extension through the constant's bit WIDTH even for an UNSIGNED
+            // enum. Here the value reads through llvm::APSInt::getExtValue() — the
+            // smallest bindable surface (APSInt's OWN method; getSExtValue lives on the
+            // unbound llvm::APInt base) and sign-CORRECT: it extends by the constant's
+            // real signedness. The two agree for every signed constant and every unsigned
+            // constant below the top bit; for an unsigned constant WITH the top bit set
+            // (e.g. `enum X : unsigned { M = 0x80000000 }`) libclang reports the
+            // sign-mangled negative — a Phase C normalizer entry (mask: sign-extend the
+            // libclang value by the underlying width). EnumConstantDecl's Decl is the
+            // address-identical primary base (ValueDecl chain; Decl.h: `: public
+            // ValueDecl, public Mergeable<>, public APIntStorage`), so the kind-gated
+            // re-view mirrors its static classof (`getKind() == EnumConstant`).
+            val value = EnumConstantDecl(constant.ptr, constant.memScope)
+                .getInitVal()
+                .getExtValue()
+            WrappedEnumConstant(name, value)
+        }
+    return WrappedEnumType(
+        qualified,
+        buildWrappedType(enumDecl.getIntegerType()),
+        constants
+    )
 }
 
 // Leaf spelling, mirroring createForType's const-stripped spelling read (the constness is


### PR DESCRIPTION
Phase B brick 5 of #44: template DECLARATIONS and enum construction in `cppfrontend/`, mirrored rule-for-rule against the libclang-C front-end with in-code citations.

## Template declarations (ModelFactories' ClassTemplate branch)
- A `ClassTemplateDecl` becomes the model's `WrappedTemplate(spelling)` (ModelFactories `CXCursor_ClassTemplate` + the `WrappedTemplate` factory); its TYPE params become `WrappedTemplateParam(spelling, usr)` (`CXCursor_TemplateTypeParameter`); non-type/template-template params are skipped exactly as map's `else -> null` does.
- The pattern record's bases + members run through the SAME shared class-construction path (`addBasesAndMembers`, refactored to take `parent: WrappedElement` + `ClassMetadata` so WrappedClass and WrappedTemplate share every member branch and metadata side-effect — the decl-side equivalent of mapAll's recursion + the `(parent as? WrappedTemplate)?.metadata` mirrors).
- **Dependent-type shape (the question the brick asked):** the libclang path produces `WrappedTemplateRef(param decl's USR)` — NOT `type-parameter-0-0`, NOT the bare name `T` (TypeFactories' `CXCursor_TemplateTypeParameter` branch). Mirrored: a `TemplateTypeParmType` decodes to `WrappedTemplateRef("cpp:<canonical-id>")`, read off the SUGARED type (the canonical one carries no decl — `assert(!TTPDecl == Canon.isNull())`), keyed to the SAME identity as the matching `WrappedTemplateParam.usr` so substitution can match. Self-checked: field/return/`const T&` arg/member typedef all key to the param's usr.
- Typedef ELEMENTS (map's `CXCursor_TypedefDecl` branch, level-agnostic): `WrappedTypedef(name, reducer-stack target)` at TU/class/template level; a `using` alias produces NO element (no `CXCursor_TypeAliasDecl` branch) — mirrored with a `Kind.Typedef` gate. The target runs the shared `buildTypedefTargetType` (size_type/difference_type/C-alias rules + underlying collapse), so Scene's `size_type` element lands on `size_t` exactly like `sizeTypedefElement`.

## Enums (TypeFactories' CXCursor_EnumDecl branch)
- An `EnumDecl` itself produces **NO element** — faithful to ModelFactories.map, which has no EnumDecl branch (`else -> return null`). The payload rides on every enum-typed LEAF as `WrappedEnumType(cppName, underlying, constants)`:
  - `cppName` = qualified name (`fullyQualified` ≡ `getQualifiedNameAsString`; nested enum spells `Palette::Flavor`),
  - `underlying` = `EnumDecl::getIntegerType()` (≡ `clang_getEnumDeclIntegerType`): explicit for fixed enums, clang's computed type otherwise,
  - `constants` = the `EnumConstantDecl` children's (name, value) pairs.
- **Value-extraction choice (documented):** libclang uses `getInitVal().getSExtValue()` (CIndex.cpp). Here the value reads `llvm::APSInt::getExtValue()` — the smallest bindable surface (APSInt's OWN method; `getSExtValue` lives on the unbound `llvm::APInt` base) and sign-correct. Identical for every signed constant and unsigned constants below the top bit; for an unsigned constant WITH the top bit set libclang reports a sign-mangled negative — recorded as a Phase C normalizer entry (mask: sign-extend the libclang value by the underlying width).
- Expected underlyings/values were pinned against a real libclang oracle run on the exact fixture (`clang_getEnumDeclIntegerType` + `clang_getEnumConstantDeclValue`): Color → `unsigned int`, RED=0/GREEN=5; Mode → `unsigned char`, A=0/B=1; Status → `long`, OK=-2; Palette::Flavor → `unsigned int`, qualified spelling.

## only() / bridges / fixups
- only() += `clang::TemplateDecl`, `ClassTemplateDecl`, `TemplateParameterList`, `TemplateTypeParmDecl`, `TemplateTypeParmType`, `EnumDecl`, `EnumConstantDecl`, `llvm::APSInt`.
- `clang::EnumType` is deliberately NOT bound (generator gap #1): it declares no own ctors (only `using TagType::TagType`), so nothing marks `hasConstructor` and krapper synthesizes an ill-formed `new clang::EnumType()` default-construct wrapper. The enum decl is reached through the already-bound `Type::getAsTagDecl()` + generated `Decl.asEnumDecl()` instead.
- Fixups (generator gap #2, v8-precedent `removeMethod`): four of `llvm::APSInt`'s operators emit invalid Kotlin — `operator==(int64_t)`/`operator<(int64_t)` (collision-suffixed `override fun _equals`/`operator fun _compareTo`) and prefix `++`/`--` (nullable `inc()`/`dec()` returns). All four removed by uniqueCName; none is needed by the value bridge. Both gaps documented in build.gradle.kts for a krapper_gen follow-up.
- Probe-confirmed cast surface: `Decl.asEnumDecl/asEnumConstantDecl/asTemplateTypeParmDecl` and `Type.asTemplateTypeParmType` ARE generated (used directly); `Decl.asClassTemplateDecl` is NOT (`RedeclarableTemplateDecl` unbound breaks the chain) — bridged with the TypedefType-pattern kind-gated re-view; `getTemplateParameters()` reached by TemplateDecl re-view (primary-base, address-identical).

## Fixture + self-checks: 52 → 72 (ALL PASS)
```
template<T> class Holder (5 children)
  typedef value_type = template<cpp:2974>
  val value: template<cpp:2974>
  fun get(): template<cpp:2974> [METHOD] const
  fun set(v: const template<cpp:2974>&): void [METHOD]
class Palette (7 members)
  val primary: Color
  fun cycle(from: Color): Color [METHOD]
  fun currentMode(): Mode [METHOD] const
  fun status(): Status [METHOD] const
  fun flavor(): Palette::Flavor [METHOD] const
```
Serialized template (the params/members/dependent-type shape):
```json
{ "kind": "template", "name": "Holder", "children": [
    { "kind": "templateParam", "name": "T", "usr": "cpp:2974" },
    { "kind": "typedef", "name": "value_type", "type": "template<cpp:2974>" },
    { "kind": "field", "name": "value", "type": "template<cpp:2974>" },
    { "kind": "method", "name": "get", "returnType": "template<cpp:2974>", "methodType": "METHOD", "isConst": true },
    { "kind": "method", "name": "set", "returnType": "void", "children": [
        { "kind": "arg", "name": "v", "type": "const template<cpp:2974>&", "usr": "cpp:3158" } ] } ] }
```
Key self-check lines:
```
[PASS] TU contains exactly one WrappedTemplate: Holder
[PASS] no WrappedClass shadows Holder (implicit specialization never surfaced) — got [Shape, Scene, Palette]
[PASS] field 'T value': WrappedTemplateRef keyed to the param's usr (substitution contract)
[PASS] in-template `typedef T value_type`: WrappedTypedef -> WrappedTemplateRef(param usr)
[PASS] TU has exactly 8 children (the 3 enum DECLs contribute NO elements)
[PASS] Color constants mirror the oracle: RED=0, GREEN=5
[PASS] scoped `enum class Mode : unsigned char` arg: EXPLICIT underlying + A=0, B=1
[PASS] unscoped-explicit `enum Status : long`: underlying 'long', SIGNED value OK=-2
[PASS] nested enum spells QUALIFIED: 'Palette::Flavor' (fullyQualified rule), MILD+BOLD
cppfrontend: ALL SELF-CHECKS PASSED
```

## Verify
- Default unaffected: `./gradlew :krapper_gen:nativeTest :krapper_model:build :krapper_gen:ktlintCheck` — BUILD SUCCESSFUL (`:krapper_model` untouched, no featuregen gate needed).
- Gated: `./gradlew :cppfrontend:runReleaseExecutableKlinker -PenableClang` — BUILD SUCCESSFUL, 72/72 self-checks PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
