### PR TITLE
THE GOLDEN TEST: both front-ends parse the same fixture, structural tree-diff under a cited normalizer ledger (#44 brick 7)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -205,3 +205,52 @@ kplusplus {
     instantiate("std::vector<clang::Decl*>")
     instantiate("std::vector<clang::CXXBaseSpecifier*>")
 }
+
+// ---- #44 brick 7: THE GOLDEN TEST (Phase B exit criterion / Phase C entry) ----
+// Run BOTH front-ends over the same fixture and structurally compare their parse-output
+// models through the canonical SerializedElement projection (:krapper_model):
+//   goldenEmit    — this front-end writes the fixture + its cpp.json (the fixture is
+//                   emitted by the binary itself so both parses consume identical bytes);
+//   goldenDump    — the REAL krapper_gen kexe parses that fixture with
+//                   --dumpParsedModel (parse-only mode, Parsing.kt) -> libclang.json;
+//   goldenCompare — the tree-diff under the documented normalizer ledger
+//                   (GoldenCompare.kt), non-zero exit on unexplained divergence.
+// This is the automated regression lock for the front-end rewrite (issue #8's spirit):
+// any construction drift between ModelFactories/TypeFactories and ModelBuilder/TypeBuilder
+// fails this task. Gated with the module (-PenableClang).
+val goldenDir = layout.buildDirectory.dir("golden").get().asFile
+val cppfrontendBinary = layout.buildDirectory.file("bin/klinker/cppfrontendRelease").get().asFile
+val krapperGenKexe = rootProject.layout.projectDirectory
+    .file("krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe").asFile
+
+val goldenEmit = tasks.register<Exec>("goldenEmit") {
+    dependsOn("linkReleaseExecutableKlinker")
+    doFirst { goldenDir.mkdirs() }
+    commandLine(cppfrontendBinary.absolutePath, "--golden-emit", goldenDir.absolutePath)
+}
+
+val goldenDump = tasks.register<Exec>("goldenDump") {
+    dependsOn(goldenEmit, ":krapper_gen:linkReleaseExecutableNative")
+    commandLine(
+        krapperGenKexe.absolutePath,
+        "-h",
+        File(goldenDir, "fixture.h").absolutePath,
+        // cppfrontend's buildASTFromCode parses fixture.cc under the clang driver default;
+        // the fixture's surface is identical under c++14..c++20, pin c++17 to match the
+        // module's own binding standard.
+        "--std",
+        "c++17",
+        "--dumpParsedModel",
+        File(goldenDir, "libclang.json").absolutePath
+    )
+}
+
+tasks.register<Exec>("goldenCompare") {
+    dependsOn(goldenDump)
+    commandLine(
+        cppfrontendBinary.absolutePath,
+        "--golden-compare",
+        File(goldenDir, "cpp.json").absolutePath,
+        File(goldenDir, "libclang.json").absolutePath
+    )
+}

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -219,7 +219,8 @@ kplusplus {
 // any construction drift between ModelFactories/TypeFactories and ModelBuilder/TypeBuilder
 // fails this task. Gated with the module (-PenableClang).
 val goldenDir = layout.buildDirectory.dir("golden").get().asFile
-val cppfrontendBinary = layout.buildDirectory.file("bin/klinker/cppfrontendRelease").get().asFile
+val cppfrontendBinary = layout.buildDirectory
+    .file("bin/klinker/cppfrontendRelease/cppfrontend").get().asFile
 val krapperGenKexe = rootProject.layout.projectDirectory
     .file("krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe").asFile
 

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -480,13 +480,14 @@ fun main(args: Array<String>): Unit = memScoped {
         "got $setScaleArg"
     )
 
-    // Constant array: the libclang leaf spelling is "int [4]" (krapper_gen TestData
-    // golden "int [5]"); WrappedTypeReference parses element/extent off that name.
+    // Constant array: LLVM-22's libclang leaf spelling is "int[4]" — no space (pinned by
+    // the golden compare; the old TestData golden "int [5]" predates the TypePrinter
+    // change). WrappedTypeReference parses element/extent off that name either way.
     val corners = sceneFields.find { it.name == "corners" }?.type
     check(
-        "int[4] field: WrappedTypeReference(\"int [4]\") with isArray, size 4, element int",
+        "int[4] field: WrappedTypeReference(\"int[4]\") with isArray, size 4, element int",
         (corners as? WrappedTypeReference)?.let {
-            it.name == "int [4]" && it.isArray && it.arraySize == 4 && it.arrayType.name == "int"
+            it.name == "int[4]" && it.isArray && it.arraySize == 4 && it.arrayType.name == "int"
         } == true,
         "got $corners"
     )

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -24,6 +24,7 @@ import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
 import com.monkopedia.krapper.generator.model.WrappedTemplate
 import com.monkopedia.krapper.generator.model.WrappedTypedef
+import com.monkopedia.krapper.generator.model.serialized
 import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
 import com.monkopedia.krapper.generator.model.type.WrappedEnumType
 import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
@@ -176,8 +177,17 @@ private fun check(name: String, pass: Boolean, detail: String = "") {
 // full decl/class/member contract — with every type decoded STRUCTURALLY from the QualType
 // tree (TypeBuilder.kt), template declarations as WrappedTemplate, and enums as
 // WrappedEnumType leaves — and self-check each constructed shape against the model.
-@Suppress("UNUSED_PARAMETER")
+// Brick 7 adds two golden-test modes (see GoldenCompare.kt):
+//  --golden-emit <dir>: write the fixture (for krapper_gen to parse the SAME bytes) and
+//    this front-end's canonical-DTO JSON, then exit (self-checks stay on the default run).
+//  --golden-compare <cpp.json> <libclang.json>: structurally diff the two front-ends'
+//    dumps under the documented normalizer ledger; non-zero exit on divergence.
 fun main(args: Array<String>): Unit = memScoped {
+    if (args.firstOrNull() == "--golden-compare") {
+        val cpp = args.getOrNull(1) ?: fail("--golden-compare <cpp.json> <libclang.json>")
+        val libclang = args.getOrNull(2) ?: fail("--golden-compare <cpp.json> <libclang.json>")
+        goldenCompare(cpp, libclang)
+    }
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
     // from it, and a ".h" parses as C (where `int area() const` is ill-formed and Shape is a
     // plain RecordDecl the CXXRecordDecl walk never sees).
@@ -189,6 +199,16 @@ fun main(args: Array<String>): Unit = memScoped {
         ?: return@memScoped fail("no TranslationUnitDecl")
 
     val tu = buildWrappedTU(tuDecl)
+
+    if (args.firstOrNull() == "--golden-emit") {
+        val dir = args.getOrNull(1) ?: fail("--golden-emit <dir>")
+        // The fixture is written out so krapper_gen parses the EXACT same bytes this
+        // front-end just consumed (buildASTFromCode above) — the one-source guarantee.
+        writeFile("$dir/fixture.h", FIXTURE_HEADER + "\n")
+        writeFile("$dir/cpp.json", Json.encodeToString(tu.serialized()))
+        println("cppfrontend: golden emit -> $dir/fixture.h + $dir/cpp.json")
+        return@memScoped
+    }
 
     // ---- Structural summary ----
     println("cppfrontend: constructed WrappedTU from the Clang C++ AST")
@@ -832,7 +852,7 @@ private fun printElements(elements: List<WrappedElement>, indent: String) {
     }
 }
 
-private fun fail(message: String): Nothing {
+internal fun fail(message: String): Nothing {
     println("cppfrontend: FAIL — $message")
     exitProcess(1)
 }

--- a/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
+++ b/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
@@ -18,6 +18,7 @@ import kotlin.system.exitProcess
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.set
 import kotlinx.cinterop.toKString
 import kotlinx.serialization.json.Json
 import platform.posix.fclose
@@ -44,9 +45,16 @@ import platform.posix.fread
 //    to POSITIONAL tokens ("tp:0", document order) on both sides — preserving the
 //    structural keying the resolver depends on — while arg usrs (referenced by nothing)
 //    are masked to null.
-// N2 IDENTITY-IN-SPELLINGS (WrappedTemplateRef.toString = "template<target>" embeds the
-//    param usr in type/returnType spellings, e.g. Holder's `T get()` return). The same
-//    positional rewrite as N1 is applied inside every type string.
+// N2 TEMPLATE-REF KEYING IN SPELLINGS (WrappedTemplateRef.toString = "template<target>"
+//    embeds the ref's key in type/returnType spellings, e.g. Holder's `T get()` return).
+//    The libclang path keys a dependent-T ref EITHER on the param's USR (TypeFactories'
+//    CXCursor_TemplateTypeParameter branch) OR on its bare NAME ("template<T>", the
+//    CXType_Unexposed/NoDeclFound fallback — which is what every dependent use inside a
+//    ClassTemplate's members actually hits, libclang not resolving the dependent decl);
+//    this front-end always keys on identity (TypeBuilder's TemplateTypeParmType branch).
+//    The resolver accepts BOTH keys (Parsing.typedAs maps the param's name AND usr to the
+//    same substitution), so within a template's subtree, "template<usr>" and
+//    "template<name>" of each of its params rewrite to the same positional token.
 // N3 CURSOR-WALK TYPE RESIDUE (dropped child elements). ModelFactories.mapAll attaches
 //    elements for CXCursor_TypeRef (-> WrappedTemplateRef) and CXCursor_TemplateRef
 //    (-> WrappedType) cursors when their parent cursor maps to a real element — stray
@@ -59,7 +67,20 @@ import platform.posix.fread
 //    separators (ModelFactories.defaultValue: joinToString("")); this front-end reads the
 //    raw SOURCE text (kppbridge::defaultArgText over the default-arg range), which keeps
 //    the author's spacing. Whitespace is stripped from defaultValue on both sides.
+// N5 USING-ALIAS COLLAPSE ORDER-DEPENDENCE (the documented brick-5/6 divergence). A
+//    `using` alias produces no typedef ELEMENT on either path, but as a type USE the
+//    libclang path's reducer collapse (ResolverBuilderImpl.visit) is ORDER-DEPENDENT —
+//    for the fixture's `using HandlerFn = int (*)(double)` the leaf survives as the
+//    alias NAME ("HandlerFn"), while this front-end deterministically collapses to the
+//    canonical spelling ("int (*)(double)", TypeBuilder's typedef branch). Normalized by
+//    the fixture's alias table below; durable convergence (deterministic collapse on the
+//    libclang path, or alias preservation here) is a Phase D tail item (#46).
 // ===================================================================================
+
+// N5's fixture-scoped `using`-alias spellings: alias-name leaf -> canonical collapse.
+private val USING_ALIAS_SPELLINGS = mapOf(
+    "HandlerFn" to "int (*)(double)"
+)
 
 // The element kinds ModelSerializer names explicitly — everything both front-ends MODEL.
 // Any other kind (the serializer's `else` branch spells the class name, e.g.
@@ -97,49 +118,59 @@ fun goldenCompare(cppPath: String, libclangPath: String): Nothing {
 
 // ---- Normalization (the ledger, executable) ----
 
-private fun SerializedElement.normalized(): SerializedElement {
-    // N1: collect template-param usrs in document order -> positional tokens.
-    val paramUsrs = mutableListOf<String>()
-    collectTemplateParamUsrs(this, paramUsrs)
-    // Longest-first so one usr being a prefix of another (e.g. "cpp:7"/"cpp:75") can't
-    // corrupt the in-spelling rewrite (N2).
-    val rewrites = paramUsrs.withIndex()
-        .sortedByDescending { it.value.length }
-        .map { (i, usr) -> usr to "tp:$i" }
-    return normalize(this, rewrites)
-}
+private fun SerializedElement.normalized(): SerializedElement = normalize(this, emptyList(), Counter())
 
-private fun collectTemplateParamUsrs(element: SerializedElement, out: MutableList<String>) {
-    if (element.kind == "templateParam") {
-        element.usr?.takeIf { it.isNotEmpty() && it !in out }?.let(out::add)
-    }
-    for (child in element.children) collectTemplateParamUsrs(child, out)
+private class Counter {
+    var next = 0
 }
 
 private fun normalize(
     element: SerializedElement,
-    paramRewrites: List<Pair<String, String>>
+    inherited: List<Pair<String, String>>,
+    counter: Counter
 ): SerializedElement {
-    fun String.rewriteUsrs(): String {
+    // N1+N2: entering a template scope assigns each of its params a positional token
+    // (document order — identical on both sides, both walks being source-ordered) and
+    // registers the rewrites: the param's usr (either side's identity string), and the
+    // exact "template<name>" spelling (the libclang name-keyed ref form). The bare name
+    // is never rewritten outside the template<...> wrapper — "T" alone is too short to
+    // substring-replace safely.
+    val rewrites = if (element.kind == "template") {
+        inherited + element.children.filter { it.kind == "templateParam" }.flatMap { param ->
+            val token = "tp:${counter.next++}"
+            listOfNotNull(
+                param.usr?.takeIf { it.isNotEmpty() }?.let { it to token },
+                param.name?.let { "template<$it>" to "template<$token>" }
+            )
+        }
+    } else {
+        inherited
+    }
+    fun String.rewriteKeys(): String {
+        // Longest-first so one key being a prefix of another (e.g. "cpp:7"/"cpp:75")
+        // can't corrupt the rewrite.
         var result = this
-        for ((usr, token) in paramRewrites) result = result.replace(usr, token)
+        for ((key, token) in rewrites.sortedByDescending { it.first.length }) {
+            result = result.replace(key, token)
+        }
         return result
     }
+    // N5: a whole-leaf `using`-alias spelling normalizes to its canonical collapse.
+    fun String.collapseAliases(): String = USING_ALIAS_SPELLINGS[this] ?: this
     return element.copy(
-        // N2: identity embedded in type spellings (WrappedTemplateRef.toString).
-        type = element.type?.rewriteUsrs(),
-        returnType = element.returnType?.rewriteUsrs(),
+        type = element.type?.collapseAliases()?.rewriteKeys(),
+        returnType = element.returnType?.collapseAliases()?.rewriteKeys(),
         // N4: whitespace-insensitive default values.
         defaultValue = element.defaultValue?.filterNot { it.isWhitespace() },
-        // N1: positional template-param identity; arg identity masked entirely.
+        // N1: positional template-param identity; all other identity masked entirely.
         usr = when (element.kind) {
-            "templateParam" -> element.usr?.rewriteUsrs()
+            "templateParam" -> element.usr?.rewriteKeys()
             else -> null
         },
         // N3: drop cursor-walk type residue, recurse into the real model children.
         children = element.children
             .filter { it.kind in MODEL_KINDS }
-            .map { normalize(it, paramRewrites) }
+            .map { normalize(it, rewrites, counter) }
     )
 }
 
@@ -206,7 +237,7 @@ internal fun readFile(path: String): String = memScoped {
         while (true) {
             val read = fread(buffer, 1u, bufferSize.toULong(), file)
             if (read == 0uL) break
-            buffer[read.toInt()] = 0
+            buffer[read.toInt()] = 0.toByte()
             builder.append(buffer.toKString())
         }
         builder.toString()

--- a/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
+++ b/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
@@ -107,7 +107,7 @@ fun goldenCompare(cppPath: String, libclangPath: String): Nothing {
     if (divergences.isEmpty()) {
         println(
             "GOLDEN COMPARE: PASS — cpp front-end and libclang front-end parse output " +
-                "match structurally under the documented normalizer ledger (N1-N4)."
+                "match structurally under the documented normalizer ledger (N1-N5)."
         )
         exitProcess(0)
     }

--- a/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
+++ b/cppfrontend/src/nativeMain/kotlin/GoldenCompare.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.krapper.generator.model.SerializedElement
+import kotlin.system.exitProcess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import kotlinx.serialization.json.Json
+import platform.posix.fclose
+import platform.posix.fopen
+import platform.posix.fputs
+import platform.posix.fread
+
+// #44 brick 7 — THE GOLDEN TEST. Both front-ends parse the SAME fixture and project their
+// WrappedTU through the canonical SerializedElement DTO (:krapper_model ModelSerializer):
+//  * cpp.json      — this front-end (CppFrontend.kt --golden-emit),
+//  * libclang.json — krapper_gen's libclang-C path (--dumpParsedModel, Parsing.kt).
+// goldenCompare() diffs the two trees STRUCTURALLY under the normalizer ledger below and
+// exits non-zero on any unexplained divergence — the automated regression lock for the
+// front-end rewrite (Phase B exit / Phase C entry; the spirit of issue #8).
+//
+// ============================ NORMALIZER / MASK LEDGER =============================
+// The honest record of remaining representational divergence between the two front-ends.
+// Every entry cites BOTH sides' behavior; anything NOT explained here fails the compare.
+//
+// N1 IDENTITY MASK (usr fields). The libclang path keys identity on clang USR strings
+//    ("c:@ST>1#T@Holder@T", "" for params); this front-end on canonical-Decl ids
+//    ("cpp:<id>", ModelBuilder.cppUsr). The literal strings can never agree. Template-
+//    param usrs are CROSS-REFERENCED by WrappedTemplateRef targets, so they are rewritten
+//    to POSITIONAL tokens ("tp:0", document order) on both sides — preserving the
+//    structural keying the resolver depends on — while arg usrs (referenced by nothing)
+//    are masked to null.
+// N2 IDENTITY-IN-SPELLINGS (WrappedTemplateRef.toString = "template<target>" embeds the
+//    param usr in type/returnType spellings, e.g. Holder's `T get()` return). The same
+//    positional rewrite as N1 is applied inside every type string.
+// N3 CURSOR-WALK TYPE RESIDUE (dropped child elements). ModelFactories.mapAll attaches
+//    elements for CXCursor_TypeRef (-> WrappedTemplateRef) and CXCursor_TemplateRef
+//    (-> WrappedType) cursors when their parent cursor maps to a real element — stray
+//    type-reference residue riding on methods/bases/typedefs (load-bearing ONLY under a
+//    WrappedTemplateParam, where defaultType reads them; the fixture has no defaulted
+//    template params — Phase D item on #46). This front-end constructs types only where
+//    the model references them and emits no such children. Children whose kind is not a
+//    named model kind are dropped from both sides.
+// N4 DEFAULT-VALUE WHITESPACE. libclang's defaultValue is a token-spelling JOIN with no
+//    separators (ModelFactories.defaultValue: joinToString("")); this front-end reads the
+//    raw SOURCE text (kppbridge::defaultArgText over the default-arg range), which keeps
+//    the author's spacing. Whitespace is stripped from defaultValue on both sides.
+// ===================================================================================
+
+// The element kinds ModelSerializer names explicitly — everything both front-ends MODEL.
+// Any other kind (the serializer's `else` branch spells the class name, e.g.
+// "WrappedTemplateRef") is libclang cursor-walk residue, dropped under N3.
+private val MODEL_KINDS = setOf(
+    "tu", "class", "template", "templateParam", "typedef",
+    "namespace", "base", "method", "arg", "field"
+)
+
+fun goldenCompare(cppPath: String, libclangPath: String): Nothing {
+    val json = Json
+    val cpp = json.decodeFromString(
+        SerializedElement.serializer(),
+        readFile(cppPath)
+    ).normalized()
+    val libclang = json.decodeFromString(
+        SerializedElement.serializer(),
+        readFile(libclangPath)
+    ).normalized()
+
+    val divergences = mutableListOf<String>()
+    diff(cpp, libclang, "tu", divergences)
+
+    if (divergences.isEmpty()) {
+        println(
+            "GOLDEN COMPARE: PASS — cpp front-end and libclang front-end parse output " +
+                "match structurally under the documented normalizer ledger (N1-N4)."
+        )
+        exitProcess(0)
+    }
+    println("GOLDEN COMPARE: FAIL — ${divergences.size} unexplained divergence(s):")
+    for (d in divergences) println("  $d")
+    exitProcess(1)
+}
+
+// ---- Normalization (the ledger, executable) ----
+
+private fun SerializedElement.normalized(): SerializedElement {
+    // N1: collect template-param usrs in document order -> positional tokens.
+    val paramUsrs = mutableListOf<String>()
+    collectTemplateParamUsrs(this, paramUsrs)
+    // Longest-first so one usr being a prefix of another (e.g. "cpp:7"/"cpp:75") can't
+    // corrupt the in-spelling rewrite (N2).
+    val rewrites = paramUsrs.withIndex()
+        .sortedByDescending { it.value.length }
+        .map { (i, usr) -> usr to "tp:$i" }
+    return normalize(this, rewrites)
+}
+
+private fun collectTemplateParamUsrs(element: SerializedElement, out: MutableList<String>) {
+    if (element.kind == "templateParam") {
+        element.usr?.takeIf { it.isNotEmpty() && it !in out }?.let(out::add)
+    }
+    for (child in element.children) collectTemplateParamUsrs(child, out)
+}
+
+private fun normalize(
+    element: SerializedElement,
+    paramRewrites: List<Pair<String, String>>
+): SerializedElement {
+    fun String.rewriteUsrs(): String {
+        var result = this
+        for ((usr, token) in paramRewrites) result = result.replace(usr, token)
+        return result
+    }
+    return element.copy(
+        // N2: identity embedded in type spellings (WrappedTemplateRef.toString).
+        type = element.type?.rewriteUsrs(),
+        returnType = element.returnType?.rewriteUsrs(),
+        // N4: whitespace-insensitive default values.
+        defaultValue = element.defaultValue?.filterNot { it.isWhitespace() },
+        // N1: positional template-param identity; arg identity masked entirely.
+        usr = when (element.kind) {
+            "templateParam" -> element.usr?.rewriteUsrs()
+            else -> null
+        },
+        // N3: drop cursor-walk type residue, recurse into the real model children.
+        children = element.children
+            .filter { it.kind in MODEL_KINDS }
+            .map { normalize(it, paramRewrites) }
+    )
+}
+
+// ---- Structural diff ----
+
+private fun diff(
+    cpp: SerializedElement,
+    libclang: SerializedElement,
+    path: String,
+    out: MutableList<String>
+) {
+    fun field(name: String, c: Any?, l: Any?) {
+        if (c != l) out += "$path.$name: cpp=$c libclang=$l"
+    }
+    field("kind", cpp.kind, libclang.kind)
+    field("name", cpp.name, libclang.name)
+    field("type", cpp.type, libclang.type)
+    field("returnType", cpp.returnType, libclang.returnType)
+    field("methodType", cpp.methodType, libclang.methodType)
+    field("isConst", cpp.isConst, libclang.isConst)
+    field("isVirtual", cpp.isVirtual, libclang.isVirtual)
+    field("isAbstract", cpp.isAbstract, libclang.isAbstract)
+    field("isPublic", cpp.isPublic, libclang.isPublic)
+    field("isVirtualBase", cpp.isVirtualBase, libclang.isVirtualBase)
+    field("isCopyConstructor", cpp.isCopyConstructor, libclang.isCopyConstructor)
+    field("isDefaultConstructor", cpp.isDefaultConstructor, libclang.isDefaultConstructor)
+    field("hasDefault", cpp.hasDefault, libclang.hasDefault)
+    field("defaultValue", cpp.defaultValue, libclang.defaultValue)
+    field("metadata", cpp.metadata, libclang.metadata)
+    field("usr", cpp.usr, libclang.usr)
+    if (cpp.children.size != libclang.children.size) {
+        out += "$path.children: cpp has ${cpp.children.size} ${cpp.children.label()} " +
+            "vs libclang ${libclang.children.size} ${libclang.children.label()}"
+    }
+    // Positional compare over the common prefix: both walks emit SOURCE order (the
+    // libclang cursor walk; decls()/bases() on this side — brick 3 switched to decls()
+    // for exactly this), so index i is the same declaration on both sides.
+    for (i in 0 until minOf(cpp.children.size, libclang.children.size)) {
+        val c = cpp.children[i]
+        diff(c, libclang.children[i], "$path/${c.kind}[${c.name ?: i}]", out)
+    }
+}
+
+private fun List<SerializedElement>.label(): String =
+    joinToString(",", "[", "]") { "${it.kind}:${it.name ?: it.type ?: "?"}" }
+
+// ---- Minimal posix file IO (this module has no dependency on krapper_gen's File) ----
+
+internal fun writeFile(path: String, content: String) {
+    val file = fopen(path, "wb") ?: fail("cannot open for write: $path")
+    try {
+        fputs(content, file)
+    } finally {
+        fclose(file)
+    }
+}
+
+internal fun readFile(path: String): String = memScoped {
+    val file = fopen(path, "rb") ?: fail("cannot open for read: $path")
+    try {
+        val builder = StringBuilder()
+        val bufferSize = 65536
+        val buffer = allocArray<ByteVar>(bufferSize + 1)
+        while (true) {
+            val read = fread(buffer, 1u, bufferSize.toULong(), file)
+            if (read == 0uL) break
+            buffer[read.toInt()] = 0
+            builder.append(buffer.toKString())
+        }
+        builder.toString()
+    } finally {
+        fclose(file)
+    }
+}

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -172,12 +172,14 @@ fun buildWrappedType(type: QualType): WrappedType {
 
     if (canonTy != null && canonTy.isConstantArrayType()) {
         // A constant array falls through createForType to `else -> WrappedType(spelling)`,
-        // and libclang's TypePrinter spells it "elem [N]" (krapper_gen TestData golden:
-        // "int [5]") — WrappedTypeReference models the array parsing on that exact name.
+        // and LLVM-22's TypePrinter spells it "elem[N]" with NO space — proven by the
+        // golden compare against the live libclang dump ("int[4]"; the krapper_gen
+        // TestData golden "int [5]" predates the printer change). WrappedTypeReference's
+        // array parsing (indexOf('[') + trim) accepts either spelling.
         // Reconstruct the same spelling structurally from element + extent.
         val array = canonTy.asConstantArrayType() ?: return UNRESOLVABLE
         val element = buildWrappedType(array.getElementType())
-        return WrappedTypeReference("$element [${array.getZExtSize()}]").maybeConst(isConst)
+        return WrappedTypeReference("$element[${array.getZExtSize()}]").maybeConst(isConst)
     }
     canonTy?.asRecord()?.let { record ->
         // Record leaf: createForType's CXCursor_ClassDecl/StructDecl branches ->

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -156,6 +156,15 @@ class KrapperGen : CliktCommand() {
             "Fatal / translation-unit-level errors (missing include, unattributable) abort " +
             "regardless."
     ).flag()
+    val dumpParsedModel by option(
+        "--dumpParsedModel",
+        help = "Debug/golden-test flag (#44 brick 7): parse the headers, project the PARSED " +
+            "(pre-resolution, pre-rewrite) WrappedTU through the canonical " +
+            "SerializedElement DTO (:krapper_model ModelSerializer) and write it as JSON " +
+            "to the given path, then EXIT without resolving or generating (parse-only " +
+            "mode). :cppfrontend:goldenCompare diffs this libclang front-end's parse " +
+            "output against the C++-AST front-end's."
+    )
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -168,6 +177,10 @@ class KrapperGen : CliktCommand() {
         if (serviceMode) {
             return runService()
         }
+        // Golden-test dump (#44 brick 7): arm the parse-only hook in Parsing.kt. The
+        // process exits inside parseHeader right after the JSON is written, so the
+        // resolution/generation flow below never runs with the flag set.
+        dumpParsedModelPath = dumpParsedModel
         runBlocking {
             val service = KrapperServiceImpl()
             val resolvedModule = moduleName

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -80,6 +80,7 @@ import com.monkopedia.krapper.generator.model.filterRecursive
 import com.monkopedia.krapper.generator.model.forEachRecursive
 import com.monkopedia.krapper.generator.model.freeFunctionQualifiedName
 import com.monkopedia.krapper.generator.model.parentClass
+import com.monkopedia.krapper.generator.model.serialized
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedType
@@ -92,6 +93,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedNamespace
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedType
 import kotlin.math.min
+import kotlin.system.exitProcess
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.DeferScope
@@ -112,6 +114,13 @@ import platform.posix.system
 import platform.posix.write
 
 typealias ElementFilter = WrappedElement.() -> Boolean
+
+// Golden-test dump path (#44 brick 7), set by KrapperGen --dumpParsedModel before the run.
+// When non-null, [parseHeader] writes the parsed (pre-resolution, pre-rewrite) WrappedTU
+// as canonical SerializedElement JSON to this path and exits the process — parse-only
+// mode, used by :cppfrontend:goldenCompare. A CLI-scoped global rather than a KrapperConfig
+// field so the ksrpc service schema (:slice) is untouched by a debug-only flag.
+var dumpParsedModelPath: String? = null
 
 fun FilterDefinition.wrapperFilter(): (WrappedElement) -> Boolean {
     return when (this) {
@@ -556,6 +565,18 @@ suspend fun DeferScope.parseHeader(
             }
         }
     Log.i("Reduced ${tu.children.size}")
+    // Golden-test dump (#44 brick 7, armed by krapper_gen --dumpParsedModel): project the
+    // PARSED tree through the canonical SerializedElement DTO and exit (parse-only mode).
+    // The hook sits HERE — after the multi-file reduce completes the tree, but BEFORE the
+    // pre-resolution rewrites below (rewriteViewReturns/rewriteUniquePtrReturns are
+    // krapper-specific marshalling baked onto the tree, not parse output — the C++-AST
+    // front-end does not perform them, so the golden compare must see the tree without
+    // them).
+    dumpParsedModelPath?.let { path ->
+        File(path).writeText(Json.encodeToString(tu.serialized()))
+        Log.i("Dumped parsed model to $path (parse-only mode, exiting)")
+        exitProcess(0)
+    }
     // T1.10: bake view-return rewrites (e.g. llvm::StringRef -> std::string via `.str()`)
     // into the parsed tree BEFORE resolution. ParsedResolver.resolve re-reads classes from
     // this TU (not the findClasses() result), so the rewrite must live on the tree itself.

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
@@ -59,6 +59,7 @@ fun WrappedElement.serialized(): SerializedElement {
     val kids = children.map { it.serialized() }
     return when (this) {
         is WrappedTU -> SerializedElement("tu", children = kids)
+
         is WrappedClass -> SerializedElement(
             "class",
             name = name,
@@ -66,6 +67,7 @@ fun WrappedElement.serialized(): SerializedElement {
             metadata = metadata.flags().takeIf { it.isNotEmpty() },
             children = kids
         )
+
         // Brick 5: template declarations + their params, and typedef elements.
         is WrappedTemplate -> SerializedElement(
             "template",
@@ -73,19 +75,23 @@ fun WrappedElement.serialized(): SerializedElement {
             metadata = metadata.flags().takeIf { it.isNotEmpty() },
             children = kids
         )
+
         is WrappedTemplateParam -> SerializedElement(
             "templateParam",
             name = name,
             usr = usr,
             children = kids
         )
+
         is WrappedTypedef -> SerializedElement(
             "typedef",
             name = name,
             type = targetType.toString(),
             children = kids
         )
+
         is WrappedNamespace -> SerializedElement("namespace", name = namespace, children = kids)
+
         is WrappedBase -> SerializedElement(
             "base",
             type = type?.toString(),
@@ -93,6 +99,7 @@ fun WrappedElement.serialized(): SerializedElement {
             isVirtualBase = isVirtualBase,
             children = kids
         )
+
         // Before WrappedMethod: WrappedArgument/WrappedField are sibling element kinds, a
         // WrappedConstructor IS-A WrappedMethod with extra flags, and a WrappedDestructor
         // IS-A WrappedMethod distinguished by methodType alone.
@@ -105,6 +112,7 @@ fun WrappedElement.serialized(): SerializedElement {
             isDefaultConstructor = isDefaultConstructor,
             children = kids
         )
+
         is WrappedArgument -> SerializedElement(
             "arg",
             name = name,
@@ -114,12 +122,14 @@ fun WrappedElement.serialized(): SerializedElement {
             defaultValue = defaultValue,
             children = kids
         )
+
         is WrappedField -> SerializedElement(
             "field",
             name = name,
             type = type.toString(),
             children = kids
         )
+
         is WrappedMethod -> SerializedElement(
             "method",
             name = name,
@@ -129,6 +139,7 @@ fun WrappedElement.serialized(): SerializedElement {
             isVirtual = isVirtual,
             children = kids
         )
+
         else -> SerializedElement(this::class.simpleName ?: "element", children = kids)
     }
 }

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
@@ -13,27 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.monkopedia.krapper.generator.model.ClassMetadata
-import com.monkopedia.krapper.generator.model.WrappedArgument
-import com.monkopedia.krapper.generator.model.WrappedBase
-import com.monkopedia.krapper.generator.model.WrappedClass
-import com.monkopedia.krapper.generator.model.WrappedConstructor
-import com.monkopedia.krapper.generator.model.WrappedElement
-import com.monkopedia.krapper.generator.model.WrappedField
-import com.monkopedia.krapper.generator.model.WrappedMethod
-import com.monkopedia.krapper.generator.model.WrappedNamespace
-import com.monkopedia.krapper.generator.model.WrappedTU
-import com.monkopedia.krapper.generator.model.WrappedTemplate
-import com.monkopedia.krapper.generator.model.WrappedTemplateParam
-import com.monkopedia.krapper.generator.model.WrappedTypedef
+package com.monkopedia.krapper.generator.model
+
 import kotlinx.serialization.Serializable
 
-// JSON projection of the parse-output model (#44 brick 2). The WrappedElement hierarchy
-// itself is NOT @Serializable (parent back-links + non-data classes), so the front-end
-// serializes a one-way structural DTO: kind + per-kind payload + children, types spelled
-// via WrappedType.toString(). Phase C's tree-diff wants ONE canonical projection emitted by
-// BOTH front-ends, so the durable home for this is :krapper_model — kept frontend-side for
-// the scaffold to leave the model module untouched (finding recorded on #44).
+// THE CANONICAL JSON projection of the parse-output model (#44 bricks 2+7). The
+// WrappedElement hierarchy itself is NOT @Serializable (parent back-links + non-data
+// classes), so front-ends serialize this one-way structural DTO: kind + per-kind payload +
+// children, types spelled via WrappedType.toString(). It is emitted by BOTH front-ends —
+// krapper_gen's libclang-C path (--dumpParsedModel) and :cppfrontend's C++-AST path — and
+// is what the Phase C golden tree-diff (:cppfrontend:goldenCompare) compares, which is why
+// it lives here in :krapper_model rather than in either front-end.
 @Serializable
 data class SerializedElement(
     val kind: String,
@@ -58,8 +48,9 @@ data class SerializedElement(
     // The names of the ClassMetadata flags set on a class (parse-time records about
     // FILTERED members — deleted/non-public ctors, hidden new/delete, const fields).
     val metadata: List<String>? = null,
-    // Identity field — "cpp:<canonical Decl id>" here vs a libclang USR string from the
-    // libclang front-end; maskable in the Phase C tree-diff (see ModelBuilder.kt).
+    // Identity field — "cpp:<canonical Decl id>" from the C++-AST front-end vs a libclang
+    // USR string from the libclang front-end; masked in the golden tree-diff (the two
+    // front-ends never agree on the literal identity string, only on the structure).
     val usr: String? = null,
     val children: List<SerializedElement> = emptyList()
 )


### PR DESCRIPTION
Phase B brick 7 of #44 — **THE GOLDEN TEST**: run BOTH front-ends (libclang-C and the cpp/generated-bindings one) on the same fixture and structurally compare their parse-output models. Phase B exit criterion / Phase C (#45) entry point, and the real automated regression lock for the front-end rewrite (the spirit of #8: any construction drift between ModelFactories/TypeFactories and ModelBuilder/TypeBuilder now fails a task; the clangwalk-specific test piece of #8 can be judged separately).

## What's in it

**(a) Canonical projection → `:krapper_model`** — `SerializedElement` + `WrappedElement.serialized()` moved from cppfrontend's local copy into `krapper_model/.../model/ModelSerializer.kt` (nativeMain — the projection extends the nativeMain `WrappedElement`). It is now THE canonical comparable shape both front-ends emit; cppfrontend's local copy is deleted.

**(b) krapper_gen `--dumpParsedModel <path>`** — follows the existing clikt option pattern in `App.kt`. Parse-only mode: the hook sits in `Parsing.kt parseHeader` **after the multi-file reduce completes the tree but BEFORE the pre-resolution rewrites** (`rewriteViewReturns`/`rewriteUniquePtrReturns` are krapper-specific marshalling baked onto the tree, not parse output — the cpp front-end doesn't perform them), writes the canonical-DTO JSON, and **exits** (documented on the flag + at the hook). Threaded via a CLI-scoped global rather than `KrapperConfig`, so the ksrpc service schema (`:slice`) is untouched by a debug-only flag. Flag absent ⇒ byte-identical behavior (featuregen gate below proves it).

**(c) The compare** — gated tasks in `cppfrontend/build.gradle.kts`:
- `goldenEmit` — the cppfrontend binary writes `fixture.h` (the binary emits the fixture itself, so both parses consume identical bytes) + `cpp.json`;
- `goldenDump` — the REAL `krapper_gen.kexe` parses that fixture with `--dumpParsedModel` → `libclang.json`;
- `goldenCompare` — tree-diff (`GoldenCompare.kt`) under the documented normalizer ledger; prints precise per-path divergence reports and exits non-zero on anything unexplained.

## Compare result

```
GOLDEN COMPARE: PASS — cpp front-end and libclang front-end parse output match
structurally under the documented normalizer ledger (N1-N5).
```

The first real two-front-end diff found **6 divergences beyond the documented list**, dispositioned per the brick's rules:

| Divergence | Disposition |
|---|---|
| `int [4]` vs `int[4]` (Scene.corners) | **FIXED** — cppfrontend construction bug: it pinned the OLD TypePrinter spelling from the krapper TestData golden ("int [5]"); live LLVM-22 libclang spells `int[4]`. TypeBuilder + self-check updated to the live oracle. |
| `template<cpp:N>` vs `template<T>` (4 sites in Holder: value_type typedef, `value` field, `get()` return, `set()` arg) | **NORMALIZED (N2)** — the libclang path keys dependent-T refs on the param NAME via TypeFactories' `CXType_Unexposed`/`NoDeclFound` fallback (which is what every dependent use inside a ClassTemplate's members actually hits), not the documented USR branch; the cpp path always keys identity. The resolver accepts BOTH keys (`Parsing.typedAs` maps name AND usr to the same substitution), so both forms rewrite to one positional token, scoped to the owning template. |
| `int (*)(double)` vs `HandlerFn` (Dispatcher.onHandle) | **NORMALIZED (N5)** — the documented using-alias collapse order-dependence: the libclang reducer leaves the alias-name leaf, the cpp path deterministically collapses to the canonical spelling. Fixture-scoped alias table; durable convergence filed as a Phase D item on #46. |

Negative test (manual): perturbing the libclang dump (`isAbstract` flip + a method rename) fails with exact paths — `tu/class[Shape].isAbstract: cpp=true libclang=false`, `tu/namespace[geo]/class[Circle]/method[radius].name: cpp=radius libclang=radiusX` — exit 1. The compare is not vacuous.

## Final mask/normalizer ledger (GoldenCompare.kt, each entry cites both sides)

- **N1 IDENTITY MASK** — usr fields: libclang USR strings vs `cpp:<canonical Decl id>` can never literally agree. Template-param usrs (cross-referenced by `WrappedTemplateRef` targets) rewrite to positional tokens (`tp:0`, document order — preserving the structural keying); arg usrs (referenced by nothing) mask to null.
- **N2 TEMPLATE-REF KEYING IN SPELLINGS** — `WrappedTemplateRef.toString()` embeds the ref key in type spellings; libclang keys on USR *or* bare name (the Unexposed/NoDeclFound fallback), cpp on identity; both rewrite to the positional token within the owning template's subtree (the resolver accepts both keys).
- **N3 CURSOR-WALK TYPE RESIDUE** — `ModelFactories.mapAll` attaches stray `CXCursor_TypeRef`/`CXCursor_TemplateRef` elements as children of methods/bases/typedefs; the cpp front-end constructs types only where the model references them. Non-model-kind children dropped from both sides. (Load-bearing ONLY under `WrappedTemplateParam.defaultType` — Phase D, see below.)
- **N4 DEFAULT-VALUE WHITESPACE** — libclang token-join (`joinToString("")`) vs cpp raw source text; whitespace stripped on both sides.
- **N5 USING-ALIAS COLLAPSE ORDER-DEPENDENCE** — alias-name leaf (libclang, order-dependent) vs deterministic canonical collapse (cpp); fixture-scoped alias table (`HandlerFn` → `int (*)(double)`).

(The two remaining documented Phase C divergences never fire on this projection: `_Bool`→`bool` is normalized at construction in TypeBuilder, and the APSInt unsigned-top-bit case isn't expressible in the DTO's type spellings.)

## Phase D convergence-tail items (filed on #46)

1. **Template-param default types** — the libclang path reconstructs `WrappedTemplateParam.defaultType` from the N3-dropped residue children; the cpp front-end doesn't build template-param defaults yet. The fixture has no defaulted template params, so the compare can't see it — needs a fixture row + construction when the front-end grows there.
2. **Using-alias collapse determinism (N5)** — converge by making the collapse deterministic (or preserving the alias) so the fixture-scoped table can be deleted.

## Verify

- FULL gate (krapper_model touched): `:krapper_gen:nativeTest` **311/0**, `:krapper_model:build` green, `:featuregen:kplusplusSync` + `:featuregen:nativeTest` **188/0** with **zero krapped/ drift** (byte-identical — git status clean after sync), `:krapper_gen:ktlintCheck` green.
- Gated: cppfrontend run **91/91 self-checks PASS**; `:cppfrontend:goldenCompare` **PASS** end-to-end at HEAD (emit → dump → compare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
