### PR TITLE
krapper_gen --frontend=cpp: THE HANDOFF — resolve+codegen on a cppfrontend-produced WrappedTU (#45 brick 2)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -255,3 +255,50 @@ tasks.register<Exec>("goldenCompare") {
         File(goldenDir, "libclang.json").absolutePath
     )
 }
+
+// ---- #45 brick 2: THE HANDOFF (Phase C) ----
+// The first time generated-bindings-parsed C++ flows through krapper_gen's REAL pipeline:
+//   goldenEmit       — the cppfrontend binary parses the fixture with the Clang C++ AST
+//                      and writes model.json (full-fidelity ModelIo JSON) next to the
+//                      compare projection;
+//   handoffGenerate  — krapper_gen --frontend=cpp loads that model (libclang parse
+//                      SKIPPED), runs resolution + codegen, emits the Kotlin bindings +
+//                      C++ wrapper for the fixture, and COMPILES the wrapper against
+//                      fixture.h (writeTo's CppCompiler step — clang++ -c; a non-zero
+//                      exit fails the task), proving the handed-off model carries
+//                      everything the real pipeline consumes.
+// --instantiate is scoped out on this path (forcing re-parses synthesized headers
+// through libclang); the fixture needs no instantiations. Gated with the module
+// (-PenableClang), like the golden tasks above.
+val handoffDir = layout.buildDirectory.dir("handoff").get().asFile
+
+tasks.register<Exec>("handoffGenerate") {
+    dependsOn(goldenEmit, ":krapper_gen:linkReleaseExecutableNative")
+    doFirst { handoffDir.mkdirs() }
+    commandLine(
+        krapperGenKexe.absolutePath,
+        "-h",
+        File(goldenDir, "fixture.h").absolutePath,
+        // Same standard pin as goldenDump: the wrapper compile must match the parse.
+        "--std",
+        "c++17",
+        "--frontend",
+        "cpp",
+        "--parsedModel",
+        File(goldenDir, "model.json").absolutePath,
+        "-o",
+        handoffDir.absolutePath,
+        "fixture"
+    )
+    doLast {
+        // The run already failed on any resolve/codegen/compile error; assert the
+        // artifacts the next phase consumes actually materialized.
+        val expected = listOf("fixture.h", "fixture.cc", "fixture.def", "libfixture.a")
+        val missing = expected.filter { !File(handoffDir, it).exists() }
+        check(missing.isEmpty()) { "handoffGenerate: missing generated artifact(s): $missing" }
+        val kotlinFiles = File(handoffDir, "src").walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }.toList()
+        check(kotlinFiles.isNotEmpty()) { "handoffGenerate: no Kotlin bindings generated" }
+        println("handoffGenerate: generated " + (expected + kotlinFiles.map { it.name }))
+    }
+}

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import clang.tooling.buildASTFromCode
+import com.monkopedia.krapper.generator.model.ModelIo
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.model.WrappedConstructor
@@ -206,7 +207,16 @@ fun main(args: Array<String>): Unit = memScoped {
         // front-end just consumed (buildASTFromCode above) — the one-source guarantee.
         writeFile("$dir/fixture.h", FIXTURE_HEADER + "\n")
         writeFile("$dir/cpp.json", Json.encodeToString(tu.serialized()))
-        println("cppfrontend: golden emit -> $dir/fixture.h + $dir/cpp.json")
+        // #45 brick 2 (THE HANDOFF): alongside the lossy-by-design compare projection
+        // above, emit the FULL-fidelity ModelIo round-trip JSON — the --frontend=cpp
+        // handoff format krapper_gen loads to run resolution+codegen on this tree.
+        // ModelIo's encoder is DAG-aware (Def/Ref), so any element/type instances this
+        // front-end shares across use sites encode as back-references, exactly like a
+        // libclang-built tree's interned types.
+        writeFile("$dir/model.json", ModelIo.encodeToString(tu))
+        println(
+            "cppfrontend: golden emit -> $dir/fixture.h + $dir/cpp.json + $dir/model.json"
+        )
         return@memScoped
     }
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -68,6 +68,19 @@ val ErrorPolicy.policy: CodeGenerationPolicy
 typealias ErrorPolicy = com.monkopedia.krapper.ErrorPolicy
 typealias ReferencePolicy = com.monkopedia.krapper.ReferencePolicy
 
+/** Which parser front-end produces the parse-output model (#45 brick 2). */
+enum class Frontend {
+    /** The libclang-C reducer: parse --header in-process (the historical path). */
+    LIBCLANG,
+
+    /**
+     * THE HANDOFF: skip the libclang parse and load the WrappedTU from --parsedModel —
+     * the full-fidelity ModelIo JSON emitted by the cppfrontend binary (the front-end
+     * built on kplusplus-generated libclang-cpp bindings).
+     */
+    CPP
+}
+
 class KrapperGen : CliktCommand() {
     val header by option(
         "-h",
@@ -174,6 +187,22 @@ class KrapperGen : CliktCommand() {
             "--frontend=cpp handoff format. Also enabled by KRAPPER_ROUNDTRIP_MODEL=1 " +
             "in the environment (which reaches service-mode runs too)."
     ).flag()
+    val frontend by option(
+        "--frontend",
+        help = "Which front-end produces the parse-output model (#45 brick 2): " +
+            "'libclang' (default — parse --header in-process with the libclang-C " +
+            "reducer) or 'cpp' (SKIP the libclang parse and load the WrappedTU from " +
+            "--parsedModel, the full-fidelity ModelIo JSON emitted by the cppfrontend " +
+            "binary). With cpp, --header is NOT parsed — it still supplies the " +
+            "#include list for the generated C++ wrapper. --instantiate is not yet " +
+            "supported with cpp (instantiation forcing re-parses synthesized headers " +
+            "through libclang)."
+    ).enum<Frontend>().default(Frontend.LIBCLANG)
+    val parsedModel by option(
+        "--parsedModel",
+        help = "Path to the ModelIo JSON WrappedTU to load when --frontend=cpp " +
+            "(required in that mode; ignored otherwise)."
+    )
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -191,6 +220,20 @@ class KrapperGen : CliktCommand() {
         // resolution/generation flow below never runs with the flag set.
         dumpParsedModelPath = dumpParsedModel
         if (roundTripModel) roundTripParsedModel = true
+        // THE HANDOFF (#45 brick 2): arm the cpp-front-end hook in Parsing.kt. The
+        // pipeline below is otherwise unchanged — parseHeader returns a ParsedResolver
+        // over the LOADED tree instead of a libclang parse, and resolution+codegen run
+        // exactly as the --roundTripModel oracle proved they can on a decoded model.
+        if (frontend == Frontend.CPP) {
+            require(instantiate.isEmpty()) {
+                "--frontend=cpp does not support --instantiate yet: instantiation " +
+                    "forcing synthesizes a forcing header and re-parses it through " +
+                    "libclang (IndexedServiceImpl.requestInstantiation), which the cpp " +
+                    "front-end path skips. Scoped out of #45 brick 2."
+            }
+            cppParsedModelPath = parsedModel
+                ?: error("--frontend=cpp requires --parsedModel <path>")
+        }
         runBlocking {
             val service = KrapperServiceImpl()
             val resolvedModule = moduleName

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -134,6 +134,17 @@ var dumpParsedModelPath: String? = null
 var roundTripParsedModel: Boolean =
     getenv("KRAPPER_ROUNDTRIP_MODEL")?.toKString() == "1"
 
+// THE HANDOFF (#45 brick 2), set by KrapperGen --frontend=cpp --parsedModel <path>.
+// When non-null, [parseHeader] SKIPS the libclang parse entirely and instead loads the
+// WrappedTU from this path — the full-fidelity ModelIo JSON the cppfrontend binary
+// emitted from the Clang C++ AST (on kplusplus-generated bindings). The loaded tree
+// enters the pipeline at the exact post-parse point the --roundTripModel oracle proved
+// (brick 1): the pre-resolution rewrites below run on it, then ParsedResolver wraps it.
+// CLI-scoped global (same rationale as [dumpParsedModelPath]): the ksrpc service schema
+// stays untouched. The libclang cinterop remains LINKED into the binary — flip/deletion
+// is Phase E; what matters here is the cpp path never CALLS it.
+var cppParsedModelPath: String? = null
+
 fun FilterDefinition.wrapperFilter(): (WrappedElement) -> Boolean {
     return when (this) {
         is AndFilter -> {
@@ -563,6 +574,20 @@ suspend fun DeferScope.parseHeader(
     // diagnostics abort. See [handleDiagnostics].
     strictDiagnostics: Boolean = false
 ): Resolver {
+    // THE HANDOFF (#45 brick 2): with --frontend=cpp the model was already produced by
+    // the cppfrontend binary; decode it and skip the libclang parse below entirely. No
+    // cursor->element memo exists on this path (nothing was parsed in-process), and no
+    // memo is needed: the CLI forbids --instantiate with this front-end (instantiation
+    // forcing re-parses synthesized headers with libclang — see KrapperGen.run), so no
+    // later parse ever needs to rediscover these instances. The pre-resolution rewrites
+    // run on the loaded tree exactly as they do on a --roundTripModel restored tree.
+    cppParsedModelPath?.let { path ->
+        val restored = ModelIo.decodeFromString(File(path).readText())
+        Log.i("cpp front-end handoff: loaded parsed model from $path (libclang parse skipped)")
+        rewriteViewReturns(restored)
+        rewriteUniquePtrReturns(restored)
+        return ParsedResolver(restored)
+    }
     val builder = ResolverBuilderImpl()
     val tu = file.map {
         parseHeader(index, it, builder, includePaths, args, debug, strictDiagnostics)


### PR DESCRIPTION
#45 Phase C brick 2 — THE HANDOFF: krapper_gen consumes a WrappedTU produced by the cpp front-end and runs its real pipeline on it. First time generated-bindings-parsed C++ flows through resolve+codegen.

## Pipeline

`cppfrontend (Clang C++ AST on generated bindings) → model.json (full-fidelity ModelIo JSON) → krapper_gen --frontend=cpp --parsedModel (libclang parse SKIPPED) → resolve → codegen → clang++ compiles the wrapper`

## What changed

- **cppfrontend**: `--golden-emit` now also writes `model.json` = `ModelIo.encodeToString(tu)` (the handoff format), alongside the lossy compare projection. ModelIo's DAG-aware Def/Ref encoding handles any instance sharing the same way it does libclang-interned types — no cppfrontend/ModelIo gaps surfaced; nothing needed fixing en route.
- **krapper_gen**: `--frontend={libclang|cpp}` (default libclang, default behavior bit-for-bit unchanged) + `--parsedModel <path>` (required with cpp). The hook sits at the top of `parseHeader`: decode → `rewriteViewReturns`/`rewriteUniquePtrReturns` on the loaded tree → `ParsedResolver` — the exact post-parse entry point the `--roundTripModel` oracle (brick 1) proved. CLI-scoped global like `dumpParsedModelPath`; ksrpc service schema untouched. libclang stays LINKED, just never CALLED on this path (flip/deletion is Phase E).
- **`:cppfrontend:handoffGenerate`** (gated, `-PenableClang`): the end-to-end proof. krapper_gen runs to completion on the cpp-front-end model and `writeTo`'s CppCompiler step compiles the generated `.cc` against `fixture.h` with clang++ (non-zero exit fails the task); `doLast` asserts the artifacts.

## Generated output

`fixture.h`, `fixture.cc`, `fixture.def`, `libfixture.a` (compiled), + 12 Kotlin files: `root_Shape.kt`, `root_ShapeApi.kt`, `geo_Circle.kt`, `geo_Functions.kt`, `root_Scene.kt`, `root_Palette.kt`, `palette_Flavor.kt`, `root_Color.kt`, `root_Mode.kt`, `root_Status.kt`, `root_Dispatcher.kt`, `CppBinding.kt`.

```kotlin
@krapper.CppBinding("geo::Circle")
class Circle(
    override val ptr: COpaquePointer,
    val memScope: MemScope,
) : root.ShapeApi {
    inline fun name(): String? {
        val str: CPointer<ByteVar>? = Shape_name(ptr)
        ...
```

**Cross-front-end identity check** (not just plausibility): ran the SAME fixture through the default libclang front-end and diffed the outputs — every generated Kotlin file and the wrapper sources are **byte-identical** modulo output-dir path artifacts (the `#include` relative path and the `.def`'s `-I`/`libraryPaths`).

## What dropped (all expected, ledger-cited)

Identical drop set on both front-ends (5 bound / 6 dropped):
- `corners: int[4]`, `shapes: Holder<Shape*>` — field-type drops; `Holder<T>` has no instantiation (IGNORE_MISSING) and array fields aren't marshalable. Same drops on the libclang path.
- `visit(void (*)(Shape *))` — CB-cfnptr-richsig: class-pointer param fails the stage-1 compat gate (both front-ends).
- `onHandle(...)` — the `using HandlerFn` alias; drops on both, spelled `int (*)(double)` (cpp, deterministic collapse) vs `HandlerFn` (libclang, order-dependent alias leaf) — the documented N-ledger using-collapse divergence, same semantics.

## Scoped out

`--instantiate` with `--frontend=cpp` is **rejected with a clear error**: instantiation forcing (`IndexedServiceImpl.requestInstantiation`) synthesizes a forcing header and re-parses it through libclang — entangled with the in-process parse + the cursor→element memo. The fixture needs no instantiations; this is the known next chunk on #45.

## Verify

- Full gate: krapper_gen `nativeTest` 311/0, featuregen `kplusplusSync` + `nativeTest` 188/0, `:krapper_model:build` green, `ktlintCheck` green, ZERO `krapped/` drift (flags default-off change nothing).
- Gated: cppfrontend 91 self-checks PASS, `goldenCompare` PASS, `handoffGenerate` green end-to-end (kexe completes, C++ compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
