### PR TITLE
krapper_gen: dedup per-instantiation class copies — one wrapper section per class (#60)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -267,9 +267,15 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             alreadyBoundKeys,
             forcedContainerKeys
         )
-        classes = classes + newClasses.filter {
-            it !is ResolvedMethod || it.forcingIdentity in boundMethodIds
-        }
+        // One entry per class type-key, last copy wins (#60): without this, every
+        // writer received a fresh full copy of each bound class per instantiation
+        // request and the C++ writers emitted a complete wrapper section per copy
+        // (18 sections per class in featuregen). See dedupClassesLastWins.
+        classes = (
+            classes + newClasses.filter {
+                it !is ResolvedMethod || it.forcingIdentity in boundMethodIds
+            }
+            ).dedupClassesLastWins()
     }
 
     // The std headers needed to declare the types named in an instantiation

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -385,6 +385,35 @@ suspend fun List<WrappedElement>.resolveForcing(
     return resolved
 }
 
+/**
+ * Collapse the per-instantiation class copies to ONE entry per class type-key (#60).
+ *
+ * Each `requestInstantiation` appends a re-resolved copy of every already-bound class
+ * (that's how pass-3 recovery upgrades them), so after featuregen's header parse + 17
+ * instantiation requests the element list carries 18 copies of each main-bound class.
+ * KotlinWriter already collapses these via `associateBy { it.type.toString() }` —
+ * last copy wins — but HeaderWriter/CppWriter iterated the raw list, emitting a full
+ * wrapper section per copy: 18 identical declarations per symbol in the .h (legal
+ * redeclarations) and 18 definitions in the .cc that only compiled because the
+ * builder's `Scope.allocateName` `_`-uniquified the colliding names into dead
+ * `_timespec_new`/`__timespec_new`/... variants.
+ *
+ * Mirror the KotlinWriter semantics exactly: LAST copy wins (the most recent pass-3
+ * re-resolution is the most completely resolved one — cumulative forcing guarantees the
+ * final copy carries every recovered range accessor regardless of request order), kept
+ * at the key's FIRST position (matching `associateBy`'s LinkedHashMap order, so the
+ * Kotlin output is unchanged). Non-class elements pass through untouched.
+ */
+fun List<ResolvedElement>.dedupClassesLastWins(): List<ResolvedElement> {
+    val lastByKey = filterIsInstance<ResolvedClass>().associateBy { it.type.toString() }
+    val seen = mutableSetOf<String>()
+    return mapNotNull { element ->
+        if (element !is ResolvedClass) return@mapNotNull element
+        val key = element.type.toString()
+        if (seen.add(key)) lastByKey.getValue(key) else null
+    }
+}
+
 data class ResolveContext(
     val tracker: ResolveTracker,
     val resolver: Resolver,

--- a/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ReturnShapeTest.kt
@@ -18,8 +18,10 @@ package com.monkopedia.krapper.generator
 import com.monkopedia.krapper.AllowListFilter
 import com.monkopedia.krapper.ReferencePolicy
 import com.monkopedia.krapper.generator.builders.CppCodeBuilder
+import com.monkopedia.krapper.generator.builders.LogPolicy
 import com.monkopedia.krapper.generator.codegen.CppWriter
 import com.monkopedia.krapper.generator.codegen.File
+import com.monkopedia.krapper.generator.codegen.HeaderWriter
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ArgumentCastMode
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
@@ -767,6 +769,97 @@ class ReturnShapeTest {
             assertTrue(
                 names.sortedBy { it ?: "" } == listOf("Holder_align_of", "Holder_size_of"),
                 "Re-resolution must keep exactly ONE clean-named sizeOf/alignOf pair; got $names"
+            )
+        }
+    }
+
+    // #60: per-instantiation SECTION duplication. Every requestInstantiation appends a
+    // re-resolved copy of each already-bound class (the carrier of pass-3 recovery), and
+    // the C++ writers iterated the RAW list — emitting a full wrapper section per copy
+    // (header parse + 17 instantiations = 18 sections per class in featuregen's .h/.cc;
+    // the .cc only compiled because Scope.allocateName renamed the colliding definitions
+    // into dead `_`-prefixed variants). Drive resolveForcing twice over a bound class
+    // whose range method is only recovered by pass 3 (so the copies genuinely differ),
+    // dedup as requestInstantiation now does, and assert (a) one copy per type-key,
+    // (b) the survivor is the LAST (recovered) copy, (c) HeaderWriter emits exactly one
+    // section per class.
+    @Test
+    fun repeatedForcingEmitsOneSectionPerClass() = memScoped {
+        runBlocking {
+            val index = createIndex(0, 0) ?: error("Failed to create Index")
+            defer { index.dispose() }
+            val headerFile = "/tmp/krapper_dedup_${random()}_${random()}.h"
+            File(headerFile).writeText(
+                """
+                |#include <vector>
+                |struct Thing { int id; };
+                |struct Holder {
+                |    std::vector<Thing*> items() const { return {}; }
+                |};
+                """.trimMargin()
+            )
+            val mainResolver =
+                parseHeader(index, listOf(headerFile), generateIncludes("clang++"))
+            var classes: List<ResolvedElement> =
+                mainResolver.findClasses(AllowListFilter(listOf("Holder")).wrapperFilter())
+                    .resolveAll(mainResolver, ReferencePolicy.IGNORE_MISSING)
+
+            val forceFile = "/tmp/krapper_dedup_inst_${random()}.h"
+            File(forceFile).writeText(
+                """
+                |#include <vector>
+                |#include "$headerFile"
+                |struct KrapperForce_Holder { std::vector<Thing*> value; };
+                """.trimMargin()
+            )
+            val forceResolver =
+                parseHeader(index, listOf(forceFile), generateIncludes("clang++"))
+
+            // Two rounds = two instantiation requests, each appending a re-resolved copy
+            // of the bound Holder (pre-fix: 3 raw copies, 3 emitted sections).
+            val forcedKeys = mutableSetOf<String>()
+            repeat(2) {
+                val alreadyBound = classes.filterIsInstance<ResolvedClass>()
+                    .mapTo(HashSet()) { it.type.toString() }
+                val scoped = forceResolver.findClasses { defaultFilter() }.filter {
+                    val cls = it as? WrappedClass ?: return@filter true
+                    val key = cls.type.toString()
+                    key.contains("KrapperForce_Holder") || key in alreadyBound
+                }
+                classes = (
+                    classes + scoped.resolveForcing(
+                        forceResolver,
+                        ReferencePolicy.IGNORE_MISSING,
+                        alreadyBound,
+                        forcedKeys
+                    )
+                    ).dedupClassesLastWins()
+            }
+
+            // (a) one copy per class type-key.
+            val keys = classes.filterIsInstance<ResolvedClass>().map { it.type.toString() }
+            assertTrue(
+                keys.size == keys.distinct().size,
+                "dedup must keep one copy per class type-key; got $keys"
+            )
+            // (b) LAST-wins: the main-resolve Holder dropped items() (the container was
+            // unbound), so only the pass-3-recovered copy carries it.
+            val holder =
+                classes.filterIsInstance<ResolvedClass>().first { it.type.type == "Holder" }
+            assertTrue(
+                holder.children.filterIsInstance<ResolvedMethod>().any { it.name == "items" },
+                "the surviving Holder must be the recovered (last) copy carrying items()"
+            )
+            // (c) writer-level: exactly one wrapper section per class.
+            val builder = CppCodeBuilder()
+            HeaderWriter(builder, policy = LogPolicy)
+                .generate("dedup_probe", listOf(headerFile), classes)
+            val sections = builder.toString().lines()
+                .filter { it.contains("BEGIN KRAPPER GEN for") }
+            assertTrue(
+                sections.size == sections.distinct().size &&
+                    sections.any { it.contains("for Holder") },
+                "header must emit exactly one section per class; got $sections"
             )
         }
     }


### PR DESCRIPTION
Fixes #60

## Confirmed mechanism

Every `requestInstantiation` appends a re-resolved copy of each already-bound class (`classes = classes + newClasses` in `IndexedServiceImpl`) — that append is the carrier of pass-3 recovery. After featuregen's header parse + 17 instantiation requests, the element list held **18 copies** of each main-bound class (78 classes at 18x, plus 2x/6x for containers bound mid-run; 101 distinct keys).

`KotlinWriter` already collapsed the copies (`associateBy { it.type.toString() }`, last-wins), but `HeaderWriter`/`CppWriter` (via `CodeGenerator.generate`) iterated the **raw list**, emitting a full wrapper section per copy:

* **.h** — 18 identical declarations per symbol (`timespec_new` at 18 places). Legal C redeclarations, so it compiled.
* **.cc** — 18 *definitions* per symbol, which only compiled because `Scope.allocateName` `_`-uniquified the collisions into dead name-distinct variants (`timespec_new`, `_timespec_new`, ... 17 underscores). The live symbol (the one the .h declares and Kotlin imports) was the **first** copy's body — i.e. the C++ side was effectively first-wins while the Kotlin side was last-wins.
* **.def** — module config only, no per-class content: unaffected (verified byte-identical).

## Fix

Dedup at the shared input — the `requestInstantiation` append — with the exact `KotlinWriter` semantics: **last copy wins** (cumulative forcing, #40, guarantees the final copy carries every recovered range accessor regardless of request order), kept at the key's **first-occurrence position** (matching `associateBy`'s LinkedHashMap order so Kotlin output is unchanged). One dedup; all three writers now describe the same final class, and the live .cc body is the last copy's — consistent with Kotlin at last.

## Diff characterization (regenerated at parent ff9c140 vs fix)

* `timespec_new`: **18 → 1** in both .h and .cc; every one of the 101 classes now has exactly **1** section (`.h` 46,131 → 3,729 lines; `.cc` 93,483 → 7,323).
* **Last-wins proof (.h):** the surviving section is **byte-identical to the pre-fix LAST section** for 92/101 classes — spot-checked `timespec`, `StringFeature`, `Vec2`, `std::vector<Thing*>`, and `RangeHolder` (the #40 pass-3-recovery class, where last differs from first: only the last copy carries `items()` — first-wins would have lost it). The 9 divergent classes (`Base`, `Shape`, `Animal`, ...) differ ONLY by removing *within-section* duplicated dyncast/upcast helper declarations — the same root cause (18 derived-class copies in `ClassLookup`), verified mechanically: zero added lines, removals all duplicate helper decls.
* **.cc:** surviving section == pre-fix last section exactly (18 classes) or modulo the underscore de-mangling (73; clean names now on the live definitions); the remaining 10 additionally drop the duplicated dyncast helper *definitions* (verified: residual diffs are pure duplicate removals).
* **Everything non-C++ byte-identical:** Kotlin `src/` (119 files), `.def`, forcing headers, `generated.txt`, `requested.txt` — only `.h`/`.cc` changed.
* **Stability:** two post-fix syncs → byte-identical tree; parent-commit regeneration also reproduced the saved baseline exactly.

Known sibling (out of scope, pre-existing): namespace **free functions** (`ResolvedMethod` elements, e.g. `hh_default_handler`) still duplicate 18x in .h/.cc *and* in the Kotlin facades (`_default_handler`...) — KotlinWriter never deduped those either, so fixing them changes the Kotlin baseline; worth its own issue.

## Test

`repeatedForcingEmitsOneSectionPerClass` (ReturnShapeTest, mirroring #59's pattern): two forcing rounds over a bound class whose range accessor only pass-3 recovery restores; asserts one copy per type-key, the recovered (last) copy survives, and `HeaderWriter` emits exactly one section per class.

## Verification

* `:krapper_gen:nativeTest` **313/0** (312 + new test), `:krapper_model:build`, `:featuregen:kplusplusSync`, `:featuregen:nativeTest` **188/0** on the new baseline, `:krapper_gen:ktlintCheck` — all green.
* Gated: `:cppfrontend:goldenCompare :cppfrontend:handoffGenerate -PenableClang` green (exercises the changed C++ writer end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
