### PR TITLE
krapper_model: full-fidelity WrappedTU round-trip (DAG-aware ModelIo) + --roundTripModel oracle — byte-identical featuregen sync (#45 brick 1)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -165,6 +165,15 @@ class KrapperGen : CliktCommand() {
             "mode). :cppfrontend:goldenCompare diffs this libclang front-end's parse " +
             "output against the C++-AST front-end's."
     )
+    val roundTripModel by option(
+        "--roundTripModel",
+        help = "Debug/oracle flag (#45 brick 1): after each parse, serialize the full " +
+            "WrappedTU through the ModelIo round-trip JSON, deserialize it back, and run " +
+            "resolution+generation on the DESERIALIZED model. Output should be " +
+            "byte-identical to a run without the flag — the verification gate for the " +
+            "--frontend=cpp handoff format. Also enabled by KRAPPER_ROUNDTRIP_MODEL=1 " +
+            "in the environment (which reaches service-mode runs too)."
+    ).flag()
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -181,6 +190,7 @@ class KrapperGen : CliktCommand() {
         // process exits inside parseHeader right after the JSON is written, so the
         // resolution/generation flow below never runs with the flag set.
         dumpParsedModelPath = dumpParsedModel
+        if (roundTripModel) roundTripParsedModel = true
         runBlocking {
             val service = KrapperServiceImpl()
             val resolvedModule = moduleName

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
@@ -29,7 +29,6 @@ import clang.CX_CXXAccessSpecifier
 import com.monkopedia.krapper.generator.model.ElementIdentity
 import com.monkopedia.krapper.generator.model.MethodType
 import com.monkopedia.krapper.generator.model.RangeReturn
-import com.monkopedia.krapper.generator.model.forEachIdentityPair
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
@@ -43,6 +42,7 @@ import com.monkopedia.krapper.generator.model.WrappedTU
 import com.monkopedia.krapper.generator.model.WrappedTemplate
 import com.monkopedia.krapper.generator.model.WrappedTemplateParam
 import com.monkopedia.krapper.generator.model.WrappedTypedef
+import com.monkopedia.krapper.generator.model.forEachIdentityPair
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
 import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedType

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
@@ -26,8 +26,10 @@ import clang.CXCursorKind.CXCursor_TypedefDecl
 import clang.CXType
 import clang.CXTypeKind.CXType_Pointer
 import clang.CX_CXXAccessSpecifier
+import com.monkopedia.krapper.generator.model.ElementIdentity
 import com.monkopedia.krapper.generator.model.MethodType
 import com.monkopedia.krapper.generator.model.RangeReturn
+import com.monkopedia.krapper.generator.model.forEachIdentityPair
 import com.monkopedia.krapper.generator.model.WrappedArgument
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
@@ -70,6 +72,26 @@ private var droppedUsrs: Set<String> = emptySet()
  * [mapAll]. */
 fun WrappedElement.Companion.setDroppedUsrs(usrs: Set<String>) {
     droppedUsrs = usrs
+}
+
+/**
+ * Round-trip oracle support (#45 brick 1): after `--roundTripModel` replaces a parsed
+ * tree with its deserialized copy, point every [elementLookup] memo entry that referenced
+ * an element of the ORIGINAL tree at its RESTORED counterpart. The memo is what carries
+ * element identity ACROSS parses (a class re-encountered in a later forcing header is the
+ * same instance, and resolution mutates it in place — metadata, synthetic children,
+ * dedup), so without the remap the post-round-trip parses would keep building on the
+ * abandoned originals and the run would diverge from a non-flag run for reasons that have
+ * nothing to do with serialization fidelity.
+ */
+fun WrappedElement.Companion.remapMemoized(original: WrappedElement, restored: WrappedElement) {
+    val replacements = HashMap<ElementIdentity, WrappedElement>()
+    forEachIdentityPair(original, restored) { old, new ->
+        replacements[ElementIdentity(old)] = new
+    }
+    for (entry in elementLookup.entries) {
+        replacements[ElementIdentity(entry.value)]?.let { entry.setValue(it) }
+    }
 }
 
 fun WrappedElement.Companion.mapAll(

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -589,26 +589,33 @@ suspend fun DeferScope.parseHeader(
         Log.i("Dumped parsed model to $path (parse-only mode, exiting)")
         exitProcess(0)
     }
+    // Round-trip oracle (#45 brick 1): serialize the parsed model to JSON, deserialize
+    // it back, and hand the rest of the pipeline THE DESERIALIZED TREE. Placed at the
+    // same point as the --dumpParsedModel golden hook — post-reduce, BEFORE the
+    // pre-resolution rewrites below — because the rewrites REPLACE method children with
+    // copies (rewriteMethods): running them after the swap lets them act on the restored
+    // tree, so the cursor->element memo (remapped to the restored instances by
+    // remapMemoized) and the live tree stay aligned exactly as in a non-flag run. The
+    // rewrite-produced fields (returnsPairSecond/returnViaMemberCall/rangeElementType)
+    // are still covered by the schema — they're serialized whenever set (e.g. by the
+    // instantiation-time rewrite passes feeding later parses through shared elements).
+    val model = if (roundTripParsedModel) {
+        val json = ModelIo.encodeToString(tu)
+        val restored = ModelIo.decodeFromString(json)
+        WrappedElement.remapMemoized(tu, restored)
+        Log.i("Round-tripped parsed model through ModelIo JSON (${json.length} chars)")
+        restored
+    } else {
+        tu
+    }
     // T1.10: bake view-return rewrites (e.g. llvm::StringRef -> std::string via `.str()`)
     // into the parsed tree BEFORE resolution. ParsedResolver.resolve re-reads classes from
     // this TU (not the findClasses() result), so the rewrite must live on the tree itself.
-    rewriteViewReturns(tu)
+    rewriteViewReturns(model)
     // T1.7e: a by-value `std::unique_ptr<T>` return -> raw `T*` (ownership transferred via
     // `.release()`). Same pre-resolution baking rationale as rewriteViewReturns.
-    rewriteUniquePtrReturns(tu)
-    // Round-trip oracle (#45 brick 1): serialize the parsed model to JSON, deserialize
-    // it back, and hand RESOLUTION THE DESERIALIZED TREE. Placed AFTER the pre-resolution
-    // rewrites above (unlike the --dumpParsedModel golden hook) because the rewrites bake
-    // krapper-specific state (returnsPairSecond/returnViaMemberCall/rangeElementType +
-    // rewritten return types) onto the tree before resolution consumes it — round-tripping
-    // post-rewrite covers those fields too, maximizing what the oracle proves.
-    if (roundTripParsedModel) {
-        val json = ModelIo.encodeToString(tu)
-        val restored = ModelIo.decodeFromString(json)
-        Log.i("Round-tripped parsed model through ModelIo JSON (${json.length} chars)")
-        return ParsedResolver(restored)
-    }
-    return ParsedResolver(tu)
+    rewriteUniquePtrReturns(model)
+    return ParsedResolver(model)
 }
 
 private fun DeferScope.parseHeader(

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -65,6 +65,7 @@ import com.monkopedia.krapper.TypeFilter
 import com.monkopedia.krapper.filter
 import com.monkopedia.krapper.generator.canonicalType
 import com.monkopedia.krapper.generator.codegen.File
+import com.monkopedia.krapper.generator.model.ModelIo
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
@@ -121,6 +122,17 @@ typealias ElementFilter = WrappedElement.() -> Boolean
 // mode, used by :cppfrontend:goldenCompare. A CLI-scoped global rather than a KrapperConfig
 // field so the ksrpc service schema (:slice) is untouched by a debug-only flag.
 var dumpParsedModelPath: String? = null
+
+// Round-trip oracle (#45 brick 1), set by KrapperGen --roundTripModel or the
+// KRAPPER_ROUNDTRIP_MODEL=1 environment variable (the env var also reaches service-mode
+// runs, where CLI options don't apply — e.g. the gradle plugin's kplusplusSync spawn).
+// When enabled, [parseHeader] serializes each parsed WrappedTU through the
+// full-fidelity ModelIo JSON, deserializes it back, and continues the normal
+// resolution+generation pipeline ON THE DESERIALIZED MODEL — so a byte-identical
+// generated output proves every field resolution+codegen consume survives the
+// round-trip (the verification gate for the --frontend=cpp handoff format).
+var roundTripParsedModel: Boolean =
+    getenv("KRAPPER_ROUNDTRIP_MODEL")?.toKString() == "1"
 
 fun FilterDefinition.wrapperFilter(): (WrappedElement) -> Boolean {
     return when (this) {
@@ -584,6 +596,18 @@ suspend fun DeferScope.parseHeader(
     // T1.7e: a by-value `std::unique_ptr<T>` return -> raw `T*` (ownership transferred via
     // `.release()`). Same pre-resolution baking rationale as rewriteViewReturns.
     rewriteUniquePtrReturns(tu)
+    // Round-trip oracle (#45 brick 1): serialize the parsed model to JSON, deserialize
+    // it back, and hand RESOLUTION THE DESERIALIZED TREE. Placed AFTER the pre-resolution
+    // rewrites above (unlike the --dumpParsedModel golden hook) because the rewrites bake
+    // krapper-specific state (returnsPairSecond/returnViaMemberCall/rangeElementType +
+    // rewritten return types) onto the tree before resolution consumes it — round-tripping
+    // post-rewrite covers those fields too, maximizing what the oracle proves.
+    if (roundTripParsedModel) {
+        val json = ModelIo.encodeToString(tu)
+        val restored = ModelIo.decodeFromString(json)
+        Log.i("Round-tripped parsed model through ModelIo JSON (${json.length} chars)")
+        return ParsedResolver(restored)
+    }
     return ParsedResolver(tu)
 }
 

--- a/krapper_model/build.gradle.kts
+++ b/krapper_model/build.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
     sourceSets["commonMain"].dependencies {
         implementation(libs.serialization.json)
     }
+    sourceSets["commonTest"].dependencies {
+        implementation(kotlin("test"))
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator.model
+
+import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
+import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
+import com.monkopedia.krapper.generator.model.type.WrappedModifiedType
+import com.monkopedia.krapper.generator.model.type.WrappedPrefixedType
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
+import com.monkopedia.krapper.generator.model.type.WrappedTypedefRef
+import com.monkopedia.krapper.generator.model.type.WrappedTypename
+import com.monkopedia.krapper.generator.resolvedmodel.AllocationStyle
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+// FULL-FIDELITY round-trip serialization of the parse-output model (#45 brick 1) — the
+// `--frontend=cpp` handoff format. Unlike the sibling [SerializedElement] (a ONE-WAY,
+// lossy-by-design comparable projection for the golden tree-diff), this DTO mirror
+// carries EVERY field resolution and codegen consume (the ModelResolution.kt
+// when-dispatch is the consumption map), and [ModelIo.decodeFromString] rebuilds a
+// functionally identical WrappedTU from the JSON.
+//
+// Design decisions:
+//  - A parallel DTO mirror rather than @Serializable on the model classes themselves:
+//    the element classes carry a private constructor children list on the abstract
+//    base, parent back-links, non-constructor mutable state (method flags, metadata,
+//    template merge counters) and identity caches — a mirror keeps the model untouched
+//    (flag-off behavior provably unchanged) and doubles as the explicit, reviewable
+//    schema of the handoff format.
+//  - Parent back-links are NOT serialized: [toModel] rebuilds them by reconstructing
+//    bottom-up through addAllChildren (which re-parents every child), so the cyclic
+//    reference never reaches the encoder.
+//  - Polymorphism: one sealed NodeDto hierarchy covering BOTH element and type kinds —
+//    WrappedType IS-A WrappedElement and types appear as children (e.g. under template
+//    params), so the children list must be able to carry either.
+//  - Type interning/identity: GenerationContext.internedTypes only ever caches plain
+//    [WrappedTypeReference]s (WrappedType.invoke's other branches non-local-return past
+//    the getOrPut), and WrappedTypeReference is a value-equal data class — so referential
+//    identity of types is not load-bearing for equality and decode constructs fresh
+//    instances without touching the intern cache.
+@Serializable
+sealed class NodeDto {
+    abstract val children: List<NodeDto>
+}
+
+@Serializable
+@SerialName("tu")
+data class TuDto(override val children: List<NodeDto> = emptyList()) : NodeDto()
+
+@Serializable
+@SerialName("ns")
+data class NamespaceDto(
+    val namespace: String,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("cls")
+data class ClassDto(
+    val name: String,
+    val isAbstract: Boolean = false,
+    val specifiedType: TypeDto? = null,
+    val metadata: ClassMetadata = ClassMetadata(),
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("tmpl")
+data class TemplateDto(
+    val name: String,
+    val metadata: ClassMetadata = ClassMetadata(),
+    // The template-param merge cursor (WrappedTemplate.addChild): restored verbatim so
+    // any post-load param add merges exactly as it would have on the parsed instance.
+    val templateArgCounter: Int = 0,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("tparam")
+data class TemplateParamDto(
+    val name: String,
+    val usr: String,
+    // Same-name params merged from sibling declarations — held OUTSIDE the children
+    // list (WrappedTemplateParam.merge), so they need their own slot.
+    val otherParams: List<TemplateParamDto> = emptyList(),
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("typedef")
+data class TypedefDto(
+    val name: String,
+    val targetType: TypeDto,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("base")
+data class BaseDto(
+    val type: TypeDto? = null,
+    val isPublic: Boolean = true,
+    val isVirtualBase: Boolean = false,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("method")
+data class MethodDto(
+    val name: String,
+    val returnType: TypeDto,
+    val methodType: MethodType = MethodType.METHOD,
+    val isVirtual: Boolean = false,
+    val isConst: Boolean = false,
+    val returnsPairSecond: Boolean = false,
+    val returnViaMemberCall: String? = null,
+    val rangeElementType: String? = null,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("ctor")
+data class ConstructorDto(
+    val name: String,
+    val returnType: TypeDto,
+    val isCopyConstructor: Boolean = false,
+    val isDefaultConstructor: Boolean = false,
+    val allocationStyle: AllocationStyle = AllocationStyle.DIRECT,
+    val isVirtual: Boolean = false,
+    val isConst: Boolean = false,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("dtor")
+data class DestructorDto(
+    val name: String,
+    val returnType: TypeDto,
+    val isVirtual: Boolean = false,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("arg")
+data class ArgumentDto(
+    val name: String,
+    val type: TypeDto,
+    val usr: String = "",
+    val hasDefault: Boolean = false,
+    val defaultValue: String? = null,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+@SerialName("field")
+data class FieldDto(
+    val name: String,
+    val type: TypeDto,
+    override val children: List<NodeDto> = emptyList()
+) : NodeDto()
+
+@Serializable
+sealed class TypeDto : NodeDto()
+
+@Serializable
+@SerialName("t.ref")
+data class TypeRefDto(
+    val name: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.mod")
+data class ModifiedTypeDto(
+    val baseType: TypeDto,
+    val modifier: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.pre")
+data class PrefixedTypeDto(
+    val baseType: TypeDto,
+    val modifier: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.tmpl")
+data class TemplateTypeDto(
+    val baseType: TypeDto,
+    val templateArgs: List<TypeDto> = emptyList(),
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.tref")
+data class TemplateRefDto(
+    val target: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.typedef")
+data class TypedefRefDto(
+    val usr: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.typename")
+data class TypenameDto(
+    val target: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.enum")
+data class EnumTypeDto(
+    val cppName: String,
+    val underlying: TypeDto,
+    val constants: List<WrappedEnumConstant> = emptyList(),
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("t.fnptr")
+data class FunctionPointerDto(
+    val cName: String,
+    val returnType: TypeDto,
+    val argTypes: List<TypeDto> = emptyList(),
+    // Only carried when it differs from cName (a namespace-qualified typedef).
+    val cppName: String? = null,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+fun WrappedElement.toDto(): NodeDto {
+    val kids = children.map { it.toDto() }
+    return when (this) {
+        is WrappedType -> toTypeDto(kids)
+        is WrappedTU -> TuDto(kids)
+        is WrappedNamespace -> NamespaceDto(namespace, kids)
+        is WrappedClass -> ClassDto(name, isAbstract, specifiedType?.toDto(), metadata.copy(), kids)
+        is WrappedTemplate -> TemplateDto(name, metadata.copy(), templateArgCounter, kids)
+        is WrappedTemplateParam ->
+            TemplateParamDto(name, usr, otherParams.map { it.toDto() as TemplateParamDto }, kids)
+        is WrappedTypedef -> TypedefDto(name, targetType.toDto(), kids)
+        is WrappedBase -> BaseDto(type?.toDto(), isPublic, isVirtualBase, kids)
+        // Order matters: WrappedConstructor/WrappedDestructor IS-A WrappedMethod.
+        is WrappedConstructor -> ConstructorDto(
+            name,
+            returnType.toDto(),
+            isCopyConstructor,
+            isDefaultConstructor,
+            allocationStyle,
+            isVirtual,
+            isConst,
+            kids
+        )
+        is WrappedDestructor -> DestructorDto(name, returnType.toDto(), isVirtual, kids)
+        is WrappedMethod -> MethodDto(
+            name,
+            returnType.toDto(),
+            methodType,
+            isVirtual,
+            isConst,
+            returnsPairSecond,
+            returnViaMemberCall,
+            rangeElementType,
+            kids
+        )
+        is WrappedArgument -> ArgumentDto(name, type.toDto(), usr, hasDefault, defaultValue, kids)
+        is WrappedField -> FieldDto(name, type.toDto(), kids)
+        // Fail loudly: a silently-dropped kind would surface as inexplicable codegen
+        // drift; an unknown kind means this schema needs a new DTO.
+        else -> throw IllegalArgumentException("No DTO mapping for element kind ${this::class}")
+    }
+}
+
+fun WrappedType.toDto(): TypeDto = toTypeDto(children.map { it.toDto() })
+
+private fun WrappedType.toTypeDto(kids: List<NodeDto>): TypeDto = when (this) {
+    is WrappedTypeReference -> TypeRefDto(name, kids)
+    is WrappedModifiedType -> ModifiedTypeDto(baseType.toDto(), modifier, kids)
+    is WrappedPrefixedType -> PrefixedTypeDto(baseType.toDto(), modifier, kids)
+    is WrappedTemplateType ->
+        TemplateTypeDto(baseType.toDto(), templateArgs.map { it.toDto() }, kids)
+    is WrappedTemplateRef -> TemplateRefDto(target, kids)
+    is WrappedTypedefRef -> TypedefRefDto(usr, kids)
+    is WrappedTypename -> TypenameDto(target, kids)
+    is WrappedEnumType -> EnumTypeDto(cppName, underlying.toDto(), constants, kids)
+    is WrappedFunctionPointer -> FunctionPointerDto(
+        cName,
+        returnType.toDto(),
+        argTypes.map { it.toDto() },
+        cppName.takeIf { it != cName },
+        kids
+    )
+    else -> throw IllegalArgumentException("No DTO mapping for type kind ${this::class}")
+}
+
+fun NodeDto.toModel(): WrappedElement {
+    val element = when (this) {
+        is TypeDto -> toType()
+        is TuDto -> WrappedTU()
+        is NamespaceDto -> WrappedNamespace(namespace)
+        is ClassDto -> WrappedClass(name, isAbstract, specifiedType?.toType()).also {
+            it.metadata = metadata.copy()
+        }
+        is TemplateDto -> WrappedTemplate(name).also {
+            it.metadata = metadata.copy()
+            it.templateArgCounter = templateArgCounter
+        }
+        is TemplateParamDto -> WrappedTemplateParam(name, usr).also { param ->
+            param.otherParams.addAll(otherParams.map { it.toModel() as WrappedTemplateParam })
+        }
+        is TypedefDto -> WrappedTypedef(name, targetType.toType())
+        is BaseDto -> WrappedBase(type?.toType(), isPublic, isVirtualBase)
+        is ConstructorDto -> WrappedConstructor(
+            name,
+            returnType.toType(),
+            isCopyConstructor,
+            isDefaultConstructor,
+            allocationStyle
+        ).also {
+            it.isVirtual = isVirtual
+            it.isConst = isConst
+        }
+        is DestructorDto -> WrappedDestructor(name, returnType.toType()).also {
+            it.isVirtual = isVirtual
+        }
+        is MethodDto -> WrappedMethod(name, returnType.toType(), methodType).also {
+            it.isVirtual = isVirtual
+            it.isConst = isConst
+            it.returnsPairSecond = returnsPairSecond
+            it.returnViaMemberCall = returnViaMemberCall
+            it.rangeElementType = rangeElementType
+        }
+        is ArgumentDto -> WrappedArgument(name, type.toType(), usr, hasDefault, defaultValue)
+        is FieldDto -> WrappedField(name, type.toType())
+    }
+    // Rebuild the tree (and thereby every parent back-link) bottom-up. NOTE: base-class
+    // addAllChildren appends + re-parents WITHOUT the subclass addChild hooks, so the
+    // template param-merge logic doesn't re-fire on already-merged children.
+    element.addAllChildren(children.map { it.toModel() })
+    return element
+}
+
+fun TypeDto.toType(): WrappedType {
+    val type = when (this) {
+        is TypeRefDto -> WrappedTypeReference(name)
+        is ModifiedTypeDto -> WrappedModifiedType(baseType.toType(), modifier)
+        is PrefixedTypeDto -> WrappedPrefixedType(baseType.toType(), modifier)
+        is TemplateTypeDto ->
+            WrappedTemplateType(baseType.toType(), templateArgs.map { it.toType() })
+        is TemplateRefDto -> WrappedTemplateRef(target)
+        is TypedefRefDto -> WrappedTypedefRef(usr)
+        is TypenameDto -> WrappedTypename(target)
+        is EnumTypeDto -> WrappedEnumType(cppName, underlying.toType(), constants)
+        is FunctionPointerDto -> WrappedFunctionPointer(
+            cName,
+            returnType.toType(),
+            argTypes.map { it.toType() },
+            cppName ?: cName
+        )
+    }
+    type.addAllChildren(children.map { it.toModel() })
+    return type
+}
+
+object ModelIo {
+    // Discriminator can't be the default "type" — several DTOs carry a real `type`
+    // property. Defaults omitted to keep the (large, whole-TU) payload compact.
+    val json = Json {
+        classDiscriminator = "k"
+        encodeDefaults = false
+    }
+
+    fun encodeToString(tu: WrappedTU): String =
+        json.encodeToString(NodeDto.serializer(), tu.toDto())
+
+    fun decodeFromString(text: String): WrappedTU =
+        json.decodeFromString(NodeDto.serializer(), text).toModel() as WrappedTU
+}

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
@@ -52,11 +52,18 @@ import kotlinx.serialization.json.Json
 //  - Polymorphism: one sealed NodeDto hierarchy covering BOTH element and type kinds —
 //    WrappedType IS-A WrappedElement and types appear as children (e.g. under template
 //    params), so the children list must be able to carry either.
-//  - Type interning/identity: GenerationContext.internedTypes only ever caches plain
-//    [WrappedTypeReference]s (WrappedType.invoke's other branches non-local-return past
-//    the getOrPut), and WrappedTypeReference is a value-equal data class — so referential
-//    identity of types is not load-bearing for equality and decode constructs fresh
-//    instances without touching the intern cache.
+//  - IDENTITY IS PART OF THE MODEL: the in-memory parse output is a DAG, not a tree —
+//    one element instance can sit under two parents (a free function under both its
+//    namespace and a class), interned/memoized types are shared by every use site, and
+//    resolution MUTATES elements in place (metadata flags, synthetic sizeOf/alignOf
+//    children, const-overload dedup), so two aliases observing one instance is
+//    semantically different from two equal copies. A naive value-tree encode duplicated
+//    shared nodes and the featuregen oracle caught it as codegen drift. Encoding is
+//    therefore DAG-aware: the first occurrence of an identity-shared node is wrapped in
+//    [DefDto] (assigning it an id) and every later occurrence collapses to a [RefDto]
+//    back-reference; decode rebuilds the exact aliasing structure. Encode and decode
+//    walk the graph in the same canonical order ([modelFields] then children), so a
+//    definition is always materialized before its back-references resolve.
 @Serializable
 sealed class NodeDto {
     abstract val children: List<NodeDto>
@@ -99,7 +106,7 @@ data class TemplateParamDto(
     val usr: String,
     // Same-name params merged from sibling declarations — held OUTSIDE the children
     // list (WrappedTemplateParam.merge), so they need their own slot.
-    val otherParams: List<TemplateParamDto> = emptyList(),
+    val otherParams: List<NodeDto> = emptyList(),
     override val children: List<NodeDto> = emptyList()
 ) : NodeDto()
 
@@ -175,8 +182,23 @@ data class FieldDto(
     override val children: List<NodeDto> = emptyList()
 ) : NodeDto()
 
+// TypeDto is the subset valid where the model declares a WrappedType-typed slot. DefDto
+// and RefDto are members so an identity-shared TYPE can be defined/back-referenced in a
+// type position (decode checks the definition really is a type when consumed as one).
 @Serializable
 sealed class TypeDto : NodeDto()
+
+@Serializable
+@SerialName("def")
+data class DefDto(
+    val id: Int,
+    val node: NodeDto,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
+
+@Serializable
+@SerialName("ref")
+data class RefDto(val id: Int, override val children: List<NodeDto> = emptyList()) : TypeDto()
 
 @Serializable
 @SerialName("t.ref")
@@ -209,18 +231,24 @@ data class TemplateTypeDto(
 
 @Serializable
 @SerialName("t.tref")
-data class TemplateRefDto(val target: String, override val children: List<NodeDto> = emptyList()) :
-    TypeDto()
+data class TemplateRefDto(
+    val target: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
 
 @Serializable
 @SerialName("t.typedef")
-data class TypedefRefDto(val usr: String, override val children: List<NodeDto> = emptyList()) :
-    TypeDto()
+data class TypedefRefDto(
+    val usr: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
 
 @Serializable
 @SerialName("t.typename")
-data class TypenameDto(val target: String, override val children: List<NodeDto> = emptyList()) :
-    TypeDto()
+data class TypenameDto(
+    val target: String,
+    override val children: List<NodeDto> = emptyList()
+) : TypeDto()
 
 @Serializable
 @SerialName("t.enum")
@@ -242,180 +270,327 @@ data class FunctionPointerDto(
     override val children: List<NodeDto> = emptyList()
 ) : TypeDto()
 
-fun WrappedElement.toDto(): NodeDto {
-    val kids = children.map { it.toDto() }
-    return when (this) {
-        is WrappedType -> toTypeDto(kids)
+/** Identity (===) wrapper so HashSet/HashMap can key model nodes by instance, not value
+ * (several model classes are value-equal data classes). hashCode delegates to the
+ * element's own hashCode — identity hash for regular classes, a STABLE value hash for
+ * the data classes (their hash only covers immutable constructor vals), so distinct
+ * equal-value instances simply co-bucket while remaining distinct keys. */
+class ElementIdentity(val element: WrappedElement) {
+    override fun equals(other: Any?): Boolean =
+        other is ElementIdentity && other.element === element
 
-        is WrappedTU -> TuDto(kids)
+    override fun hashCode(): Int = element.hashCode()
+}
 
-        is WrappedNamespace -> NamespaceDto(namespace, kids)
+/** The model's non-child object edges (WrappedType-valued fields + template-param merge
+ * captures), in the CANONICAL traversal order shared by encode, decode and
+ * [forEachIdentityPair]: fields first (matching decode, which constructs an element —
+ * fields included — before decoding its children), then children. */
+private fun WrappedElement.modelFields(): List<WrappedElement> = when (this) {
+    is WrappedClass -> listOfNotNull(specifiedType)
 
-        is WrappedClass -> ClassDto(name, isAbstract, specifiedType?.toDto(), metadata.copy(), kids)
+    is WrappedTemplateParam -> otherParams
 
-        is WrappedTemplate -> TemplateDto(name, metadata.copy(), templateArgCounter, kids)
+    is WrappedTypedef -> listOf(targetType)
 
-        is WrappedTemplateParam ->
-            TemplateParamDto(name, usr, otherParams.map { it.toDto() as TemplateParamDto }, kids)
+    is WrappedBase -> listOfNotNull(type)
 
-        is WrappedTypedef -> TypedefDto(name, targetType.toDto(), kids)
+    // Covers WrappedConstructor/WrappedDestructor too.
+    is WrappedMethod -> listOf(returnType)
 
-        is WrappedBase -> BaseDto(type?.toDto(), isPublic, isVirtualBase, kids)
+    is WrappedArgument -> listOf(type)
 
-        // Order matters: WrappedConstructor/WrappedDestructor IS-A WrappedMethod.
-        is WrappedConstructor -> ConstructorDto(
-            name,
-            returnType.toDto(),
-            isCopyConstructor,
-            isDefaultConstructor,
-            allocationStyle,
-            isVirtual,
-            isConst,
-            kids
+    is WrappedField -> listOf(type)
+
+    is WrappedModifiedType -> listOf(baseType)
+
+    is WrappedPrefixedType -> listOf(baseType)
+
+    is WrappedTemplateType -> listOf(baseType) + templateArgs
+
+    is WrappedEnumType -> listOf(underlying)
+
+    is WrappedFunctionPointer -> listOf(returnType) + argTypes
+
+    else -> emptyList()
+}
+
+/** Pass 1 of encode: every node reachable through more than one edge (an alias). */
+private fun collectShared(root: WrappedElement): Set<ElementIdentity> {
+    val seen = HashSet<ElementIdentity>()
+    val shared = HashSet<ElementIdentity>()
+
+    fun visit(element: WrappedElement) {
+        if (!seen.add(ElementIdentity(element))) {
+            shared.add(ElementIdentity(element))
+            return
+        }
+        element.modelFields().forEach(::visit)
+        element.children.forEach(::visit)
+    }
+    visit(root)
+    return shared
+}
+
+private class ModelEncoder(private val shared: Set<ElementIdentity>) {
+    private val ids = HashMap<ElementIdentity, Int>()
+
+    fun element(element: WrappedElement): NodeDto {
+        val key = ElementIdentity(element)
+        if (key in shared) {
+            ids[key]?.let { return RefDto(it) }
+            // Assign the id BEFORE recursing so a (pathological) cycle degrades to a
+            // back-reference instead of hanging the encoder.
+            val id = ids.size
+            ids[key] = id
+            return DefDto(id, raw(element))
+        }
+        return raw(element)
+    }
+
+    fun type(type: WrappedType): TypeDto = element(type) as TypeDto
+
+    // NOTE: every branch encodes [modelFields] (constructor-argument order) before
+    // kids() — the canonical traversal order decode and the identity zip share.
+    private fun raw(element: WrappedElement): NodeDto {
+        val kids = { element.children.map { element(it) } }
+        return when (element) {
+            is WrappedType -> rawType(element, kids)
+
+            is WrappedTU -> TuDto(kids())
+
+            is WrappedNamespace -> NamespaceDto(element.namespace, kids())
+
+            is WrappedClass -> ClassDto(
+                element.name,
+                element.isAbstract,
+                element.specifiedType?.let(::type),
+                element.metadata.copy(),
+                kids()
+            )
+
+            is WrappedTemplate ->
+                TemplateDto(element.name, element.metadata.copy(), element.templateArgCounter, kids())
+
+            is WrappedTemplateParam ->
+                TemplateParamDto(element.name, element.usr, element.otherParams.map(::element), kids())
+
+            is WrappedTypedef -> TypedefDto(element.name, type(element.targetType), kids())
+
+            is WrappedBase ->
+                BaseDto(element.type?.let(::type), element.isPublic, element.isVirtualBase, kids())
+
+            // Order matters: WrappedConstructor/WrappedDestructor IS-A WrappedMethod.
+            is WrappedConstructor -> ConstructorDto(
+                element.name,
+                type(element.returnType),
+                element.isCopyConstructor,
+                element.isDefaultConstructor,
+                element.allocationStyle,
+                element.isVirtual,
+                element.isConst,
+                kids()
+            )
+
+            is WrappedDestructor ->
+                DestructorDto(element.name, type(element.returnType), element.isVirtual, kids())
+
+            is WrappedMethod -> MethodDto(
+                element.name,
+                type(element.returnType),
+                element.methodType,
+                element.isVirtual,
+                element.isConst,
+                element.returnsPairSecond,
+                element.returnViaMemberCall,
+                element.rangeElementType,
+                kids()
+            )
+
+            is WrappedArgument -> ArgumentDto(
+                element.name,
+                type(element.type),
+                element.usr,
+                element.hasDefault,
+                element.defaultValue,
+                kids()
+            )
+
+            is WrappedField -> FieldDto(element.name, type(element.type), kids())
+
+            // Fail loudly: a silently-dropped kind would surface as inexplicable codegen
+            // drift; an unknown kind means this schema needs a new DTO.
+            else -> throw IllegalArgumentException(
+                "No DTO mapping for element kind ${element::class}"
+            )
+        }
+    }
+
+    private fun rawType(t: WrappedType, kids: () -> List<NodeDto>): TypeDto = when (t) {
+        is WrappedTypeReference -> TypeRefDto(t.name, kids())
+
+        is WrappedModifiedType -> ModifiedTypeDto(type(t.baseType), t.modifier, kids())
+
+        is WrappedPrefixedType -> PrefixedTypeDto(type(t.baseType), t.modifier, kids())
+
+        is WrappedTemplateType ->
+            TemplateTypeDto(type(t.baseType), t.templateArgs.map(::type), kids())
+
+        is WrappedTemplateRef -> TemplateRefDto(t.target, kids())
+
+        is WrappedTypedefRef -> TypedefRefDto(t.usr, kids())
+
+        is WrappedTypename -> TypenameDto(t.target, kids())
+
+        is WrappedEnumType -> EnumTypeDto(t.cppName, type(t.underlying), t.constants, kids())
+
+        is WrappedFunctionPointer -> FunctionPointerDto(
+            t.cName,
+            type(t.returnType),
+            t.argTypes.map(::type),
+            t.cppName.takeIf { it != t.cName },
+            kids()
         )
 
-        is WrappedDestructor -> DestructorDto(name, returnType.toDto(), isVirtual, kids)
-
-        is WrappedMethod -> MethodDto(
-            name,
-            returnType.toDto(),
-            methodType,
-            isVirtual,
-            isConst,
-            returnsPairSecond,
-            returnViaMemberCall,
-            rangeElementType,
-            kids
-        )
-
-        is WrappedArgument -> ArgumentDto(name, type.toDto(), usr, hasDefault, defaultValue, kids)
-
-        is WrappedField -> FieldDto(name, type.toDto(), kids)
-
-        // Fail loudly: a silently-dropped kind would surface as inexplicable codegen
-        // drift; an unknown kind means this schema needs a new DTO.
-        else -> throw IllegalArgumentException("No DTO mapping for element kind ${this::class}")
+        else -> throw IllegalArgumentException("No DTO mapping for type kind ${t::class}")
     }
 }
 
-fun WrappedType.toDto(): TypeDto = toTypeDto(children.map { it.toDto() })
+private class ModelDecoder {
+    private val byId = HashMap<Int, WrappedElement>()
 
-private fun WrappedType.toTypeDto(kids: List<NodeDto>): TypeDto = when (this) {
-    is WrappedTypeReference -> TypeRefDto(name, kids)
+    fun element(dto: NodeDto): WrappedElement {
+        when (dto) {
+            is RefDto -> return byId[dto.id]
+                ?: throw IllegalArgumentException("Back-reference to undefined node ${dto.id}")
 
-    is WrappedModifiedType -> ModifiedTypeDto(baseType.toDto(), modifier, kids)
+            is DefDto -> return element(dto.node).also { byId[dto.id] = it }
 
-    is WrappedPrefixedType -> PrefixedTypeDto(baseType.toDto(), modifier, kids)
-
-    is WrappedTemplateType ->
-        TemplateTypeDto(baseType.toDto(), templateArgs.map { it.toDto() }, kids)
-
-    is WrappedTemplateRef -> TemplateRefDto(target, kids)
-
-    is WrappedTypedefRef -> TypedefRefDto(usr, kids)
-
-    is WrappedTypename -> TypenameDto(target, kids)
-
-    is WrappedEnumType -> EnumTypeDto(cppName, underlying.toDto(), constants, kids)
-
-    is WrappedFunctionPointer -> FunctionPointerDto(
-        cName,
-        returnType.toDto(),
-        argTypes.map { it.toDto() },
-        cppName.takeIf { it != cName },
-        kids
-    )
-
-    else -> throw IllegalArgumentException("No DTO mapping for type kind ${this::class}")
-}
-
-fun NodeDto.toModel(): WrappedElement {
-    val element = when (this) {
-        is TypeDto -> toType()
-
-        is TuDto -> WrappedTU()
-
-        is NamespaceDto -> WrappedNamespace(namespace)
-
-        is ClassDto -> WrappedClass(name, isAbstract, specifiedType?.toType()).also {
-            it.metadata = metadata.copy()
+            else -> {}
         }
+        val element = when (dto) {
+            is TypeDto -> rawType(dto)
 
-        is TemplateDto -> WrappedTemplate(name).also {
-            it.metadata = metadata.copy()
-            it.templateArgCounter = templateArgCounter
+            is TuDto -> WrappedTU()
+
+            is NamespaceDto -> WrappedNamespace(dto.namespace)
+
+            is ClassDto -> WrappedClass(dto.name, dto.isAbstract, dto.specifiedType?.let(::type))
+                .also { it.metadata = dto.metadata.copy() }
+
+            is TemplateDto -> WrappedTemplate(dto.name).also {
+                it.metadata = dto.metadata.copy()
+                it.templateArgCounter = dto.templateArgCounter
+            }
+
+            is TemplateParamDto -> WrappedTemplateParam(dto.name, dto.usr).also { param ->
+                param.otherParams.addAll(
+                    dto.otherParams.map { it.toParam() }
+                )
+            }
+
+            is TypedefDto -> WrappedTypedef(dto.name, type(dto.targetType))
+
+            is BaseDto -> WrappedBase(dto.type?.let(::type), dto.isPublic, dto.isVirtualBase)
+
+            is ConstructorDto -> WrappedConstructor(
+                dto.name,
+                type(dto.returnType),
+                dto.isCopyConstructor,
+                dto.isDefaultConstructor,
+                dto.allocationStyle
+            ).also {
+                it.isVirtual = dto.isVirtual
+                it.isConst = dto.isConst
+            }
+
+            is DestructorDto -> WrappedDestructor(dto.name, type(dto.returnType)).also {
+                it.isVirtual = dto.isVirtual
+            }
+
+            is MethodDto -> WrappedMethod(dto.name, type(dto.returnType), dto.methodType).also {
+                it.isVirtual = dto.isVirtual
+                it.isConst = dto.isConst
+                it.returnsPairSecond = dto.returnsPairSecond
+                it.returnViaMemberCall = dto.returnViaMemberCall
+                it.rangeElementType = dto.rangeElementType
+            }
+
+            is ArgumentDto ->
+                WrappedArgument(dto.name, type(dto.type), dto.usr, dto.hasDefault, dto.defaultValue)
+
+            is FieldDto -> WrappedField(dto.name, type(dto.type))
         }
-
-        is TemplateParamDto -> WrappedTemplateParam(name, usr).also { param ->
-            param.otherParams.addAll(otherParams.map { it.toModel() as WrappedTemplateParam })
-        }
-
-        is TypedefDto -> WrappedTypedef(name, targetType.toType())
-
-        is BaseDto -> WrappedBase(type?.toType(), isPublic, isVirtualBase)
-
-        is ConstructorDto -> WrappedConstructor(
-            name,
-            returnType.toType(),
-            isCopyConstructor,
-            isDefaultConstructor,
-            allocationStyle
-        ).also {
-            it.isVirtual = isVirtual
-            it.isConst = isConst
-        }
-
-        is DestructorDto -> WrappedDestructor(name, returnType.toType()).also {
-            it.isVirtual = isVirtual
-        }
-
-        is MethodDto -> WrappedMethod(name, returnType.toType(), methodType).also {
-            it.isVirtual = isVirtual
-            it.isConst = isConst
-            it.returnsPairSecond = returnsPairSecond
-            it.returnViaMemberCall = returnViaMemberCall
-            it.rangeElementType = rangeElementType
-        }
-
-        is ArgumentDto -> WrappedArgument(name, type.toType(), usr, hasDefault, defaultValue)
-
-        is FieldDto -> WrappedField(name, type.toType())
+        // Rebuild the tree (and thereby every parent back-link) bottom-up. NOTE:
+        // base-class addAllChildren appends + re-parents WITHOUT the subclass addChild
+        // hooks, so the template param-merge logic doesn't re-fire on already-merged
+        // children, and re-adding an identity-shared node under its second parent
+        // re-points its parent the same way the original parse did (last add wins).
+        element.addAllChildren(dto.children.map { element(it) })
+        return element
     }
-    // Rebuild the tree (and thereby every parent back-link) bottom-up. NOTE: base-class
-    // addAllChildren appends + re-parents WITHOUT the subclass addChild hooks, so the
-    // template param-merge logic doesn't re-fire on already-merged children.
-    element.addAllChildren(children.map { it.toModel() })
-    return element
-}
 
-fun TypeDto.toType(): WrappedType {
-    val type = when (this) {
-        is TypeRefDto -> WrappedTypeReference(name)
+    fun type(dto: TypeDto): WrappedType = element(dto) as? WrappedType
+        ?: throw IllegalArgumentException("Expected a type at ${dto::class}")
 
-        is ModifiedTypeDto -> WrappedModifiedType(baseType.toType(), modifier)
+    private fun NodeDto.toParam(): WrappedTemplateParam = element(this) as? WrappedTemplateParam
+        ?: throw IllegalArgumentException("Expected a template param at ${this::class}")
 
-        is PrefixedTypeDto -> WrappedPrefixedType(baseType.toType(), modifier)
+    private fun rawType(dto: TypeDto): WrappedType = when (dto) {
+        is TypeRefDto -> WrappedTypeReference(dto.name)
+
+        is ModifiedTypeDto -> WrappedModifiedType(type(dto.baseType), dto.modifier)
+
+        is PrefixedTypeDto -> WrappedPrefixedType(type(dto.baseType), dto.modifier)
 
         is TemplateTypeDto ->
-            WrappedTemplateType(baseType.toType(), templateArgs.map { it.toType() })
+            WrappedTemplateType(type(dto.baseType), dto.templateArgs.map(::type))
 
-        is TemplateRefDto -> WrappedTemplateRef(target)
+        is TemplateRefDto -> WrappedTemplateRef(dto.target)
 
-        is TypedefRefDto -> WrappedTypedefRef(usr)
+        is TypedefRefDto -> WrappedTypedefRef(dto.usr)
 
-        is TypenameDto -> WrappedTypename(target)
+        is TypenameDto -> WrappedTypename(dto.target)
 
-        is EnumTypeDto -> WrappedEnumType(cppName, underlying.toType(), constants)
+        is EnumTypeDto -> WrappedEnumType(dto.cppName, type(dto.underlying), dto.constants)
 
         is FunctionPointerDto -> WrappedFunctionPointer(
-            cName,
-            returnType.toType(),
-            argTypes.map { it.toType() },
-            cppName ?: cName
+            dto.cName,
+            type(dto.returnType),
+            dto.argTypes.map(::type),
+            dto.cppName ?: dto.cName
         )
+
+        is DefDto, is RefDto -> error("def/ref handled in element()")
     }
-    type.addAllChildren(children.map { it.toModel() })
-    return type
+}
+
+/**
+ * Walk [original] and [restored] (its round-tripped copy) in lockstep and emit every
+ * (original, restored) instance pair exactly once — identity-shared originals pair with
+ * their single restored alias. The oracle harness uses this to point the cross-parse
+ * cursor->element memo at the restored instances, so post-round-trip parses keep
+ * accumulating state on the SAME objects resolution sees, exactly like a non-flag run.
+ */
+fun forEachIdentityPair(
+    original: WrappedElement,
+    restored: WrappedElement,
+    onPair: (WrappedElement, WrappedElement) -> Unit
+) {
+    val seen = HashSet<ElementIdentity>()
+
+    fun visit(old: WrappedElement, new: WrappedElement) {
+        if (!seen.add(ElementIdentity(old))) return
+        onPair(old, new)
+        val oldFields = old.modelFields()
+        val newFields = new.modelFields()
+        require(oldFields.size == newFields.size && old.children.size == new.children.size) {
+            "Round-trip shape mismatch at $old"
+        }
+        oldFields.zip(newFields).forEach { (o, n) -> visit(o, n) }
+        old.children.zip(new.children).forEach { (o, n) -> visit(o, n) }
+    }
+    visit(original, restored)
 }
 
 object ModelIo {
@@ -427,8 +602,8 @@ object ModelIo {
     }
 
     fun encodeToString(tu: WrappedTU): String =
-        json.encodeToString(NodeDto.serializer(), tu.toDto())
+        json.encodeToString(NodeDto.serializer(), ModelEncoder(collectShared(tu)).element(tu))
 
     fun decodeFromString(text: String): WrappedTU =
-        json.decodeFromString(NodeDto.serializer(), text).toModel() as WrappedTU
+        ModelDecoder().element(json.decodeFromString(NodeDto.serializer(), text)) as WrappedTU
 }

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
@@ -231,24 +231,18 @@ data class TemplateTypeDto(
 
 @Serializable
 @SerialName("t.tref")
-data class TemplateRefDto(
-    val target: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TemplateRefDto(val target: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.typedef")
-data class TypedefRefDto(
-    val usr: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TypedefRefDto(val usr: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.typename")
-data class TypenameDto(
-    val target: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TypenameDto(val target: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.enum")
@@ -370,10 +364,20 @@ private class ModelEncoder(private val shared: Set<ElementIdentity>) {
             )
 
             is WrappedTemplate ->
-                TemplateDto(element.name, element.metadata.copy(), element.templateArgCounter, kids())
+                TemplateDto(
+                    element.name,
+                    element.metadata.copy(),
+                    element.templateArgCounter,
+                    kids()
+                )
 
             is WrappedTemplateParam ->
-                TemplateParamDto(element.name, element.usr, element.otherParams.map(::element), kids())
+                TemplateParamDto(
+                    element.name,
+                    element.usr,
+                    element.otherParams.map(::element),
+                    kids()
+                )
 
             is WrappedTypedef -> TypedefDto(element.name, type(element.targetType), kids())
 

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
@@ -68,10 +68,8 @@ data class TuDto(override val children: List<NodeDto> = emptyList()) : NodeDto()
 
 @Serializable
 @SerialName("ns")
-data class NamespaceDto(
-    val namespace: String,
-    override val children: List<NodeDto> = emptyList()
-) : NodeDto()
+data class NamespaceDto(val namespace: String, override val children: List<NodeDto> = emptyList()) :
+    NodeDto()
 
 @Serializable
 @SerialName("cls")
@@ -182,10 +180,8 @@ sealed class TypeDto : NodeDto()
 
 @Serializable
 @SerialName("t.ref")
-data class TypeRefDto(
-    val name: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TypeRefDto(val name: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.mod")
@@ -213,24 +209,18 @@ data class TemplateTypeDto(
 
 @Serializable
 @SerialName("t.tref")
-data class TemplateRefDto(
-    val target: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TemplateRefDto(val target: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.typedef")
-data class TypedefRefDto(
-    val usr: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TypedefRefDto(val usr: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.typename")
-data class TypenameDto(
-    val target: String,
-    override val children: List<NodeDto> = emptyList()
-) : TypeDto()
+data class TypenameDto(val target: String, override val children: List<NodeDto> = emptyList()) :
+    TypeDto()
 
 @Serializable
 @SerialName("t.enum")
@@ -256,14 +246,22 @@ fun WrappedElement.toDto(): NodeDto {
     val kids = children.map { it.toDto() }
     return when (this) {
         is WrappedType -> toTypeDto(kids)
+
         is WrappedTU -> TuDto(kids)
+
         is WrappedNamespace -> NamespaceDto(namespace, kids)
+
         is WrappedClass -> ClassDto(name, isAbstract, specifiedType?.toDto(), metadata.copy(), kids)
+
         is WrappedTemplate -> TemplateDto(name, metadata.copy(), templateArgCounter, kids)
+
         is WrappedTemplateParam ->
             TemplateParamDto(name, usr, otherParams.map { it.toDto() as TemplateParamDto }, kids)
+
         is WrappedTypedef -> TypedefDto(name, targetType.toDto(), kids)
+
         is WrappedBase -> BaseDto(type?.toDto(), isPublic, isVirtualBase, kids)
+
         // Order matters: WrappedConstructor/WrappedDestructor IS-A WrappedMethod.
         is WrappedConstructor -> ConstructorDto(
             name,
@@ -275,7 +273,9 @@ fun WrappedElement.toDto(): NodeDto {
             isConst,
             kids
         )
+
         is WrappedDestructor -> DestructorDto(name, returnType.toDto(), isVirtual, kids)
+
         is WrappedMethod -> MethodDto(
             name,
             returnType.toDto(),
@@ -287,8 +287,11 @@ fun WrappedElement.toDto(): NodeDto {
             rangeElementType,
             kids
         )
+
         is WrappedArgument -> ArgumentDto(name, type.toDto(), usr, hasDefault, defaultValue, kids)
+
         is WrappedField -> FieldDto(name, type.toDto(), kids)
+
         // Fail loudly: a silently-dropped kind would surface as inexplicable codegen
         // drift; an unknown kind means this schema needs a new DTO.
         else -> throw IllegalArgumentException("No DTO mapping for element kind ${this::class}")
@@ -299,14 +302,22 @@ fun WrappedType.toDto(): TypeDto = toTypeDto(children.map { it.toDto() })
 
 private fun WrappedType.toTypeDto(kids: List<NodeDto>): TypeDto = when (this) {
     is WrappedTypeReference -> TypeRefDto(name, kids)
+
     is WrappedModifiedType -> ModifiedTypeDto(baseType.toDto(), modifier, kids)
+
     is WrappedPrefixedType -> PrefixedTypeDto(baseType.toDto(), modifier, kids)
+
     is WrappedTemplateType ->
         TemplateTypeDto(baseType.toDto(), templateArgs.map { it.toDto() }, kids)
+
     is WrappedTemplateRef -> TemplateRefDto(target, kids)
+
     is WrappedTypedefRef -> TypedefRefDto(usr, kids)
+
     is WrappedTypename -> TypenameDto(target, kids)
+
     is WrappedEnumType -> EnumTypeDto(cppName, underlying.toDto(), constants, kids)
+
     is WrappedFunctionPointer -> FunctionPointerDto(
         cName,
         returnType.toDto(),
@@ -314,26 +325,35 @@ private fun WrappedType.toTypeDto(kids: List<NodeDto>): TypeDto = when (this) {
         cppName.takeIf { it != cName },
         kids
     )
+
     else -> throw IllegalArgumentException("No DTO mapping for type kind ${this::class}")
 }
 
 fun NodeDto.toModel(): WrappedElement {
     val element = when (this) {
         is TypeDto -> toType()
+
         is TuDto -> WrappedTU()
+
         is NamespaceDto -> WrappedNamespace(namespace)
+
         is ClassDto -> WrappedClass(name, isAbstract, specifiedType?.toType()).also {
             it.metadata = metadata.copy()
         }
+
         is TemplateDto -> WrappedTemplate(name).also {
             it.metadata = metadata.copy()
             it.templateArgCounter = templateArgCounter
         }
+
         is TemplateParamDto -> WrappedTemplateParam(name, usr).also { param ->
             param.otherParams.addAll(otherParams.map { it.toModel() as WrappedTemplateParam })
         }
+
         is TypedefDto -> WrappedTypedef(name, targetType.toType())
+
         is BaseDto -> WrappedBase(type?.toType(), isPublic, isVirtualBase)
+
         is ConstructorDto -> WrappedConstructor(
             name,
             returnType.toType(),
@@ -344,9 +364,11 @@ fun NodeDto.toModel(): WrappedElement {
             it.isVirtual = isVirtual
             it.isConst = isConst
         }
+
         is DestructorDto -> WrappedDestructor(name, returnType.toType()).also {
             it.isVirtual = isVirtual
         }
+
         is MethodDto -> WrappedMethod(name, returnType.toType(), methodType).also {
             it.isVirtual = isVirtual
             it.isConst = isConst
@@ -354,7 +376,9 @@ fun NodeDto.toModel(): WrappedElement {
             it.returnViaMemberCall = returnViaMemberCall
             it.rangeElementType = rangeElementType
         }
+
         is ArgumentDto -> WrappedArgument(name, type.toType(), usr, hasDefault, defaultValue)
+
         is FieldDto -> WrappedField(name, type.toType())
     }
     // Rebuild the tree (and thereby every parent back-link) bottom-up. NOTE: base-class
@@ -367,14 +391,22 @@ fun NodeDto.toModel(): WrappedElement {
 fun TypeDto.toType(): WrappedType {
     val type = when (this) {
         is TypeRefDto -> WrappedTypeReference(name)
+
         is ModifiedTypeDto -> WrappedModifiedType(baseType.toType(), modifier)
+
         is PrefixedTypeDto -> WrappedPrefixedType(baseType.toType(), modifier)
+
         is TemplateTypeDto ->
             WrappedTemplateType(baseType.toType(), templateArgs.map { it.toType() })
+
         is TemplateRefDto -> WrappedTemplateRef(target)
+
         is TypedefRefDto -> WrappedTypedefRef(usr)
+
         is TypenameDto -> WrappedTypename(target)
+
         is EnumTypeDto -> WrappedEnumType(cppName, underlying.toType(), constants)
+
         is FunctionPointerDto -> WrappedFunctionPointer(
             cName,
             returnType.toType(),

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
@@ -18,6 +18,7 @@ package com.monkopedia.krapper.generator.model
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.ALIGN_OF
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType.SIZE_OF
+import kotlinx.serialization.Serializable
 
 class WrappedBase(
     val type: WrappedType?,
@@ -29,6 +30,7 @@ class WrappedBase(
     }
 }
 
+@Serializable
 data class ClassMetadata(
     var hasHiddenNew: Boolean = false,
     var hasHiddenDelete: Boolean = false,

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedEnumType.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedEnumType.kt
@@ -15,7 +15,10 @@
  */
 package com.monkopedia.krapper.generator.model.type
 
+import kotlinx.serialization.Serializable
+
 /** One constant of a C/C++ enum: its declared name and integer value. */
+@Serializable
 data class WrappedEnumConstant(val name: String, val value: Long)
 
 /**

--- a/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
+++ b/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator.model
+
+import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
+import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateRef
+import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.model.type.WrappedTypedefRef
+import com.monkopedia.krapper.generator.resolvedmodel.AllocationStyle.STACK
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Fast structural signal for the ModelIo round-trip: a hand-built model exercising every
+ * node kind survives encode -> decode with state, tree shape, and parent back-links
+ * intact. The REAL gate is the featuregen oracle (`KRAPPER_ROUNDTRIP_MODEL=1` sync must
+ * be byte-identical), which covers the full parse surface; this test pins the basics and
+ * fails fast on schema regressions.
+ */
+class ModelIoTest {
+
+    private fun buildModel(): WrappedTU {
+        val tu = WrappedTU()
+        val ns = WrappedNamespace("demo")
+        tu.addChild(ns)
+
+        val cls = WrappedClass("Thing", isAbstract = true)
+        cls.metadata.hasConstructor = true
+        cls.metadata.hasDeletedCopyConstructor = true
+        ns.addChild(cls)
+        cls.addChild(WrappedBase(WrappedType("demo::Base"), isPublic = false, isVirtualBase = true))
+        cls.addChild(WrappedField("count", WrappedType("int")))
+
+        val method = WrappedMethod(
+            "lookup",
+            WrappedType.referenceTo(WrappedType.const(WrappedType("std::string"))),
+            MethodType.METHOD
+        )
+        method.isVirtual = true
+        method.isConst = true
+        method.returnsPairSecond = true
+        method.returnViaMemberCall = ".str()"
+        method.rangeElementType = "clang::Decl"
+        method.addChild(
+            WrappedArgument(
+                "key",
+                WrappedType("int"),
+                "c:@key",
+                hasDefault = true,
+                defaultValue = "10"
+            )
+        )
+        method.addChild(
+            WrappedArgument(
+                "cb",
+                WrappedFunctionPointer(
+                    "Transform",
+                    WrappedType("int"),
+                    listOf(WrappedType("int")),
+                    "demo::Transform"
+                )
+            )
+        )
+        method.addChild(
+            WrappedArgument(
+                "items",
+                WrappedTemplateType(
+                    WrappedType("std::vector"),
+                    listOf(WrappedType.pointerTo(WrappedType("int")))
+                )
+            )
+        )
+        method.addChild(
+            WrappedArgument(
+                "color",
+                WrappedEnumType(
+                    "demo::Color",
+                    WrappedType("int"),
+                    listOf(WrappedEnumConstant("RED", 1))
+                )
+            )
+        )
+        cls.addChild(method)
+
+        val ctor = WrappedConstructor(
+            "Thing",
+            WrappedType.VOID,
+            isCopyConstructor = true,
+            isDefaultConstructor = false,
+            allocationStyle = STACK
+        )
+        cls.addChild(ctor)
+        cls.addChild(WrappedDestructor("~Thing", WrappedType.VOID).also { it.isVirtual = true })
+
+        val template = WrappedTemplate("Box")
+        template.metadata.hasDefaultConstructor = true
+        ns.addChild(template)
+        val param = WrappedTemplateParam("T", "c:@T")
+        param.addChild(WrappedType("int"))
+        param.addChild(WrappedTemplateRef("T"))
+        template.addChild(param)
+        // A merged same-name param lands in otherParams (outside children) — reset the
+        // merge cursor the way mapAll does when a template's declaration re-appears.
+        template.templateArgCounter = 0
+        template.addChild(WrappedTemplateParam("T", "c:@T2"))
+
+        ns.addChild(WrappedTypedef("id_t", WrappedTypedefRef("c:@id")))
+        return tu
+    }
+
+    @Test
+    fun roundTrip_isStable() {
+        val tu = buildModel()
+        val json = ModelIo.encodeToString(tu)
+        val restored = ModelIo.decodeFromString(json)
+        // Re-encoding the restored model must reproduce the identical JSON — every field
+        // either survived or was never captured, and this catches the former.
+        assertEquals(json, ModelIo.encodeToString(restored))
+    }
+
+    @Test
+    fun roundTrip_restoresStateAndParents() {
+        val restored = ModelIo.decodeFromString(ModelIo.encodeToString(buildModel()))
+
+        val ns = assertIs<WrappedNamespace>(restored.children.single())
+        assertSame(restored, ns.parent)
+        val cls = assertIs<WrappedClass>(ns.children[0])
+        assertSame(ns, cls.parent)
+        assertEquals("demo::Thing", cls.qualified)
+        assertTrue(cls.isAbstract)
+        assertTrue(cls.metadata.hasConstructor)
+        assertTrue(cls.metadata.hasDeletedCopyConstructor)
+
+        val base = assertIs<WrappedBase>(cls.children[0])
+        assertTrue(base.isVirtualBase)
+        assertEquals(false, base.isPublic)
+        assertEquals("demo::Base", base.type.toString())
+
+        val method = cls.children.filterIsInstance<WrappedMethod>()
+            .first { it.methodType == MethodType.METHOD }
+        assertSame(cls, method.parent)
+        assertEquals("const std::string&", method.returnType.toString())
+        assertTrue(method.isVirtual)
+        assertTrue(method.isConst)
+        assertTrue(method.returnsPairSecond)
+        assertEquals(".str()", method.returnViaMemberCall)
+        assertEquals("clang::Decl", method.rangeElementType)
+        val args = method.args
+        assertEquals(listOf("key", "cb", "items", "color"), args.map { it.name })
+        assertSame(method, args[0].parent)
+        assertEquals("c:@key", args[0].usr)
+        assertTrue(args[0].hasDefault)
+        assertEquals("10", args[0].defaultValue)
+        val fnPtr = assertIs<WrappedFunctionPointer>(args[1].type)
+        assertEquals("demo::Transform", fnPtr.cppName)
+        val vec = assertIs<WrappedTemplateType>(args[2].type)
+        assertEquals("std::vector<int*>", vec.toString())
+        val enum = assertIs<WrappedEnumType>(args[3].type)
+        assertEquals(listOf(WrappedEnumConstant("RED", 1)), enum.constants)
+
+        val ctor = cls.children.filterIsInstance<WrappedConstructor>().single()
+        assertTrue(ctor.isCopyConstructor)
+        assertEquals(false, ctor.isDefaultConstructor)
+        assertEquals(STACK, ctor.allocationStyle)
+        assertTrue(cls.children.filterIsInstance<WrappedDestructor>().single().isVirtual)
+
+        val template = assertIs<WrappedTemplate>(ns.children[1])
+        assertTrue(template.metadata.hasDefaultConstructor)
+        val param = template.templateArgs.single()
+        assertEquals("c:@T", param.usr)
+        // The merged sibling param survives in otherParams, and the default-type children
+        // (a WrappedType + a WrappedTemplateRef) survive as children of the param.
+        assertEquals(listOf("c:@T2"), param.otherParams.map { it.usr })
+        assertEquals("int<template<T>>", param.defaultType.toString())
+
+        val typedef = assertIs<WrappedTypedef>(ns.children[2])
+        assertEquals("unresolved_typedef(c:@id)", typedef.targetType.toString())
+    }
+}

--- a/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
+++ b/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
@@ -177,6 +177,9 @@ class ModelIoTest {
         assertEquals("std::vector<int*>", vec.toString())
         val enum = assertIs<WrappedEnumType>(args[3].type)
         assertEquals(listOf(WrappedEnumConstant("RED", 1)), enum.constants)
+        // Identity preservation: both `int` uses were ONE interned instance in the
+        // original model, so the DAG encode (def/ref) must restore them as ONE instance.
+        assertSame(args[0].type, enum.underlying)
 
         val ctor = cls.children.filterIsInstance<WrappedConstructor>().single()
         assertTrue(ctor.isCopyConstructor)


### PR DESCRIPTION
Phase C brick 1 of #45: full-fidelity `WrappedTU` round-trip serialization — the foundation of the `--frontend=cpp` handoff. Serialize a parsed WrappedTU to JSON, deserialize it back, and the pipeline produces **byte-identical** output.

## THE ORACLE RESULT

`featuregen kplusplusSync` run with the round-trip ON is **byte-identical** to the committed flag-off output, across the header import + all 17 instantiations (string/vector/map/set/pair/unordered/unique_ptr/Box/Pair2 — 18 parses, largest per-parse payload 1.8 MB JSON):

```
# via gradle (env var survives the single-use daemon):
KRAPPER_ROUNDTRIP_MODEL=1 ./gradlew --no-daemon :featuregen:kplusplusSync
# engagement-proof run (gradle 9 swallows the spawned kexe's stdout), same args the
# plugin passes, logging 18/18 "Round-tripped parsed model through ModelIo JSON":
KRAPPER_ROUNDTRIP_MODEL=1 krapper_gen.kexe featuregen -r INCLUDE_MISSING ... --header strings_feature.h --instantiate ... -o featuregen/krapped
diff -r <flag-off snapshot> featuregen/krapped   # -> empty, byte-identical
```

Also verified: flag-OFF output is byte-identical to main's (the schema additions alone change nothing).

## What the oracle caught (and the design that fixes it)

The first oracle run drifted massively — and not from a missing field: **instance identity is part of the model.** The parse output is a DAG (one element under two parents; interned/memoized types shared by every use site), elements are memoized ACROSS parses (`elementLookup`), and resolution MUTATES them in place (metadata flags, synthetic sizeOf/alignOf children, const-overload dedup, allocationStyle). A naive value-tree encode duplicated aliases and severed cross-parse identity (visible as runaway `_..._size_of` duplicate accumulation differences and a Drawable dispose delta). Decisions:

- **DAG-aware encoding**: pass 1 collects identity-shared nodes; the first occurrence is wrapped in `DefDto(id)`, later occurrences collapse to `RefDto(id)` back-references; decode rebuilds the exact aliasing. Encode/decode share one canonical traversal (fields, then children) so definitions always precede references.
- **Cross-parse identity (oracle harness only)**: `WrappedElement.remapMemoized` lockstep-walks original/restored trees (`forEachIdentityPair`) and points the cursor→element memo at the restored instances, so later parses accumulate state on the same objects resolution sees — exactly like a non-flag run. The production `--frontend=cpp` handoff will need stable cross-TU identities in the format itself (the USR→stable-Decl-key probe, next on #45).
- **Parent back-links**: not serialized; rebuilt bottom-up via `addAllChildren` (which re-parents every child), so the cycle never reaches the encoder.
- **DTO mirror, not `@Serializable` on the model**: the element classes carry a private base-constructor children list, parent links, non-constructor mutable state and caches; the mirror keeps the model untouched (flag-off provably unchanged) and doubles as the explicit, reviewable schema. Every field the ModelResolution.kt when-dispatch consumes is carried (incl. method flags, ClassMetadata, allocationStyle, template merge counter + `otherParams`, argument defaults/USRs, the full WrappedType hierarchy with enum constants and function-pointer cName/cppName).
- **Type interning**: `GenerationContext.internedTypes` only ever caches plain `WrappedTypeReference`s (value-equal data class) — referential identity of types is not load-bearing for equality, and within-model type aliasing is preserved by the def/ref encoding, so decode doesn't touch the intern cache.
- **Hook placement**: same point as `--dumpParsedModel` (post-reduce, pre-rewrites) — the rewrites replace method children with copies, so they must run on the restored tree to keep the memo and live tree aligned.

## Wiring

- `:krapper_model` `ModelIo.kt`: schema + `ModelIo.encodeToString` / `ModelIo.decodeFromString` — the deserialize entry point the future `--frontend=cpp` path consumes.
- `krapper_gen --roundTripModel` flag, or `KRAPPER_ROUNDTRIP_MODEL=1` env (reaches service-mode/plugin-spawned runs).
- `ModelIoTest` (new, 2 tests): hand-built model covering every node kind — JSON-stability + state/parents/aliasing restoration.

## Verify

- `:krapper_gen:nativeTest` 311/0, `:featuregen:nativeTest` 188/0, `:krapper_model:build` (+2 new tests), `:featuregen:kplusplusSync`, `:krapper_gen:ktlintCheck` — all green (JDK 17).
- Flag-off krapped/ byte-identical to main; flag-on byte-identical with 18/18 parses round-tripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
