### PR TITLE
cppfrontend: function-pointer typedefs + default-argument capture (#44 brick 6)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -171,9 +171,9 @@ kplusplus {
         "llvm::APSInt",
         // NEW for brick 6 (function-pointer typedefs): a typedef over a pointer-to-
         // function-proto decodes through FunctionProtoType — getNumParams()/getParamType()
-        // — with getReturnType() on FunctionType (its address-identical primary base;
-        // FunctionProtoType's own base list has the same multi-base CastTargets gap as
-        // TypedefType, bridged by classof + re-view in TypeBuilder).
+        // + the inherited getReturnType(). Unlike TypedefType, this chain survives
+        // resolution intact (the generated Type.asFunctionProtoType() dyn-cast is real);
+        // FunctionType is bound as the bridging base.
         "clang::FunctionType",
         "clang::FunctionProtoType",
         // NEW for brick 6 (default arguments): the smallest bindable surface for the

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -168,7 +168,19 @@ kplusplus {
         // so the heavy llvm::APInt base stays unbound.
         "clang::EnumDecl",
         "clang::EnumConstantDecl",
-        "llvm::APSInt"
+        "llvm::APSInt",
+        // NEW for brick 6 (function-pointer typedefs): a typedef over a pointer-to-
+        // function-proto decodes through FunctionProtoType — getNumParams()/getParamType()
+        // — with getReturnType() on FunctionType (its address-identical primary base;
+        // FunctionProtoType's own base list has the same multi-base CastTargets gap as
+        // TypedefType, bridged by classof + re-view in TypeBuilder).
+        "clang::FunctionType",
+        "clang::FunctionProtoType",
+        // NEW for brick 6 (default arguments): the smallest bindable surface for the
+        // default's source text — an inline helper in the slice header wrapping
+        // Lexer::getSourceText over ParmVarDecl::getDefaultArgRange() (see clang_slice.h
+        // for why Lexer/SourceManager/LangOptions aren't bound wholesale yet).
+        "kppbridge::defaultArgText"
     )
     // FIXUPS (documented generator gaps, #44 brick 5): krapper's operator generation
     // emits invalid Kotlin for four of llvm::APSInt's C++ operators —

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -1,3 +1,11 @@
+// Include guard required: the generated wrapper includes this header both directly and
+// through each KrapperForce_*.h (via differently-spelled relative paths, so #pragma once
+// can't be trusted to dedupe) — without a guard the inline kppbridge helper below is a
+// same-TU redefinition. The clang/LLVM includes self-guard, which is why the header
+// didn't need one before it carried a definition of its own.
+#ifndef KPLUSPLUS_CPPFRONTEND_CLANG_SLICE_H_
+#define KPLUSPLUS_CPPFRONTEND_CLANG_SLICE_H_
+
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/DeclTemplate.h>
@@ -38,3 +46,5 @@ inline std::string defaultArgText(clang::ParmVarDecl *parm) {
         .str();
 }
 } // namespace kppbridge
+
+#endif // KPLUSPLUS_CPPFRONTEND_CLANG_SLICE_H_

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -4,3 +4,37 @@
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Type.h>
 #include <clang/Tooling/Tooling.h>
+#include <clang/Lex/Lexer.h>
+
+#include <string>
+
+// brick-6 BRIDGE (#44, documented): the libclang front-end recovers a parameter default's
+// VALUE as source text — ModelFactories.defaultValue tokenizes the default sub-expression
+// cursor's extent and joins the spellings. The C++-AST equivalent is
+// Lexer::getSourceText(CharSourceRange::getTokenRange(ParmVarDecl::getDefaultArgRange())),
+// but binding that call through only() drags in clang::Lexer + clang::SourceManager +
+// clang::LangOptions — three very large classes bound for ONE static call, each a likely
+// source of APSInt-style operator/bitfield fixup discovery (a gap to close iteratively,
+// recorded on #44). Until that surface is proven, this inline helper is the smallest
+// bridge: one bound free function from an already-bound ParmVarDecl* to the exact text.
+// hasDefaultArg() itself IS bound and stays the authoritative flag (ModelBuilder).
+//
+// String contract vs libclang: tokenSpellings().joinToString("") concatenates tokens with
+// NO separator, while getSourceText preserves the source's inter-token whitespace. The
+// two agree for every default written without internal spaces ("5", "-1", "RED",
+// "nullptr", "Palette()"); a spaced default (`= Palette ( )`) diverges — Phase C
+// normalizer entry: compare default values with whitespace stripped.
+namespace kppbridge {
+inline std::string defaultArgText(clang::ParmVarDecl *parm) {
+    if (!parm || !parm->hasDefaultArg()) {
+        return std::string();
+    }
+    // getDefaultArgRange (not getDefaultArg()->getSourceRange()): it self-guards the
+    // unparsed/uninstantiated default states getDefaultArg() asserts on.
+    const clang::ASTContext &ctx = parm->getASTContext();
+    return clang::Lexer::getSourceText(
+               clang::CharSourceRange::getTokenRange(parm->getDefaultArgRange()),
+               ctx.getSourceManager(), ctx.getLangOpts())
+        .str();
+}
+} // namespace kppbridge

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -26,6 +26,7 @@ import com.monkopedia.krapper.generator.model.WrappedTemplate
 import com.monkopedia.krapper.generator.model.WrappedTypedef
 import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
 import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
 import com.monkopedia.krapper.generator.model.type.WrappedModifiedType
 import com.monkopedia.krapper.generator.model.type.WrappedPrefixedType
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
@@ -55,6 +56,14 @@ import kotlinx.serialization.json.Json
 // exercises enum-typed fields, params and returns. Expected underlyings/values are pinned
 // against the libclang oracle (clang_getEnumDeclIntegerType/clang_getEnumConstantDeclValue
 // run on this exact fixture).
+// Brick 6 grows it with FUNCTION-POINTER TYPEDEFS and DEFAULT ARGUMENTS: Callback (the
+// CB-cfnptr shape), Notifier (the `void*` Mode-1 context slot), ShapeVisitor (a
+// class-pointer param failing the stage-1 compat gate — CB-cfnptr-richsig), HandlerFn (a
+// `using` fn-ptr alias, which gets NO WrappedFunctionPointer on the libclang path) and the
+// namespace-scoped geo::Predicate (the cName/cppName qualification split); Dispatcher
+// carries the five default-arg value shapes (int literal, negative, enum constant,
+// nullptr, constructed) plus a multi-default trailing run (configure). Expected
+// defaultValue strings are the libclang token-join contract (ModelFactories.defaultValue).
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -91,11 +100,18 @@ private val FIXTURE_HEADER = """
     namespace geo {
         bool enabled();
         Circle* makeCircle();
+        typedef bool (*Predicate)(double);
+        void scan(Predicate p);
     }
 
     typedef unsigned long size_t;
     typedef int MyInt;
     using Real = double;
+
+    typedef void (*Callback)(int);
+    typedef int (*Notifier)(void*, int);
+    typedef void (*ShapeVisitor)(Shape*);
+    using HandlerFn = int (*)(double);
 
     enum Color { RED, GREEN = 5 };
     enum class Mode : unsigned char { A, B };
@@ -131,6 +147,20 @@ private val FIXTURE_HEADER = """
         Mode currentMode() const;
         Status status() const;
         Flavor flavor() const;
+    };
+
+    struct Dispatcher {
+        void onEvent(Callback cb);
+        Callback current() const;
+        void notifyAll(Notifier n);
+        void visit(ShapeVisitor v);
+        void onHandle(HandlerFn h);
+        void resize(int size = 5);
+        void shift(int delta = -1);
+        void paint(Color tint = RED);
+        void fill(Shape* target = nullptr);
+        void blend(Palette p = Palette());
+        void configure(int a, int b = 1, Shape* c = nullptr);
     };
 """.trimIndent()
 
@@ -248,8 +278,8 @@ fun main(args: Array<String>): Unit = memScoped {
     val geo = geos.firstOrNull()
     val geoFns = geo?.children?.filterIsInstance<WrappedMethod>().orEmpty()
     check(
-        "geo holds add+enabled+makeCircle (from both blocks) as STATIC free functions",
-        geoFns.map { it.name }.sorted() == listOf("add", "enabled", "makeCircle") &&
+        "geo holds add+enabled+makeCircle+scan (from both blocks) as STATIC free functions",
+        geoFns.map { it.name }.sorted() == listOf("add", "enabled", "makeCircle", "scan") &&
             geoFns.all { it.methodType == MethodType.STATIC },
         "got $geoFns"
     )
@@ -474,7 +504,7 @@ fun main(args: Array<String>): Unit = memScoped {
     check(
         "no WrappedClass shadows Holder (implicit specialization never surfaced)",
         tu.children.filterIsInstance<WrappedClass>().map { it.name }.sorted() ==
-            listOf("Palette", "Scene", "Shape"),
+            listOf("Dispatcher", "Palette", "Scene", "Shape"),
         "got ${tu.children.filterIsInstance<WrappedClass>().map { it.name }}"
     )
     val tParam = holder?.templateArgs?.singleOrNull()
@@ -518,8 +548,9 @@ fun main(args: Array<String>): Unit = memScoped {
     // a CXCursor_TypeAliasDecl branch, so `using Real` produces NO element).
     val tuTypedefs = tu.children.filterIsInstance<WrappedTypedef>()
     check(
-        "TU typedef elements are size_t + MyInt only (`using Real` has no element)",
-        tuTypedefs.map { it.name } == listOf("size_t", "MyInt"),
+        "TU typedef elements: the `typedef`s only (`using Real`/`using HandlerFn` have none)",
+        tuTypedefs.map { it.name } ==
+            listOf("size_t", "MyInt", "Callback", "Notifier", "ShapeVisitor"),
         "got ${tuTypedefs.map { it.name }}"
     )
     check(
@@ -541,8 +572,8 @@ fun main(args: Array<String>): Unit = memScoped {
     // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
     // pinned against the libclang oracle for this fixture.
     check(
-        "TU has exactly 8 children (the 3 enum DECLs contribute NO elements)",
-        tu.children.size == 8,
+        "TU has exactly 12 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
+        tu.children.size == 12,
         "got ${tu.children.size}"
     )
     val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }
@@ -603,6 +634,161 @@ fun main(args: Array<String>): Unit = memScoped {
         flavorRet != null && flavorRet.cppName == "Palette::Flavor" &&
             flavorRet.constants.map { it.name } == listOf("MILD", "BOLD"),
         "got $flavorRet constants=${flavorRet?.constants}"
+    )
+
+    // -- Brick 6: function-pointer typedefs (TypeFactories.functionPointerTypedefElement).
+    val dispatcher = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Dispatcher" }
+    check("TU contains class Dispatcher", dispatcher != null)
+    val dMethods = dispatcher?.children?.filterIsInstance<WrappedMethod>().orEmpty()
+
+    // The typedef ELEMENT's target runs the same reducer (WrappedTypedef(spelling,
+    // WrappedType(cursor.type)) on the libclang path hits functionPointerTypedefElement).
+    val callback = tuTypedefs.find { it.name == "Callback" }?.targetType
+    check(
+        "Callback typedef: WrappedFunctionPointer, cName == cppName == 'Callback' (global)",
+        (callback as? WrappedFunctionPointer)
+            ?.let { it.cName == "Callback" && it.cppName == "Callback" } == true,
+        "got $callback"
+    )
+    check(
+        "Callback proto decodes structurally: return 'void', args ['int']",
+        (callback as? WrappedFunctionPointer)?.let {
+            it.returnType.toString() == "void" &&
+                it.argTypes.map { a -> a.toString() } == listOf("int")
+        } == true,
+        "got ret=${(callback as? WrappedFunctionPointer)?.returnType} " +
+            "args=${(callback as? WrappedFunctionPointer)?.argTypes}"
+    )
+    // The same construction through the TYPE-USE path (a param spelled `Callback`).
+    val onEventArg = dMethods.find { it.name == "onEvent" }?.args?.singleOrNull()?.type
+    check(
+        "onEvent(Callback) param: WrappedFunctionPointer, NATIVE, spells the typedef name",
+        onEventArg is WrappedFunctionPointer && onEventArg.isNative &&
+            onEventArg.toString() == "Callback",
+        "got $onEventArg"
+    )
+    // A fn-ptr is neither pointer nor reference in the model, so the G8 const-method rule
+    // never wraps it — the const method returns the BARE WrappedFunctionPointer
+    // (CB-cfnptr-ret: the returned pointer is directly invokable).
+    val currentFnRet = dMethods.find { it.name == "current" }?.returnType
+    check(
+        "Callback current() const: bare WrappedFunctionPointer return (no const wrap)",
+        (currentFnRet as? WrappedFunctionPointer)?.cName == "Callback",
+        "got $currentFnRet"
+    )
+    // The `void*` Mode-1 context slot is compatible (isPointer && pointed.isVoid).
+    val notifier = tuTypedefs.find { it.name == "Notifier" }?.targetType
+    check(
+        "Notifier(void*, int): the void* context slot passes the stage-1 compat gate",
+        (notifier as? WrappedFunctionPointer)?.let {
+            it.returnType.toString() == "int" &&
+                it.argTypes.map { a -> a.toString() } == listOf("void*", "int")
+        } == true,
+        "got $notifier"
+    )
+    // CB-cfnptr-richsig: a class-pointer param (`Shape*` != `void*`) fails the gate, so
+    // the typedef falls through to the normal alias collapse — the bare fn-ptr leaf
+    // (createForType's `else -> WrappedType(spelling)` after visit()'s collapse).
+    val visitor = tuTypedefs.find { it.name == "ShapeVisitor" }?.targetType
+    check(
+        "ShapeVisitor (Shape* param) fails the gate: NOT a WrappedFunctionPointer",
+        visitor !is WrappedFunctionPointer && visitor?.toString() == "void (*)(Shape *)",
+        "got $visitor"
+    )
+    val visitArg = dMethods.find { it.name == "visit" }?.args?.singleOrNull()?.type
+    check(
+        "visit(ShapeVisitor) param falls through the same way",
+        visitArg !is WrappedFunctionPointer && visitArg?.toString() == "void (*)(Shape *)",
+        "got $visitArg"
+    )
+    // A `using` fn-ptr alias NEVER becomes a WrappedFunctionPointer
+    // (functionPointerTypedefElement is keyed on CXCursor_TypedefDecl only); here it
+    // collapses to the bare fn-ptr leaf (the documented using-collapse divergence — the
+    // libclang path leaves the order-dependent alias-name leaf instead).
+    val onHandleArg = dMethods.find { it.name == "onHandle" }?.args?.singleOrNull()?.type
+    check(
+        "`using HandlerFn` param: NOT a WrappedFunctionPointer (typedef-only contract)",
+        onHandleArg !is WrappedFunctionPointer && onHandleArg?.toString() == "int (*)(double)",
+        "got $onHandleArg"
+    )
+    // A namespace-scoped typedef splits the names: cName stays UNqualified (the extern-"C"
+    // redeclaration), cppName is qualified (the wrapper spelling; fullyQualified rule).
+    val predicate = geo?.children?.filterIsInstance<WrappedTypedef>()
+        ?.find { it.name == "Predicate" }?.targetType
+    check(
+        "geo::Predicate: cName 'Predicate', cppName 'geo::Predicate', bool(double) decoded",
+        (predicate as? WrappedFunctionPointer)?.let {
+            it.cName == "Predicate" && it.cppName == "geo::Predicate" &&
+                it.returnType.toString() == "bool" &&
+                it.argTypes.map { a -> a.toString() } == listOf("double")
+        } == true,
+        "got $predicate"
+    )
+    val scanArg = geoFns.find { it.name == "scan" }?.args?.singleOrNull()?.type
+    check(
+        "scan(Predicate) param carries the same WrappedFunctionPointer",
+        (scanArg as? WrappedFunctionPointer)?.cppName == "geo::Predicate",
+        "got $scanArg"
+    )
+
+    // -- Brick 6: default arguments. hasDefault = ParmVarDecl::hasDefaultArg() (the
+    // first-class fact replacing the libclang cursor-children token heuristic);
+    // defaultValue strings are pinned to the libclang token-join contract
+    // (ModelFactories.defaultValue: tokenSpellings().joinToString("")).
+    fun argOf(method: String, index: Int = 0) =
+        dMethods.find { it.name == method }?.args?.getOrNull(index)
+    check(
+        "int literal default: resize(int size = 5) -> hasDefault, \"5\"",
+        argOf("resize")?.let { it.hasDefault && it.defaultValue == "5" } == true,
+        "got ${argOf("resize")?.hasDefault}/${argOf("resize")?.defaultValue}"
+    )
+    check(
+        "negative default: shift(int delta = -1) -> \"-1\" (unary expr tokens joined)",
+        argOf("shift")?.let { it.hasDefault && it.defaultValue == "-1" } == true,
+        "got ${argOf("shift")?.defaultValue}"
+    )
+    check(
+        "enum-constant default: paint(Color tint = RED) -> \"RED\" on a WrappedEnumType arg",
+        argOf("paint")?.let {
+            it.hasDefault && it.defaultValue == "RED" && it.type is WrappedEnumType
+        } == true,
+        "got ${argOf("paint")?.defaultValue} type=${argOf("paint")?.type}"
+    )
+    check(
+        "nullptr default: fill(Shape* target = nullptr) -> \"nullptr\"",
+        argOf("fill")?.let { it.hasDefault && it.defaultValue == "nullptr" } == true,
+        "got ${argOf("fill")?.defaultValue}"
+    )
+    check(
+        "constructed default: blend(Palette p = Palette()) -> the call spelling \"Palette()\"",
+        argOf("blend")?.let { it.hasDefault && it.defaultValue == "Palette()" } == true,
+        "got ${argOf("blend")?.defaultValue}"
+    )
+    // Multi-default trailing run: the shape the trailing-defaulted-omit shortcut
+    // (ModelResolution's isOmittableDefault subList check) consumes — a REQUIRED head arg
+    // plus omittable defaulted tails. isOmittableDefault is model-side; it holds here
+    // because hasDefaultArg() never fires on the false-default type shapes (#36/#41).
+    check(
+        "configure(int a, int b = 1, Shape* c = nullptr): a required, b \"1\", c \"nullptr\"",
+        argOf("configure", 0)?.let { !it.hasDefault && it.defaultValue == null } == true &&
+            argOf("configure", 1)?.let { it.hasDefault && it.defaultValue == "1" } == true &&
+            argOf("configure", 2)
+            ?.let { it.hasDefault && it.defaultValue == "nullptr" } == true,
+        "got ${dMethods.find { it.name == "configure" }?.args
+            ?.map { "${it.hasDefault}/${it.defaultValue}" }}"
+    )
+    check(
+        "configure's defaulted tail is omittable (the resolution shortcut's contract)",
+        dMethods.find { it.name == "configure" }?.args?.drop(1)
+            ?.all { it.isOmittableDefault } == true
+    )
+    // No false positives anywhere else: every pre-brick-6 arg stays non-defaulted
+    // (hasDefaultArg() is authoritative; nothing to repair on this path).
+    check(
+        "no spurious hasDefault on non-defaulted args (freeFunction, describe, onEvent)",
+        freeFn?.args?.none { it.hasDefault } == true &&
+            sceneMethods.find { it.name == "describe" }?.args?.none { it.hasDefault } == true &&
+            dMethods.find { it.name == "onEvent" }?.args?.none { it.hasDefault } == true
     )
 
     check("JSON is non-empty", json.length > 2)

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -47,6 +47,7 @@ import com.monkopedia.krapper.generator.model.WrappedTemplateParam
 import com.monkopedia.krapper.generator.model.WrappedTypedef
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+import kppbridge.defaultArgText
 
 // The C++-AST front-end's model construction (#44 bricks 2-5): walk a parsed Clang AST on
 // the kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output
@@ -437,12 +438,30 @@ private class ModelBuilder {
             // positional name the libclang front-end synthesizes.
             val name = param.asNamedDecl().getNameAsString()?.takeIf { it.isNotBlank() }
                 ?: "_arg_$i"
-            // brick-5+: hasDefault/defaultValue (ParmVarDecl::hasDefaultArg + source text).
+            // Brick 6: hasDefault on the libclang path is the cursor-children HEURISTIC
+            // (ModelFactories.defaultExpr: the param's last child cursor that isn't a
+            // Type/Template/NamespaceRef) — the token-scrape the self-bootstrap deletes.
+            // ParmVarDecl::hasDefaultArg() is the first-class Sema-computed fact: it can
+            // never fire for an integer token inside the param's TYPE (an array bound, a
+            // non-type template arg, a function_ref signature), so the model-side
+            // typeCarriesFalseDefault repairs (#36/#41) have nothing to repair on this
+            // path — the deletion payoff. defaultValue mirrors ModelFactories.defaultValue
+            // (the default sub-expression's token spellings joined with "", blank -> null)
+            // through the kppbridge source-text read (see clang_slice.h for the contract
+            // + the whitespace normalizer entry).
+            val hasDefault = param.hasDefaultArg()
+            val defaultValue = if (hasDefault) {
+                with(param.memScope) { defaultArgText(param) }?.takeIf { it.isNotBlank() }
+            } else {
+                null
+            }
             addChild(
                 WrappedArgument(
                     name,
                     buildWrappedType(param.asValueDecl().getType()),
-                    param.asDecl().cppUsr()
+                    param.asDecl().cppUsr(),
+                    hasDefault,
+                    defaultValue
                 )
             )
         }

--- a/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelSerializer.kt
@@ -50,6 +50,11 @@ data class SerializedElement(
     // Constructor payload (WrappedConstructor).
     val isCopyConstructor: Boolean? = null,
     val isDefaultConstructor: Boolean? = null,
+    // Default-argument payload (WrappedArgument, brick 6): the resolution contract is the
+    // pair — hasDefault feeds the trailing-defaulted-omit shortcut (isOmittableDefault),
+    // defaultValue feeds KotlinWriter's Kotlin-default mapping.
+    val hasDefault: Boolean? = null,
+    val defaultValue: String? = null,
     // The names of the ClassMetadata flags set on a class (parse-time records about
     // FILTERED members — deleted/non-public ctors, hidden new/delete, const fields).
     val metadata: List<String>? = null,
@@ -114,6 +119,8 @@ fun WrappedElement.serialized(): SerializedElement {
             name = name,
             type = type.toString(),
             usr = usr,
+            hasDefault = hasDefault.takeIf { it },
+            defaultValue = defaultValue,
             children = kids
         )
         is WrappedField -> SerializedElement(

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -16,8 +16,6 @@
 import clang.CXXRecordDecl
 import clang.Decl
 import clang.EnumDecl
-import clang.FunctionProtoType
-import clang.FunctionType
 import clang.QualType
 import clang.Type
 import clang.TypedefNameDecl
@@ -65,21 +63,6 @@ private fun Type.asRecord(): CXXRecordDecl? =
 private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companion) {
     if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
 }
-
-// BRIDGE: same CastTargets gap family as TypedefType above — FunctionProtoType's base list
-// (TypeBase.h: `class FunctionProtoType final : public FunctionType, public
-// llvm::FoldingSetNode, private llvm::TrailingObjects<...>`) doesn't survive resolution,
-// so neither the generated dyn-cast nor FunctionType's inherited methods materialize.
-// classof + the same-pointer re-view; Type is the address-identical primary base through
-// FunctionType (single non-virtual chain), exactly the generated dyn-cast's semantics.
-private fun Type.asFunctionProtoTypeOrNull(): FunctionProtoType? =
-    with(FunctionProtoType.Companion) {
-        if (memScope.classof(this@asFunctionProtoTypeOrNull)) {
-            FunctionProtoType(ptr, memScope)
-        } else {
-            null
-        }
-    }
 
 // TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
 // after construction (a pointee's qualifier instead nests inside, via the recursion).
@@ -291,10 +274,10 @@ private fun functionPointerTypedef(typedef: TypedefNameDecl): WrappedType? {
     val underlying = typedef.getUnderlyingType()
     val ty = underlying.typePtr() ?: return null
     if (!ty.isPointerType()) return null
-    val proto = ty.getPointeeType().typePtr()?.asFunctionProtoTypeOrNull() ?: return null
-    // getReturnType lives on FunctionType — the address-identical primary base, reached by
-    // the same re-view as the dyn-cast bridge (the gap keeps it off FunctionProtoType).
-    val returnType = buildWrappedType(FunctionType(proto.ptr, proto.memScope).getReturnType())
+    // Unlike TypedefType (the bridge above), FunctionProtoType's full chain DOES survive
+    // resolution — the generated dyn-cast and inherited getReturnType() are both real.
+    val proto = ty.getPointeeType().typePtr()?.asFunctionProtoType() ?: return null
+    val returnType = buildWrappedType(proto.getReturnType())
     val argTypes = (0u until proto.getNumParams()).map { buildWrappedType(proto.getParamType(it)) }
     if (!returnType.isCFunctionPointerCompatible) return null
     if (argTypes.any { !it.isCFunctionPointerCompatible }) return null

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -16,13 +16,17 @@
 import clang.CXXRecordDecl
 import clang.Decl
 import clang.EnumDecl
+import clang.FunctionProtoType
+import clang.FunctionType
 import clang.QualType
 import clang.Type
 import clang.TypedefNameDecl
 import clang.TypedefType
+import clang.decl.Kind
 import clang.templateArgument.ArgKind
 import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
 import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedType
@@ -62,6 +66,21 @@ private fun Type.asTypedefTypeOrNull(): TypedefType? = with(TypedefType.Companio
     if (memScope.classof(this@asTypedefTypeOrNull)) TypedefType(ptr, memScope) else null
 }
 
+// BRIDGE: same CastTargets gap family as TypedefType above — FunctionProtoType's base list
+// (TypeBase.h: `class FunctionProtoType final : public FunctionType, public
+// llvm::FoldingSetNode, private llvm::TrailingObjects<...>`) doesn't survive resolution,
+// so neither the generated dyn-cast nor FunctionType's inherited methods materialize.
+// classof + the same-pointer re-view; Type is the address-identical primary base through
+// FunctionType (single non-virtual chain), exactly the generated dyn-cast's semantics.
+private fun Type.asFunctionProtoTypeOrNull(): FunctionProtoType? =
+    with(FunctionProtoType.Companion) {
+        if (memScope.classof(this@asFunctionProtoTypeOrNull)) {
+            FunctionProtoType(ptr, memScope)
+        } else {
+            null
+        }
+    }
+
 // TypeFactories.maybeConst: every shape gets the type's OWN const qualifier re-applied
 // after construction (a pointee's qualifier instead nests inside, via the recursion).
 private fun WrappedType.maybeConst(isConst: Boolean): WrappedType =
@@ -98,10 +117,9 @@ fun buildWrappedType(type: QualType): WrappedType {
             // A BARE function-pointer (`int (*)(int)`) spells with a trailing ')' on the
             // libclang path, so it falls through every special case to createForType's
             // `else -> WrappedType(spelling)` — an opaque named leaf. Mirror that shape.
-            // brick-6: the rich WrappedFunctionPointer only exists for a TYPEDEF over a
-            // fn-pointer (functionPointerTypedefElement) — that reducer needs the
-            // underlying-proto decode + the isCFunctionPointerCompatible recursion, so it
-            // (and a fn-pointer fixture case) is deferred to the callbacks brick.
+            // The rich WrappedFunctionPointer only exists for a `typedef` over a
+            // fn-pointer — functionPointerTypedef below (brick 6), reached through the
+            // alias branch; a `using` fn-ptr alias collapses to THIS leaf.
             val spelling = type.getAsString()?.trim() ?: return UNRESOLVABLE
             return WrappedTypeReference(spelling).maybeConst(isConst)
         }
@@ -210,6 +228,9 @@ fun buildWrappedType(type: QualType): WrappedType {
  * (buildWrappedType's TypedefType branch) and the WrappedTypedef ELEMENT
  * (ModelBuilder.buildTypedef), both of which run the same TypeFactories reducer stack
  * against the ORIGINAL declaration (createForType's originalDecl block):
+ *  - functionPointerTypedefElement (brick 6): a `typedef` over a pointer-to-function-proto
+ *    becomes a WrappedFunctionPointer (see [functionPointerTypedef]) — first in the stack,
+ *    `typedef`-only.
  *  - sizeTypedefElement: `size_type`/`difference_type` ALWAYS normalize to the
  *    `size_t`/`ptrdiff_t` aliases (so they surface as platform.posix.<name>).
  *  - cAliasTypedefElement: the C platform aliases are preserved as the alias NAME itself
@@ -231,6 +252,13 @@ fun buildWrappedType(type: QualType): WrappedType {
  *    deterministic, never the order-dependent name leaf.
  */
 fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
+    // functionPointerTypedefElement runs FIRST in createForType's originalDecl reducer
+    // stack, and is keyed on CXCursor_TypedefDecl ONLY — a `using` fn-ptr alias
+    // (TypeAliasDecl) has no branch on the libclang path, so the Kind.Typedef gate
+    // mirrors that split (it collapses to the bare fn-ptr leaf below instead).
+    if (typedef.asDecl().getKind() == Kind.Typedef) {
+        functionPointerTypedef(typedef)?.let { return it }
+    }
     val name = typedef.getNameAsString() ?: ""
     when (name) {
         "size_type" -> return WrappedTypeReference("size_t")
@@ -238,6 +266,41 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
     }
     if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name)
     return buildWrappedType(typedef.getUnderlyingType())
+}
+
+// TypeFactories.isCFunctionPointerCompatible, verbatim: only plain native scalars, void,
+// and `void*` (the Mode-1 context slot) can be re-declared verbatim in the C interop
+// header; enums/refs/class types name C++ types not in scope there.
+private val WrappedType.isCFunctionPointerCompatible: Boolean
+    get() = isVoid || (isNative && !isString) || (isPointer && pointed.isVoid)
+
+/**
+ * TypeFactories.functionPointerTypedefElement (#44 brick 6): a `typedef` over a
+ * pointer-to-function-proto (`typedef int (*IntTransform)(int);` — the CB-cfnptr shape) is
+ * captured as a [WrappedFunctionPointer]: cName = the UNqualified typedef spelling (the
+ * extern-"C" redeclaration name), cppName = the FULLY-QUALIFIED spelling
+ * (`getQualifiedNameAsString` ≡ the cursor `fullyQualified` walk; identical to cName for a
+ * global typedef), return + every param decoded structurally through [buildWrappedType].
+ * The STAGE-1 GATE is mirrored verbatim: only signatures whose return AND every param is
+ * [isCFunctionPointerCompatible] qualify — a richer proto (CB-cfnptr-richsig, e.g. a
+ * class-pointer param) returns null and falls through to the normal alias collapse, same
+ * as the libclang path. The pointer/proto shape checks mirror the CXType_Pointer +
+ * CXType_FunctionProto kind tests on typedefDeclUnderlyingType.
+ */
+private fun functionPointerTypedef(typedef: TypedefNameDecl): WrappedType? {
+    val underlying = typedef.getUnderlyingType()
+    val ty = underlying.typePtr() ?: return null
+    if (!ty.isPointerType()) return null
+    val proto = ty.getPointeeType().typePtr()?.asFunctionProtoTypeOrNull() ?: return null
+    // getReturnType lives on FunctionType — the address-identical primary base, reached by
+    // the same re-view as the dyn-cast bridge (the gap keeps it off FunctionProtoType).
+    val returnType = buildWrappedType(FunctionType(proto.ptr, proto.memScope).getReturnType())
+    val argTypes = (0u until proto.getNumParams()).map { buildWrappedType(proto.getParamType(it)) }
+    if (!returnType.isCFunctionPointerCompatible) return null
+    if (argTypes.any { !it.isCFunctionPointerCompatible }) return null
+    val cName = typedef.getNameAsString() ?: return null
+    val cppName = typedef.getQualifiedNameAsString()?.takeIf { it.isNotEmpty() } ?: cName
+    return WrappedFunctionPointer(cName, returnType, argTypes, cppName)
 }
 
 // The WrappedEnumType payload for [enumDecl] (TypeFactories' CXCursor_EnumDecl branch).

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -102,8 +102,12 @@ fun buildWrappedType(type: QualType): WrappedType {
             // `else -> WrappedType(spelling)` — an opaque named leaf. Mirror that shape.
             // The rich WrappedFunctionPointer only exists for a `typedef` over a
             // fn-pointer — functionPointerTypedef below (brick 6), reached through the
-            // alias branch; a `using` fn-ptr alias collapses to THIS leaf.
-            val spelling = type.getAsString()?.trim() ?: return UNRESOLVABLE
+            // alias branch; a `using` fn-ptr alias collapses to THIS leaf. The same
+            // PrintingPolicy bridge as spellingOf applies (a `bool` anywhere in the proto
+            // prints as C's `_Bool` under the default policy; `_Bool` is not otherwise a
+            // valid token in a C++ type spelling, so the blanket replace is safe).
+            val spelling = type.getAsString()?.trim()?.replace("_Bool", "bool")
+                ?: return UNRESOLVABLE
             return WrappedTypeReference(spelling).maybeConst(isConst)
         }
         if (ty.isPointerType()) {
@@ -274,9 +278,14 @@ private fun functionPointerTypedef(typedef: TypedefNameDecl): WrappedType? {
     val underlying = typedef.getUnderlyingType()
     val ty = underlying.typePtr() ?: return null
     if (!ty.isPointerType()) return null
-    // Unlike TypedefType (the bridge above), FunctionProtoType's full chain DOES survive
-    // resolution — the generated dyn-cast and inherited getReturnType() are both real.
-    val proto = ty.getPointeeType().typePtr()?.asFunctionProtoType() ?: return null
+    // The pointee is read CANONICALLY: the declarator `void (*Callback)(int)` wraps its
+    // proto in ParenType sugar (Pointer -> Paren -> FunctionProto), which libclang's
+    // clang_getPointeeType desugars before the CXType_FunctionProto kind test fires —
+    // getCanonicalType is the decl-side desugar. Unlike TypedefType (the bridge above),
+    // FunctionProtoType's chain survives resolution — the generated dyn-cast and the
+    // inherited getReturnType() are both real.
+    val proto = ty.getPointeeType().getCanonicalType().typePtr()
+        ?.asFunctionProtoType() ?: return null
     val returnType = buildWrappedType(proto.getReturnType())
     val argTypes = (0u until proto.getNumParams()).map { buildWrappedType(proto.getParamType(it)) }
     if (!returnType.isCFunctionPointerCompatible) return null


### PR DESCRIPTION
Phase B brick 6 of #44: the two deferred pieces that make the libclang TOKEN-SCRAPE deletable — function-pointer typedefs and default-argument capture in `cppfrontend/`.

## Function-pointer typedefs
`TypeBuilder.functionPointerTypedef` mirrors `TypeFactories.functionPointerTypedefElement` rule-for-rule:
- **typedef-only**: keyed on `Kind.Typedef` exactly as the libclang reducer is keyed on `CXCursor_TypedefDecl`; a `using` fn-ptr alias never becomes a `WrappedFunctionPointer` on either path (it collapses to the bare proto leaf here — the already-documented using-collapse divergence).
- pointer→proto shape checks = the `CXType_Pointer` + `CXType_FunctionProto` kind tests; the pointee is read **canonically** because the declarator nests `ParenType` sugar (`Pointer -> Paren -> FunctionProto`) that `clang_getPointeeType` desugars on the libclang side.
- stage-1 gate `isCFunctionPointerCompatible` copied verbatim (`isVoid || (isNative && !isString) || (isPointer && pointed.isVoid)`): Notifier's `void*` Mode-1 context slot passes, ShapeVisitor's `Shape*` fails and falls through to the alias collapse (CB-cfnptr-richsig).
- `cName` = unqualified spelling, `cppName` = `getQualifiedNameAsString()` (≡ the cursor `fullyQualified` walk) — exercised by namespace-scoped `geo::Predicate`.
- `FunctionProtoType` needed **no** classof bridge: unlike `TypedefType`, its chain survives resolution (generated `Type.asFunctionProtoType()` + inherited `getReturnType()` are real).

## Default arguments — the token-scrape deletion payoff
- `hasDefault` is now `ParmVarDecl::hasDefaultArg()` — the first-class Sema-computed fact, replacing `ModelFactories.defaultExpr`'s cursor-children heuristic. **The #36/#41 false-default workarounds are confirmed unnecessary on this path**: `hasDefaultArg()` cannot fire for an integer token inside the param's TYPE (array bound, non-type template arg, `function_ref` signature), so the model-side `typeCarriesFalseDefault` repairs have nothing to repair once the libclang front-end goes.
- `defaultValue` mirrors `ModelFactories.defaultValue`'s token-join contract via a **documented bridge**: an inline `kppbridge::defaultArgText` helper in the slice header wrapping `Lexer::getSourceText(CharSourceRange::getTokenRange(getDefaultArgRange()))`. Binding `clang::Lexer` + `clang::SourceManager` + `clang::LangOptions` wholesale (three very large classes for one static call, each a likely APSInt-style fixup-discovery source) is recorded as a deferred surface on #44.
- Verified value shapes, asserted equal to the libclang token-join strings: `5`, `-1`, `RED`, `nullptr`, `Palette()`, plus the multi-default trailing run `configure(int a, int b = 1, Shape* c = nullptr)` (whose tail satisfies `isOmittableDefault` — the trailing-defaulted-omit shortcut's contract).

## Phase C normalizer entries
- **default-value whitespace**: libclang joins tokens with `""`; `getSourceText` preserves inter-token whitespace. Identical for compactly-written defaults; a spaced default (`= Palette ( )`) diverges — normalize by stripping whitespace.
- **`_Bool` on the bare fn-ptr leaf**: extended the existing PrintingPolicy bridge (`spellingOf`) to fn-ptr proto spellings (`bool (*)(double)`), same divergence family as brick 3.
- (existing) using-alias collapse stays deterministic here vs order-dependent on the libclang path.

## Surface / fixture delta
- only(): + `clang::FunctionType`, `clang::FunctionProtoType`, `kppbridge::defaultArgText`. No new fixups. Slice header gains an include guard (the generated wrapper includes it through differently-spelled paths; the inline helper made that a same-TU redefinition).
- Fixture: + `Callback`/`Notifier`/`ShapeVisitor`/`HandlerFn`/`geo::Predicate` + `Dispatcher` (5 default shapes + trailing run); serializer carries `hasDefault`/`defaultValue` per arg.
- Self-checks: 72 → 91.
- `:krapper_model` untouched (WrappedFunctionPointer/WrappedArgument already carry the fields) — no featuregen gate needed.

## Verify
- Default unaffected: `:krapper_gen:nativeTest :krapper_model:build :krapper_gen:ktlintCheck` — BUILD SUCCESSFUL.
- Gated: `:cppfrontend:runReleaseExecutableKlinker -PenableClang` — BUILD SUCCESSFUL, **ALL 91 SELF-CHECKS PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
