### PR TITLE
Resolver: idempotent synthetic sizeOf/alignOf injection across re-resolutions (#57)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelResolution.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelResolution.kt
@@ -299,20 +299,28 @@ private fun WrappedClass.modifyMethodsIfNeeded(baseClasses: List<WrappedClass>) 
             removeChild(it)
         }
     }
-    addChild(
-        WrappedMethod(
-            "sizeOf",
-            WrappedTypeReference("int"),
-            MethodType.SIZE_OF
+    // Idempotent: this runs on the SHARED WrappedClass on EVERY resolve, and a class is
+    // re-resolved once per requestInstantiation pass (resolveForcing pass 1 + pass 3).
+    // Unconditionally appending here accumulated a fresh sizeOf/alignOf pair per pass,
+    // which the per-pass NameHandler then `_`-uniquified — e.g. `timespec_size_of`
+    // emitted 324 times with up to 34 leading underscores after featuregen's 17
+    // instantiation requests (#57). Add the pair only once per class.
+    if (children.none { (it as? WrappedMethod)?.methodType == MethodType.SIZE_OF }) {
+        addChild(
+            WrappedMethod(
+                "sizeOf",
+                WrappedTypeReference("int"),
+                MethodType.SIZE_OF
+            )
         )
-    )
-    addChild(
-        WrappedMethod(
-            "alignOf",
-            WrappedTypeReference("int"),
-            MethodType.ALIGN_OF
+        addChild(
+            WrappedMethod(
+                "alignOf",
+                WrappedTypeReference("int"),
+                MethodType.ALIGN_OF
+            )
         )
-    )
+    }
 }
 
 suspend fun WrappedElement.createThisArg(resolverContext: ResolveContext): ResolvedArgument? {

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -22,6 +22,7 @@ import com.monkopedia.krapper.generator.codegen.CppWriter
 import com.monkopedia.krapper.generator.codegen.File
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ArgumentCastMode
+import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
@@ -696,6 +697,76 @@ class ReturnShapeTest {
                 "aitems" in accessors && "bitems" in accessors,
                 "BOTH range accessors must survive after forcing both element containers; " +
                     "got $accessors (pre-fix only the last-forced `bitems` survives)"
+            )
+        }
+    }
+
+    // #57: synthetic sizeOf/alignOf must be IDEMPOTENT across re-resolutions. Each
+    // requestInstantiation re-resolves every already-bound class (resolveForcing pass 1 +
+    // pass 3), and `modifyMethodsIfNeeded` mutates the SHARED WrappedClass — before the fix
+    // it appended a FRESH sizeOf/alignOf pair on every resolve, which the per-pass
+    // NameHandler `_`-uniquified instead of deduping (timespec_size_of emitted 324 times in
+    // featuregen's krapped output, up to 34 leading underscores). Drive resolveForcing twice
+    // over the same bound class (mirroring two requestInstantiation calls) and assert the
+    // last-wins copy carries exactly ONE pair with the CLEAN names.
+    @Test
+    fun repeatedForcingDoesNotDuplicateSyntheticMembers() = memScoped {
+        runBlocking {
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val header =
+                """
+                |struct Thing { int id; };
+                |struct Holder { Thing* p_; };
+                """.trimMargin()
+            val headerFile = "/tmp/krapper_synth_${random()}_${random()}.h"
+            File(headerFile).writeText(header)
+
+            val mainResolver =
+                parseHeader(index, listOf(headerFile), generateIncludes("clang++"))
+            var classes: List<ResolvedElement> =
+                mainResolver.findClasses(AllowListFilter(listOf("Holder")).wrapperFilter())
+                    .resolveAll(mainResolver, ReferencePolicy.IGNORE_MISSING)
+
+            val forceFile = "/tmp/krapper_synth_inst_${random()}.h"
+            File(forceFile).writeText(
+                """
+                |#include <vector>
+                |#include "$headerFile"
+                |struct KrapperForce_Thing { std::vector<Thing*> value; };
+                """.trimMargin()
+            )
+            val forceResolver =
+                parseHeader(index, listOf(forceFile), generateIncludes("clang++"))
+
+            // Two rounds over the SAME forcing TU — each re-resolves the bound Holder twice
+            // (pass 1 + pass 3), so pre-fix the final copy carries 5 sizeOf children.
+            val forcedKeys = mutableSetOf<String>()
+            repeat(2) {
+                val alreadyBound = classes.filterIsInstance<ResolvedClass>()
+                    .mapTo(HashSet()) { it.type.toString() }
+                val scoped = forceResolver.findClasses { defaultFilter() }.filter {
+                    val cls = it as? WrappedClass ?: return@filter true
+                    val key = cls.type.toString()
+                    key.contains("KrapperForce_Thing") || key in alreadyBound
+                }
+                classes = classes + scoped.resolveForcing(
+                    forceResolver,
+                    ReferencePolicy.IGNORE_MISSING,
+                    alreadyBound,
+                    forcedKeys
+                )
+            }
+
+            val holder = classes.filterIsInstance<ResolvedClass>()
+                .associateBy { it.type.toString() }
+                .values.first { it.type.type == "Holder" }
+            val names = holder.children.filterIsInstance<ResolvedMethod>()
+                .filter { it.methodType in listOf(MethodType.SIZE_OF, MethodType.ALIGN_OF) }
+                .map { it.uniqueCName }
+            assertTrue(
+                names.sortedBy { it ?: "" } == listOf("Holder_align_of", "Holder_size_of"),
+                "Re-resolution must keep exactly ONE clean-named sizeOf/alignOf pair; got $names"
             )
         }
     }


### PR DESCRIPTION
Fixes #57.

## Root cause
`WrappedClass.modifyMethodsIfNeeded` (ModelResolution.kt) runs on the **shared WrappedClass** on every resolve and unconditionally `addChild`ed a fresh synthetic sizeOf/alignOf pair. Each `requestInstantiation` re-resolves every already-bound class **twice** (`resolveForcing` pass 1 + pass 3), so the class accumulated +2 pairs per request. The per-pass `NameHandler` then `_`-uniquified the duplicate names instead of collapsing them. After featuregen's 17 instantiation requests, the per-pass emitted sections carried 1, 3, 5, ..., 35 copies — `timespec_size_of` appeared **324 times (= 18²)** in `featuregen.h`/`featuregen.cc`, the worst name with 34 leading underscores. Every bound class accumulated the same way: 48,890 synthetic `sizeof`/`alignof` definitions total in the pre-fix `.cc`.

## Fix shape
Check-before-add at the injection site: the pair is added only if the class doesn't already carry a `SIZE_OF` method. Synthetic injection is now idempotent across re-resolutions, so every re-resolved copy carries exactly **one clean-named pair** (`timespec_size_of`, zero extra underscores), regardless of instantiation count or order.

## Generated-output characterization (krapped/ is gitignored, so proven by regeneration diff)
Regenerated `featuregen/krapped/` at the parent commit vs this branch:
- `timespec_size_of`: 324 → 18 occurrences (one clean decl per per-pass section); total synthetic bodies in `.cc`: 48,890 → 2,888 across all 101 emitted classes (exactly one sizeOf+alignOf per class-section).
- `featuregen.h`: 138,135 → 46,131 lines; `featuregen.cc`: 277,491 → 93,483 lines.
- **Nothing else changed**: the non-synthetic line multiset of `.h` is identical pre vs post; the `.cc` multiset delta contains only the synthetic definitions themselves (`*_size_of`/`*_align_of` signatures, `return sizeof/alignof(X);` bodies, closing braces) — zero other lines. The generated Kotlin `src/`, `.def`, and forcing headers are byte-identical.
- Remaining `_`-prefixed names (`_IO_FILE_size_of`, `_pthread_cleanup_buffer_size_of`) are real class names, not uniquifier growth.

## Stability / determinism
`:featuregen:kplusplusSync` run three times on the fix (including after a pre-fix regeneration in between): all three outputs byte-identical (`diff -r` clean), so the result is re-run-stable and instantiation-order-independent.

## Verification
- `:krapper_gen:nativeTest` 312/0 (311 + new test), `:krapper_model:build`, `:featuregen:kplusplusSync`, `:featuregen:nativeTest` 188/0, `:krapper_gen:ktlintCheck` — all green (JDK 17).
- New test `ReturnShapeTest.repeatedForcingDoesNotDuplicateSyntheticMembers`: drives `resolveForcing` twice over the same bound class (mirroring the #40 multi-forcing pattern) and asserts the last-wins copy carries exactly one pair named `Holder_size_of`/`Holder_align_of` (pre-fix: 5 pairs with underscore growth).
- Gated sanity: `:cppfrontend:goldenCompare -PenableClang` passes (golden fixture has no instantiations — untouched, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
