### PR TITLE
krapper_gen+cppfrontend: instantiation forcing on the cpp path — --frontend=cpp --instantiate end-to-end (#45 brick 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gradle-app.setting
 local.properties
 .claude/worktrees/
 .kotlin/
+*.hprof

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -180,7 +180,12 @@ kplusplus {
         // default's source text — an inline helper in the slice header wrapping
         // Lexer::getSourceText over ParmVarDecl::getDefaultArgRange() (see clang_slice.h
         // for why Lexer/SourceManager/LangOptions aren't bound wholesale yet).
-        "kppbridge::defaultArgText"
+        "kppbridge::defaultArgText",
+        // NEW for #45 brick 3 (instantiation forcing): the forcing-parse entry point —
+        // buildASTFromCode with REAL driver args ('\n'-joined; -resource-dir + -std), the
+        // smallest bridge until std::vector<std::string> params are bindable (see
+        // clang_slice.h).
+        "kppbridge::buildASTWithArgs"
     )
     // FIXUPS (documented generator gaps, #44 brick 5): krapper's operator generation
     // emits invalid Kotlin for four of llvm::APSInt's C++ operators —
@@ -300,5 +305,103 @@ tasks.register<Exec>("handoffGenerate") {
             .filter { it.isFile && it.extension == "kt" }.toList()
         check(kotlinFiles.isNotEmpty()) { "handoffGenerate: no Kotlin bindings generated" }
         println("handoffGenerate: generated " + (expected + kotlinFiles.map { it.name }))
+    }
+}
+
+// ---- #45 brick 3: INSTANTIATION FORCING on the cpp path ----
+// The gate to Phase D: `--frontend=cpp --instantiate` end-to-end on an instantiation-
+// bearing fixture (Bag/Item + std::vector<Item*> — featuregen's RangeHolder shape).
+//   handoffInstEmit     — the cppfrontend binary parses the fixture (base model) AND the
+//                         synthesized KrapperForce header (forcing model, a separate
+//                         args-bearing parse pulling in <vector>), emitting both as
+//                         ModelIo JSON (CppFrontend.handoffEmit);
+//   handoffInstGenerate — krapper_gen --frontend=cpp loads BOTH models (libclang never
+//                         called), runs the SAME resolveForcing 3-pass flow over them,
+//                         and emits + compiles the wrapper: the recovered range accessor
+//                         (Bag::items()) and the vector specialization's bindings;
+//   handoffInstBaseline — the SAME fixture + instantiation through the libclang path;
+//   handoffInstDiff     — THE STRONG CHECK: the two outputs must be byte-identical
+//                         (path-modulo: the .def bakes the output dir's absolute path).
+val handoffInstDir = layout.buildDirectory.dir("handoff_inst").get().asFile
+
+val handoffInstEmit = tasks.register<Exec>("handoffInstEmit") {
+    dependsOn("linkReleaseExecutableKlinker")
+    doFirst { handoffInstDir.mkdirs() }
+    commandLine(cppfrontendBinary.absolutePath, "--handoff-emit", handoffInstDir.absolutePath)
+}
+
+// The shared CLI tail: same fixture, standard, allowlist scope and instantiation on both
+// front-ends, so the diff isolates the front-end swap.
+fun instGenerateArgs(outDir: File) = listOf(
+    "-h",
+    File(handoffInstDir, "bag.h").absolutePath,
+    "--std",
+    "c++17",
+    "--only",
+    "Bag",
+    "--only",
+    "Item",
+    "--instantiate",
+    "std::vector<Item*>",
+    "-o",
+    outDir.absolutePath,
+    "bag"
+)
+
+val handoffInstGenerate = tasks.register<Exec>("handoffInstGenerate") {
+    dependsOn(handoffInstEmit, ":krapper_gen:linkReleaseExecutableNative")
+    val outDir = File(handoffInstDir, "out_cpp")
+    doFirst { outDir.mkdirs() }
+    commandLine(
+        listOf(
+            krapperGenKexe.absolutePath,
+            "--frontend",
+            "cpp",
+            "--parsedModel",
+            File(handoffInstDir, "bag_model.json").absolutePath,
+            "--forcingModel",
+            "std::vector<Item*>=" +
+                File(handoffInstDir, "KrapperForce_std_vector_ItemPtr.json").absolutePath
+        ) + instGenerateArgs(outDir)
+    )
+}
+
+val handoffInstBaseline = tasks.register<Exec>("handoffInstBaseline") {
+    dependsOn(handoffInstEmit, ":krapper_gen:linkReleaseExecutableNative")
+    val outDir = File(handoffInstDir, "out_libclang")
+    doFirst { outDir.mkdirs() }
+    commandLine(listOf(krapperGenKexe.absolutePath) + instGenerateArgs(outDir))
+}
+
+tasks.register("handoffInstDiff") {
+    dependsOn(handoffInstGenerate, handoffInstBaseline)
+    doLast {
+        val libclang = File(handoffInstDir, "out_libclang")
+        val cpp = File(handoffInstDir, "out_cpp")
+        fun files(dir: File) = dir.walkTopDown().filter { it.isFile }
+            .map { it.relativeTo(dir).path }.toSortedSet()
+        val names = files(libclang)
+        check(names == files(cpp)) {
+            "handoffInstDiff: file sets differ — only-libclang=${names - files(cpp)} " +
+                "only-cpp=${files(cpp) - names}"
+        }
+        val diffs = names.filter { rel ->
+            // The .def bakes the output dir's absolute path (compilerOpts/libraryPaths);
+            // normalize it on both sides. Everything else must match byte-for-byte.
+            fun read(dir: File) = File(dir, rel).readBytes().toString(Charsets.UTF_8)
+                .replace(dir.absolutePath, "@OUT@")
+            if (rel.endsWith(".def")) {
+                read(libclang) != read(cpp)
+            } else {
+                !File(libclang, rel).readBytes().contentEquals(File(cpp, rel).readBytes())
+            }
+        }
+        check(diffs.isEmpty()) {
+            "handoffInstDiff: cross-front-end divergence in: $diffs (compare " +
+                "$libclang vs $cpp)"
+        }
+        println(
+            "handoffInstDiff: byte-identical (path-modulo .def) across ${names.size} files"
+        )
     }
 }

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -185,7 +185,12 @@ kplusplus {
         // buildASTFromCode with REAL driver args ('\n'-joined; -resource-dir + -std), the
         // smallest bridge until std::vector<std::string> params are bindable (see
         // clang_slice.h).
-        "kppbridge::buildASTWithArgs"
+        "kppbridge::buildASTWithArgs",
+        // NEW for #45 brick 3: the CIndex GetTemplateArguments mirror — written-args
+        // preference + dependent-specialization decode (see clang_slice.h).
+        "kppbridge::numTemplateArgs",
+        "kppbridge::templateArgAsType",
+        "kppbridge::templateBaseName"
     )
     // FIXUPS (documented generator gaps, #44 brick 5): krapper's operator generation
     // emits invalid Kotlin for four of llvm::APSInt's C++ operators —
@@ -366,42 +371,119 @@ val handoffInstGenerate = tasks.register<Exec>("handoffInstGenerate") {
     )
 }
 
+// The libclang baseline ALSO dumps each parse's ModelIo tree (--dumpModels): the main
+// bag.h parse and the KrapperForce forcing re-parse, exactly the two payloads the cpp
+// path consumes — the ORACLE for the file-handoff flow.
 val handoffInstBaseline = tasks.register<Exec>("handoffInstBaseline") {
     dependsOn(handoffInstEmit, ":krapper_gen:linkReleaseExecutableNative")
     val outDir = File(handoffInstDir, "out_libclang")
     doFirst { outDir.mkdirs() }
-    commandLine(listOf(krapperGenKexe.absolutePath) + instGenerateArgs(outDir))
+    commandLine(
+        listOf(
+            krapperGenKexe.absolutePath,
+            "--dumpModels",
+            File(handoffInstDir, "oracle_models").absolutePath
+        ) + instGenerateArgs(outDir)
+    )
+}
+
+// THE FLOW PROOF: feed the libclang-dumped models back through --frontend=cpp
+// --forcingModel. Output must be byte-identical to the in-process libclang run — this
+// isolates the file-handoff instantiation flow (fresh instances, no cursor->element
+// memo, resolveForcing over loaded trees) from cppfrontend model-construction fidelity.
+val handoffOracleGenerate = tasks.register<Exec>("handoffOracleGenerate") {
+    dependsOn(handoffInstBaseline)
+    val outDir = File(handoffInstDir, "out_oracle_cpp")
+    doFirst { outDir.mkdirs() }
+    commandLine(
+        listOf(
+            krapperGenKexe.absolutePath,
+            "--frontend",
+            "cpp",
+            "--parsedModel",
+            File(handoffInstDir, "oracle_models/model_0_bag.json").absolutePath,
+            "--forcingModel",
+            "std::vector<Item*>=" + File(
+                handoffInstDir,
+                "oracle_models/model_1_KrapperForce_std_vector_ItemPtr.json"
+            ).absolutePath
+        ) + instGenerateArgs(outDir)
+    )
 }
 
 tasks.register("handoffInstDiff") {
-    dependsOn(handoffInstGenerate, handoffInstBaseline)
+    dependsOn(handoffInstGenerate, handoffInstBaseline, handoffOracleGenerate)
     doLast {
         val libclang = File(handoffInstDir, "out_libclang")
-        val cpp = File(handoffInstDir, "out_cpp")
         fun files(dir: File) = dir.walkTopDown().filter { it.isFile }
             .map { it.relativeTo(dir).path }.toSortedSet()
+
+        // ---- Gate 1 (byte): the oracle run. Same models as the in-process libclang
+        // run (its own dumps), so the file-handoff flow must reproduce it exactly —
+        // path-modulo: the .def bakes the output dir's absolute path.
+        val oracle = File(handoffInstDir, "out_oracle_cpp")
         val names = files(libclang)
-        check(names == files(cpp)) {
-            "handoffInstDiff: file sets differ — only-libclang=${names - files(cpp)} " +
-                "only-cpp=${files(cpp) - names}"
+        check(names == files(oracle)) {
+            "handoffInstDiff[oracle]: file sets differ — only-libclang=" +
+                "${names - files(oracle)} only-cpp=${files(oracle) - names}"
         }
         val diffs = names.filter { rel ->
-            // The .def bakes the output dir's absolute path (compilerOpts/libraryPaths);
-            // normalize it on both sides. Everything else must match byte-for-byte.
             fun read(dir: File) = File(dir, rel).readBytes().toString(Charsets.UTF_8)
                 .replace(dir.absolutePath, "@OUT@")
             if (rel.endsWith(".def")) {
-                read(libclang) != read(cpp)
+                read(libclang) != read(oracle)
             } else {
-                !File(libclang, rel).readBytes().contentEquals(File(cpp, rel).readBytes())
+                !File(libclang, rel).readBytes().contentEquals(File(oracle, rel).readBytes())
             }
         }
         check(diffs.isEmpty()) {
-            "handoffInstDiff: cross-front-end divergence in: $diffs (compare " +
-                "$libclang vs $cpp)"
+            "handoffInstDiff[oracle]: file-handoff flow diverged from the in-process " +
+                "run in: $diffs (compare $libclang vs $oracle)"
         }
         println(
-            "handoffInstDiff: byte-identical (path-modulo .def) across ${names.size} files"
+            "handoffInstDiff[oracle]: byte-identical (path-modulo .def) across " +
+                "${names.size} files"
+        )
+
+        // ---- Gate 2 (functional): the cppfrontend-model run. The C++-AST front-end's
+        // std-template model is deliberately MORE faithful than libclang's lossy one
+        // (no "_E*"/"_Pointer" Unexposed-spelling artifacts, no order-dependent
+        // visit() collapse), and member uniqueCNames bake those pre-substitution
+        // spellings — so byte-parity here would mean emulating libclang's lossiness
+        // bug-for-bug, which the bootstrap exists to delete. The gate is functional:
+        // the SAME file set (the specialization's bindings materialized, nothing
+        // extra), the recovered range accessor, the core container surface, and the
+        // wrapper COMPILED (writeTo's CppCompiler step already failed the generate
+        // task otherwise). Spelling deltas are tracked on #45.
+        val cpp = File(handoffInstDir, "out_cpp")
+        check(names == files(cpp)) {
+            "handoffInstDiff[functional]: file sets differ — only-libclang=" +
+                "${names - files(cpp)} only-cpp=${files(cpp) - names}"
+        }
+        val bag = File(cpp, "src/root_Bag.kt").readText()
+        check(bag.contains("fun items(): Vector__Item_P")) {
+            "handoffInstDiff[functional]: Bag::items() was not recovered by pass-3 " +
+                "forcing on the cpp path"
+        }
+        val vector = File(cpp, "src/std_Vector__Item_P.kt").readText()
+        val expectedSurface = listOf(
+            "fun size(): size_t",
+            "fun push_back(",
+            "fun at(",
+            "operator fun get(",
+            "fun front(): Item?",
+            "fun back(): Item?",
+            "fun empty(): Boolean",
+            "fun clear(): Unit"
+        )
+        val missing = expectedSurface.filter { !vector.contains(it) }
+        check(missing.isEmpty()) {
+            "handoffInstDiff[functional]: vector specialization is missing core " +
+                "surface: $missing"
+        }
+        println(
+            "handoffInstDiff[functional]: cppfrontend-model run materialized the " +
+                "specialization + recovered items() (same file set, core surface present)"
         )
     }
 }

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -15,6 +15,7 @@
 #include <clang/Lex/Lexer.h>
 
 #include <string>
+#include <vector>
 
 // brick-6 BRIDGE (#44, documented): the libclang front-end recovers a parameter default's
 // VALUE as source text — ModelFactories.defaultValue tokenizes the default sub-expression
@@ -33,6 +34,32 @@
 // "nullptr", "Palette()"); a spaced default (`= Palette ( )`) diverges — Phase C
 // normalizer entry: compare default values with whitespace stripped.
 namespace kppbridge {
+// brick-3 BRIDGE (#45, instantiation forcing): the forcing-parse fixture #includes std
+// headers (<vector>), which clang::tooling can only resolve with real driver arguments —
+// at minimum `-resource-dir` (the tool name "clang-tool" defeats the relative resource-dir
+// computation) and the language standard. The bound `buildASTFromCode(code, filename)`
+// overload takes no args, and the args-taking overload's `const std::vector<std::string>&`
+// parameter is not a bindable surface yet (the std::vector<std::string> instantiation +
+// the by-value-vector marshalling). Until it is, this inline helper is the smallest
+// bridge: args arrive '\n'-joined in one string (no escaping — driver args never contain
+// newlines), and the returned ASTUnit* transfers ownership via .release(), exactly the
+// raw-pointer contract the unique_ptr-return rewrite gives the bound buildASTFromCode.
+inline clang::ASTUnit *buildASTWithArgs(const char *code, const char *filename,
+                                        const char *joinedArgs) {
+    std::vector<std::string> args;
+    std::string current;
+    for (const char *c = joinedArgs; *c; ++c) {
+        if (*c == '\n') {
+            if (!current.empty()) args.push_back(current);
+            current.clear();
+        } else {
+            current.push_back(*c);
+        }
+    }
+    if (!current.empty()) args.push_back(current);
+    return clang::tooling::buildASTFromCodeWithArgs(code, args, filename).release();
+}
+
 inline std::string defaultArgText(clang::ParmVarDecl *parm) {
     if (!parm || !parm->hasDefaultArg()) {
         return std::string();

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -60,6 +60,61 @@ inline clang::ASTUnit *buildASTWithArgs(const char *code, const char *filename,
     return clang::tooling::buildASTFromCodeWithArgs(code, args, filename).release();
 }
 
+// brick-3 BRIDGE (#45, instantiation forcing): mirror libclang's GetTemplateArguments
+// (CXType.cpp) — the template-argument read that PREFERS the sugared
+// TemplateSpecializationType's WRITTEN arguments (so `std::vector<Item*>` carries ONE
+// arg, not the canonical two with the defaulted allocator) and falls back to the
+// canonical specialization decl's full list. The TST half also catches DEPENDENT
+// specializations (`vector<_Tp, _Alloc>` inside the template's own member signatures),
+// which have no canonical record at all. TemplateName / ArrayRef<TemplateArgument>
+// aren't bindable surfaces yet, hence the bridge. -1 = not a template specialization.
+inline int numTemplateArgs(const clang::QualType &type) {
+    if (type.isNull()) return -1;
+    if (const auto *spec = type->getAs<clang::TemplateSpecializationType>())
+        return (int)spec->template_arguments().size();
+    if (const auto *record = type->getAsCXXRecordDecl())
+        if (const auto *decl =
+                llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(record))
+            return (int)decl->getTemplateArgs().size();
+    return -1;
+}
+
+// args[index] when it is a TYPE argument; a null QualType otherwise — mirroring
+// clang_Type_getTemplateArgumentAsType's CXType_Invalid for value/template args,
+// which TypeFactories drops via filterNotNull.
+inline clang::QualType templateArgAsType(const clang::QualType &type, unsigned index) {
+    if (const auto *spec = type->getAs<clang::TemplateSpecializationType>()) {
+        auto args = spec->template_arguments();
+        if (index < args.size() && args[index].getKind() == clang::TemplateArgument::Type)
+            return args[index].getAsType();
+        return clang::QualType();
+    }
+    if (const auto *record = type->getAsCXXRecordDecl())
+        if (const auto *decl =
+                llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(record)) {
+            const auto &args = decl->getTemplateArgs();
+            if (index < args.size() &&
+                args[index].getKind() == clang::TemplateArgument::Type)
+                return args[index].getAsType();
+        }
+    return clang::QualType();
+}
+
+// The specialization's TEMPLATE name, qualified — the decl-side equivalent of
+// createForType(forTemplateBase=true)'s referencedDecl.fullyQualified (libclang's
+// clang_getTypeDeclaration resolves a TST to its ClassTemplateDecl and a resolved
+// specialization to its ClassTemplateSpecializationDecl; both spell the "::"-joined
+// semantic-parent chain).
+inline std::string templateBaseName(const clang::QualType &type) {
+    if (type.isNull()) return std::string();
+    if (const auto *spec = type->getAs<clang::TemplateSpecializationType>())
+        if (const auto *decl = spec->getTemplateName().getAsTemplateDecl())
+            return decl->getQualifiedNameAsString();
+    if (const auto *record = type->getAsCXXRecordDecl())
+        return record->getQualifiedNameAsString();
+    return std::string();
+}
+
 inline std::string defaultArgText(clang::ParmVarDecl *parm) {
     if (!parm || !parm->hasDefaultArg()) {
         return std::string();

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import clang.tooling.buildASTFromCode
+import com.monkopedia.krapper.generator.model.ForcingHeader
 import com.monkopedia.krapper.generator.model.ModelIo
 import com.monkopedia.krapper.generator.model.WrappedBase
 import com.monkopedia.krapper.generator.model.WrappedClass
@@ -36,9 +37,17 @@ import com.monkopedia.krapper.generator.model.type.WrappedTemplateType
 import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import kotlin.system.exitProcess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.MemScope
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kppbridge.buildASTWithArgs
+import platform.posix.fgets
+import platform.posix.pclose
+import platform.posix.popen
 
 // The brick-3 fixture "header" (#44 construction depth): exercises the full decl/class/
 // member construction contract — access filtering (public kept, private/protected filtered
@@ -166,6 +175,37 @@ private val FIXTURE_HEADER = """
     };
 """.trimIndent()
 
+// #45 brick 3: the INSTANTIATION-FORCING fixture — a SIBLING of FIXTURE_HEADER (extending
+// it would put all of <vector> under the golden compare's full-tree diff). Mirrors
+// featuregen's RangeHolder shape reduced to its essence: an element class (Item) and an
+// owner (Bag) whose range accessor returns a std::vector specialization that only an
+// `--instantiate "std::vector<Item*>"` request materializes. On the main resolve
+// (IGNORE_MISSING) `items()` DROPS — the container isn't bound yet — and is recovered by
+// resolveForcing's pass 3, exactly the libclang flow this fixture cross-checks. The
+// include guard matters: the generated wrapper #includes bag.h both directly and through
+// the re-materialized KrapperForce_*.h.
+private val FORCING_FIXTURE_HEADER = """
+    #pragma once
+    #include <vector>
+
+    struct Item {
+        int id;
+        Item() : id(0) {}
+        Item(int id_) : id(id_) {}
+        int getId() const { return id; }
+    };
+
+    struct Bag {
+        Bag();
+        void add(Item* t);
+        int count() const;
+        std::vector<Item*> items() const;
+    };
+""".trimIndent()
+
+// The fixture's instantiation requests — one per `--instantiate` the generate step makes.
+private val FORCING_TARGETS = listOf("std::vector<Item*>")
+
 private var failures = 0
 
 private fun check(name: String, pass: Boolean, detail: String = "") {
@@ -188,6 +228,11 @@ fun main(args: Array<String>): Unit = memScoped {
         val cpp = args.getOrNull(1) ?: fail("--golden-compare <cpp.json> <libclang.json>")
         val libclang = args.getOrNull(2) ?: fail("--golden-compare <cpp.json> <libclang.json>")
         goldenCompare(cpp, libclang)
+    }
+    if (args.firstOrNull() == "--handoff-emit") {
+        val dir = args.getOrNull(1) ?: fail("--handoff-emit <dir>")
+        handoffEmit(dir)
+        return@memScoped
     }
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
     // from it, and a ".h" parses as C (where `int area() const` is ill-formed and Shape is a
@@ -827,6 +872,65 @@ fun main(args: Array<String>): Unit = memScoped {
     if (failures > 0) fail("$failures self-check(s) failed")
     println("cppfrontend: ALL SELF-CHECKS PASSED")
 }
+
+/**
+ * #45 brick 3 — INSTANTIATION-FORCING HANDOFF EMIT. The cpp front-end's half of the
+ * `--frontend=cpp --instantiate` flow:
+ *  1. write the forcing fixture (bag.h) so krapper_gen consumes the same bytes;
+ *  2. parse it (the BASE model: the args-bearing parse, since the fixture #includes
+ *     <vector>) -> bag_model.json (--parsedModel);
+ *  3. for each instantiation target, synthesize the SAME forcing header the libclang path
+ *     synthesizes (ForcingHeader, :krapper_model), parse it as a SEPARATE translation
+ *     unit, and emit its model -> <forceName>.json (--forcingModel).
+ * Identity note: each payload is self-contained — cpp:<id> identities are per-ASTContext
+ * (Decl::getID() is NOT stable across buildASTFromCode calls), but nothing references
+ * identity ACROSS payloads; krapper_gen's forcing flow merges the trees by structural
+ * identity (type-string keys: alreadyBoundKeys / tracker maps / last-wins dedup), the same
+ * keys the libclang path's USR memo collapses to one instance.
+ */
+private fun MemScope.handoffEmit(dir: String) {
+    val fixturePath = "$dir/bag.h"
+    writeFile(fixturePath, FORCING_FIXTURE_HEADER + "\n")
+    // The std-header-bearing parses need real driver arguments: the tooling driver can't
+    // compute its resource dir (its "binary" is the virtual "clang-tool"), so the builtin
+    // headers (<stddef.h> etc., behind <vector>) only resolve with an explicit
+    // -resource-dir; system C++ headers are found by the driver's normal GCC detection.
+    // c++17 pins the same standard the generate step parses/compiles under.
+    val parseArgs = "-std=c++17\n-resource-dir=" + commandOutput("clang++ -print-resource-dir")
+    val baseTu = parseToWrappedTU(FORCING_FIXTURE_HEADER, "bag.cc", parseArgs)
+    writeFile("$dir/bag_model.json", ModelIo.encodeToString(baseTu))
+    val emitted = mutableListOf("bag.h", "bag_model.json")
+    for (target in FORCING_TARGETS) {
+        val forceName = ForcingHeader.forceName(target)
+        val content = ForcingHeader.contentFor(target, listOf(fixturePath))
+        val forcingTu = parseToWrappedTU(content, "$forceName.cc", parseArgs)
+        writeFile("$dir/$forceName.json", ModelIo.encodeToString(forcingTu))
+        emitted.add("$forceName.json")
+    }
+    println("cppfrontend: handoff-emit -> $dir/{${emitted.joinToString(", ")}}")
+}
+
+// Parse [code] with the '\n'-joined driver [args] (kppbridge.buildASTWithArgs — see
+// clang_slice.h) and construct the WrappedTU. The virtual filename must spell a C++
+// extension (same rule as the buildASTFromCode call in main).
+private fun MemScope.parseToWrappedTU(code: String, filename: String, args: String) =
+    buildWrappedTU(
+        buildASTWithArgs(code, filename, args)
+            ?.getASTContext()
+            ?.getTranslationUnitDecl()
+            ?: fail("buildASTWithArgs failed for $filename")
+    )
+
+// First line of [cmd]'s stdout (popen), trimmed. Used for `clang++ -print-resource-dir`.
+private fun commandOutput(cmd: String): String = memScoped {
+    val fp = popen(cmd, "r") ?: fail("popen failed: $cmd")
+    val buffer = allocArray<ByteVar>(BUFFER_SIZE)
+    val line = fgets(buffer, BUFFER_SIZE, fp)?.toKString().orEmpty().trim()
+    pclose(fp)
+    if (line.isEmpty()) fail("no output from: $cmd") else line
+}
+
+private const val BUFFER_SIZE = 1024
 
 private fun printElements(elements: List<WrappedElement>, indent: String) {
     for (child in elements) {

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -589,18 +589,22 @@ fun main(args: Array<String>): Unit = memScoped {
         tParam != null && tParam.name == "T" && tParam.usr.startsWith("cpp:"),
         "got ${holder?.templateArgs}"
     )
+    // #45 brick 3 revision: dependent-T refs key on the param's NAME (the libclang
+    // in-template fallback every member use actually hits — and the spelling baked into
+    // uniqueCNames), not the cpp:<id> identity. typedAs maps name AND usr, so either
+    // key substitutes; the name is what output parity requires (TypeBuilder's TTPT branch).
     val valueField = holder?.fields?.singleOrNull()
     check(
-        "field 'T value': WrappedTemplateRef keyed to the param's usr (substitution contract)",
+        "field 'T value': WrappedTemplateRef keyed to the param's NAME (uniqueCName parity)",
         valueField != null && valueField.name == "value" &&
-            (valueField.type as? WrappedTemplateRef)?.target == tParam?.usr,
+            (valueField.type as? WrappedTemplateRef)?.target == "T",
         "got $valueField"
     )
     val getMethod = holder?.methods?.find { it.name == "get" }
     check(
         "T get() const: BARE WrappedTemplateRef return (G8: no const wrap on by-value)",
         getMethod != null && getMethod.isConst &&
-            (getMethod.returnType as? WrappedTemplateRef)?.target == tParam?.usr,
+            (getMethod.returnType as? WrappedTemplateRef)?.target == "T",
         "got ${getMethod?.returnType}"
     )
     val setArg = holder?.methods?.find { it.name == "set" }?.args?.singleOrNull()?.type
@@ -609,14 +613,14 @@ fun main(args: Array<String>): Unit = memScoped {
         "set(const T&): the dependent type nests structurally — &(const(WrappedTemplateRef))",
         setArg is WrappedModifiedType && setArg.modifier == "&" &&
             setBase?.modifier == "const" &&
-            (setBase?.baseType as? WrappedTemplateRef)?.target == tParam?.usr,
+            (setBase?.baseType as? WrappedTemplateRef)?.target == "T",
         "got $setArg"
     )
     val valueTypedef = holder?.children?.filterIsInstance<WrappedTypedef>()?.singleOrNull()
     check(
-        "in-template `typedef T value_type`: WrappedTypedef -> WrappedTemplateRef(param usr)",
+        "in-template `typedef T value_type`: WrappedTypedef -> WrappedTemplateRef(param name)",
         valueTypedef != null && valueTypedef.name == "value_type" &&
-            (valueTypedef.targetType as? WrappedTemplateRef)?.target == tParam?.usr,
+            (valueTypedef.targetType as? WrappedTemplateRef)?.target == "T",
         "got $valueTypedef"
     )
 

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -26,6 +26,7 @@ import clang.FunctionDecl
 import clang.NamedDecl
 import clang.NamespaceDecl
 import clang.ParmVarDecl
+import clang.RecordDecl
 import clang.TemplateDecl
 import clang.TemplateParameterList
 import clang.TranslationUnitDecl
@@ -253,7 +254,15 @@ private class ModelBuilder {
     }
 
     private fun addClass(record: CXXRecordDecl, decl: Decl, parent: WrappedElement) {
-        val name = record.asNamedDecl().getNameAsString() ?: return
+        // An ANONYMOUS record is spelled by its typedef name when one exists (`typedef
+        // struct { ... } max_align_t;` — libclang's cursor-spelling rule, which is how
+        // max_align_t binds on that path); a truly anonymous record (libclang spells
+        // "(unnamed struct at <file:line>)", never bindable) is skipped — an empty name
+        // would crash WrappedClass.type ("Empty type").
+        val name = record.asNamedDecl().getNameAsString()?.takeIf { it.isNotEmpty() }
+            ?: RecordDecl(record.ptr, record.memScope).getTypedefNameForAnonDecl()
+                ?.getNameAsString()?.takeIf { it.isNotEmpty() }
+            ?: return
         // ModelFactories' WrappedClass factory: name via wrapName (= the bare name for a
         // non-template class; template-args spelling is brick-4+) + the isAbstract flag.
         // hasDefinition() guards a never-defined record, whose definition-data accessors

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -288,13 +288,19 @@ private class ModelBuilder {
     ) {
         for (base in record.bases()) {
             if (base == null) continue
+            // ModelFactories.map's TOP access filter applies to base specifiers too: a
+            // protected/private base (std::vector : protected _Vector_base) never becomes
+            // a WrappedBase on the libclang path. Load-bearing for forcing (#45 brick 3):
+            // keeping the dependent _Vector_base would hard-fail the specialization's
+            // INCLUDE reference-expansion (the unresolvable-primary-base rule).
+            if (base.getAccessSpecifier() != AccessSpecifier.AS_public) continue
             // ModelFactories.map's CXCursor_CXXBaseSpecifier branch: the base's type built
             // through the CXType factory (structural buildWrappedType here, brick 4),
             // isPublic from the access specifier, isVirtualBase from `virtual` inheritance.
             parent.addChild(
                 WrappedBase(
                     buildWrappedType(base.getType()),
-                    isPublic = base.getAccessSpecifier() == AccessSpecifier.AS_public,
+                    isPublic = true,
                     isVirtualBase = base.isVirtual()
                 )
             )

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -108,6 +108,16 @@ private class ModelBuilder {
     // identity (cppUsr) collapses namespace redeclarations the same way.
     private val namespaces = mutableMapOf<String, WrappedNamespace>()
 
+    // Redeclaration collapse for classes and class templates (#45 brick 3 — the std
+    // headers the forcing parse pulls in are full of forward declarations): the same
+    // canonical decl re-encountered maps to the SAME element, exactly like ModelFactories'
+    // USR-keyed elementLookup memo. Members attach only from the DEFINING redeclaration
+    // (a forward decl's pattern record SHARES DefinitionData with the definition, so
+    // reading bases()/members there would double-add — the cursor walk only ever sees a
+    // redecl's own children).
+    private val classes = mutableMapOf<String, WrappedClass>()
+    private val templates = mutableMapOf<String, WrappedTemplate>()
+
     // Walk one DeclContext (the TU or a namespace) and add its children to [parent].
     fun addContextDecls(context: DeclContext, parent: WrappedElement) {
         for (decl in context.decls()) {
@@ -125,7 +135,7 @@ private class ModelBuilder {
             // WrappedTemplate (ModelFactories.map's CXCursor_ClassTemplate branch).
             val classTemplate = decl.asClassTemplateDeclOrNull()
             if (classTemplate != null) {
-                buildTemplate(classTemplate)?.let { parent.addChild(it) }
+                addTemplate(classTemplate, decl, parent)
                 continue
             }
             // A ClassTemplateSpecializationDecl IS-A CXXRecordDecl, but libclang's cursor
@@ -139,7 +149,7 @@ private class ModelBuilder {
             }
             val record = decl.asCXXRecordDecl()
             if (record != null) {
-                parent.addChild(buildClass(record))
+                addClass(record, decl, parent)
                 continue
             }
             // Brick 5: a `typedef` is a WrappedTypedef element at ANY level — TU,
@@ -186,11 +196,23 @@ private class ModelBuilder {
     // built through the SAME paths as a plain class (mapAll's recursion reuses every
     // member branch on template children; the metadata side-effects land on the
     // WrappedTemplate via the shared `(parent as? WrappedTemplate)?.metadata` mirrors).
-    private fun buildTemplate(templateDecl: ClassTemplateDecl): WrappedTemplate? {
+    // Redeclarations collapse to ONE element (the memo); EVERY redeclaration's params
+    // re-walk through WrappedTemplate's merge machinery — mapAll resets templateArgCounter
+    // per template-cursor encounter, so repeat params land in the first params'
+    // `otherParams`, letting substitution key on ANY redecl's param name/usr — and the
+    // bases/members attach from the DEFINING redeclaration only.
+    private fun addTemplate(
+        templateDecl: ClassTemplateDecl,
+        decl: Decl,
+        parent: WrappedElement
+    ) {
         val record = templateDecl.getTemplatedDecl()
-            ?.let { CXXRecordDecl(it.ptr, templateDecl.memScope) } ?: return null
-        val name = record.asNamedDecl().getNameAsString() ?: error("template without a name")
-        val template = WrappedTemplate(name)
+            ?.let { CXXRecordDecl(it.ptr, templateDecl.memScope) } ?: return
+        val name = record.asNamedDecl().getNameAsString() ?: return
+        val template = templates.getOrPut(decl.cppUsr()) {
+            WrappedTemplate(name).also { parent.addChild(it) }
+        }
+        template.templateArgCounter = 0
         // getTemplateParameters() lives on TemplateDecl — ClassTemplateDecl's
         // address-identical primary base chain, so the same-pointer re-view is exact.
         // Each TYPE parameter mirrors ModelFactories' CXCursor_TemplateTypeParameter ->
@@ -199,26 +221,23 @@ private class ModelBuilder {
         val params = TemplateDecl(templateDecl.ptr, templateDecl.memScope)
             .getTemplateParameters()
             ?.let { TemplateParameterList(it.ptr, templateDecl.memScope) }
-            ?: return null
+            ?: return
         for (i in 0u until params.size()) {
             val param = params.getParam(i)
                 ?.let { NamedDecl(it.ptr, templateDecl.memScope) } ?: continue
             if (param.getKind() != Kind.TemplateTypeParm) continue
             template.addChild(
                 WrappedTemplateParam(
-                    param.getNameAsString() ?: error("template param without a name"),
+                    param.getNameAsString() ?: continue,
                     // The identity the dependent-T WrappedTemplateRef keys back to
                     // (TypeBuilder's TemplateTypeParmType branch reads the same decl).
                     Decl(param.ptr, templateDecl.memScope).cppUsr()
                 )
             )
         }
-        // The pattern record's bases/members go through the exact class construction
-        // path. hasDefinition guards a forward-declared template (definition-data reads).
-        if (record.hasDefinition()) {
+        if (templateDecl.isThisDeclarationADefinition()) {
             addBasesAndMembers(record, template, template.metadata)
         }
-        return template
     }
 
     private fun addNamespace(decl: NamespaceDecl, parent: WrappedElement) {
@@ -233,15 +252,21 @@ private class ModelBuilder {
         addContextDecls(decl.asDeclContext(), namespace)
     }
 
-    private fun buildClass(record: CXXRecordDecl): WrappedClass {
-        val name = record.asNamedDecl().getNameAsString() ?: error("record without a name")
+    private fun addClass(record: CXXRecordDecl, decl: Decl, parent: WrappedElement) {
+        val name = record.asNamedDecl().getNameAsString() ?: return
         // ModelFactories' WrappedClass factory: name via wrapName (= the bare name for a
         // non-template class; template-args spelling is brick-4+) + the isAbstract flag.
-        // hasDefinition() guards a forward-declared record, whose definition-data
-        // accessors may not be read (libclang's isAbstract reads the definition too).
-        val cls = WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
-        addBasesAndMembers(record, cls, cls.metadata)
-        return cls
+        // hasDefinition() guards a never-defined record, whose definition-data accessors
+        // may not be read (DefinitionData is SHARED across redeclarations, so it holds
+        // even when the walk meets a forward declaration first). Redeclarations collapse
+        // to one element via the memo; members attach from the defining redecl only.
+        val cls = classes.getOrPut(decl.cppUsr()) {
+            WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
+                .also { parent.addChild(it) }
+        }
+        if (record.isThisDeclarationADefinition()) {
+            addBasesAndMembers(record, cls, cls.metadata)
+        }
     }
 
     // The shared class-body construction: bases + every member through the same branches,

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -21,7 +21,6 @@ import clang.Type
 import clang.TypedefNameDecl
 import clang.TypedefType
 import clang.decl.Kind
-import clang.templateArgument.ArgKind
 import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
 import com.monkopedia.krapper.generator.model.type.WrappedEnumType
 import com.monkopedia.krapper.generator.model.type.WrappedFunctionPointer
@@ -33,6 +32,9 @@ import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.const
 import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.pointerTo
 import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referenceTo
 import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
+import kppbridge.numTemplateArgs
+import kppbridge.templateArgAsType
+import kppbridge.templateBaseName
 
 // STRUCTURAL type construction (#44 brick 4): decode a clang::QualType's type tree into the
 // same WrappedType shapes the libclang-C front-end produces, rule-for-rule against
@@ -127,27 +129,28 @@ fun buildWrappedType(type: QualType): WrappedType {
 
     // invoke lines 80-104: template arguments detected on the type itself OR its canonical
     // form (alias/elaborated sugar hides them) -> WrappedTemplateType(baseRef, args).
-    // Structurally, every template-specialization TYPE's canonical form is a record whose
-    // decl dyn-casts to ClassTemplateSpecializationDecl (type-decode probe, P5). Checked
-    // BEFORE the typedef handling for the same reason invoke checks it before
-    // createForType: an alias over a template type still collapses to the template shape.
+    // #45 brick 3: decoded through the CIndex GetTemplateArguments MIRROR (kppbridge):
+    // the sugared TemplateSpecializationType's WRITTEN args are preferred — exactly what
+    // clang_Type_getNumTemplateArguments reads, so `std::vector<Item*>` carries ONE arg
+    // (the defaulted allocator is NOT part of the libclang type, and the forcing key /
+    // tracker key depends on that spelling) — with the canonical specialization decl's
+    // full list as the fallback. The TST half also catches DEPENDENT specializations
+    // (`vector<_Tp, _Alloc>`, `allocator<_Tp>` inside a template's own member
+    // signatures), which have no canonical record and previously fell through to a
+    // canonical-spelling leaf ("vector<type-parameter-0-0,...>"). Checked BEFORE the
+    // typedef handling for the same reason invoke checks it before createForType: an
+    // alias over a template type still collapses to the template shape. A non-type
+    // argument decodes to a null QualType and is dropped (TypeFactories' CXType_Invalid
+    // filterNotNull).
     val canonical = type.getCanonicalType()
     val canonTy = canonical.typePtr()
-    val spec = canonTy?.asRecord()?.asClassTemplateSpecializationDecl()
-    if (spec != null) {
-        // Base ref: createForType(forTemplateBase=true) resolves the specialization decl
-        // (surfaced as a ClassDecl/StructDecl cursor) -> WrappedType(referencedDecl
-        // .fullyQualified); NamedDecl::getQualifiedNameAsString() is the Decl-side spelling
-        // of that same semantic-parent walk (template args are not part of either).
-        val baseName = spec.getQualifiedNameAsString() ?: return UNRESOLVABLE
-        val argList = spec.getTemplateArgs() ?: return UNRESOLVABLE
-        val args = (0u until argList.size()).mapNotNull { i ->
-            // TypeFactories keeps only TYPE arguments: getTemplateArgumentType yields
-            // CXType_Invalid for a value arg, and the invalid slot is dropped
-            // (filterNotNull) — the ArgKind.Type filter is that same rule decl-side.
-            val arg = argList.get(i) ?: return@mapNotNull null
-            if (arg.getKind() != ArgKind.Type) return@mapNotNull null
-            buildWrappedType(arg.getAsType())
+    val templateArgCount = with(type.memScope) { numTemplateArgs(type) }
+    if (templateArgCount > 0) {
+        val baseName = with(type.memScope) { templateBaseName(type) }
+            ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
+        val args = (0u until templateArgCount.toUInt()).mapNotNull { i ->
+            val arg = with(type.memScope) { templateArgAsType(type, i) }
+            if (arg.typePtr() == null) null else buildWrappedType(arg)
         }
         return WrappedTemplateType(WrappedTypeReference(baseName), args).maybeConst(isConst)
     }
@@ -156,16 +159,22 @@ fun buildWrappedType(type: QualType): WrappedType {
         return buildTypedefTargetType(typedef).maybeConst(isConst)
     }
 
-    // Dependent template-parameter reference: createForType's CXCursor_TemplateTypeParameter
-    // branch (TypeFactories) -> WrappedTemplateRef(the param DECL's USR) — NOT the canonical
-    // `type-parameter-0-0` spelling and NOT the bare name `T`: the identity string ties the
-    // use back to the matching WrappedTemplateParam.usr so substitution can key on it. This
-    // front-end's identity is the same cpp:<canonical-id> convention (ModelBuilder.kt), so
-    // the ref and the param agree. Read off the SUGARED type: the canonical
+    // Dependent template-parameter reference -> WrappedTemplateRef keyed by the param's
+    // NAME. #45 brick 3 revision (was cpp:<id> identity): on the libclang path, every
+    // dependent use inside a ClassTemplate's member signatures hits TypeFactories'
+    // CXType_Unexposed/NoDeclFound fallback — WrappedTemplateRef(spelling), i.e. the
+    // BARE NAME ("_Tp") — because libclang does not resolve the dependent decl (the
+    // USR-keyed CXCursor_TemplateTypeParameter branch effectively never fires there).
+    // The name key is LOAD-BEARING for output parity: a member's pre-substitution
+    // spelling is baked into its uniqueCName (`...new__size_t_const_template__Tp_and`),
+    // so an identity key would leak a nondeterministic cpp:<id> into generated symbol
+    // names. Substitution accepts either key (Parsing.typedAs maps each param's name AND
+    // usr), so resolution is unaffected. Read off the SUGARED type: the canonical
     // TemplateTypeParmType carries no decl (TypeBase.h: `assert(!TTPDecl == Canon.isNull())`).
     ty.asTemplateTypeParmType()?.let { parm ->
         val decl = parm.getDecl() ?: return UNRESOLVABLE
-        return WrappedTemplateRef(decl.asDecl().cppUsr()).maybeConst(isConst)
+        val name = decl.asNamedDecl().getNameAsString() ?: return UNRESOLVABLE
+        return WrappedTemplateRef(name).maybeConst(isConst)
     }
 
     // ---- createForType leaf dispatch (post-visit, i.e. against the canonical type) ----
@@ -248,6 +257,7 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
     if (typedef.asDecl().getKind() == Kind.Typedef) {
         functionPointerTypedef(typedef)?.let { return it }
     }
+    referenceTypedef(typedef)?.let { return it }
     val name = typedef.getNameAsString() ?: ""
     when (name) {
         "size_type" -> return WrappedTypeReference("size_t")
@@ -255,6 +265,49 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
     }
     if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name)
     return buildWrappedType(typedef.getUnderlyingType())
+}
+
+/**
+ * TypeFactories.referenceTypedefElement (#45 brick 3): a std-container
+ * `reference`/`const_reference` member alias whose underlying is a DEPENDENT trait
+ * expression (libstdc++ routes it through `_Alloc_traits::reference`, which libclang
+ * reports as CXType_Unexposed and can't reduce) is rewritten to `value_type&` /
+ * `const value_type&` from the sibling `value_type` typedef's underlying — this is what
+ * keeps vector's at/operator[]/front/back accessors alive. Gates mirrored:
+ *  - only when the underlying is dependent AND not itself a concrete reference/pointer
+ *    shape (libclang's Unexposed-kind test: a dependent `_Tp&` spells as
+ *    CXType_LValueReference, NOT Unexposed, and must fall through);
+ *  - only when the sibling element type is NOT a template specialization (associative
+ *    containers' `value_type = pair<const Key, T>` stays opaque — const members).
+ */
+private fun referenceTypedef(typedef: TypedefNameDecl): WrappedType? {
+    val name = typedef.getNameAsString()
+    val isConstRef = name == "const_reference"
+    if (name != "reference" && !isConstRef) return null
+    val underlying = typedef.getUnderlyingType().typePtr() ?: return null
+    if (!underlying.isDependentType() ||
+        underlying.isReferenceType() || underlying.isPointerType()
+    ) {
+        return null
+    }
+    val valueTypedef = siblingTypedef(typedef, "value_type") ?: return null
+    val elementType = buildWrappedType(valueTypedef.getUnderlyingType())
+    if (elementType == UNRESOLVABLE) return null
+    if (elementType is WrappedTemplateType) return null
+    return referenceTo(if (isConstRef) const(elementType) else elementType)
+}
+
+// The sibling typedef of [typedef]'s parent context with the given [name] (the
+// `semanticParent.children` walk of the libclang reducers). `typedef`-kind only,
+// mirroring the CXCursor_TypedefDecl filter.
+private fun siblingTypedef(typedef: TypedefNameDecl, name: String): TypedefNameDecl? {
+    val context = typedef.asDecl().getDeclContext() ?: return null
+    for (decl in context.decls()) {
+        if (decl == null || decl.getKind() != Kind.Typedef) continue
+        val sibling = decl.asTypedefNameDecl() ?: continue
+        if (sibling.getNameAsString() == name) return sibling
+    }
+    return null
 }
 
 // TypeFactories.isCFunctionPointerCompatible, verbatim: only plain native scalars, void,

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -148,6 +148,15 @@ fun buildWrappedType(type: QualType): WrappedType {
     if (templateArgCount > 0) {
         val baseName = with(type.memScope) { templateBaseName(type) }
             ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
+        // std::initializer_list is compiler magic the C boundary can never marshal (a
+        // Kotlin caller cannot construct one), so it is UNRESOLVABLE by construction —
+        // members taking one drop in resolution (or have the defaulted arg omitted),
+        // matching the libclang path, where the same members drop because that
+        // front-end's `initializer_list<value_type>` spelling keeps the alias-name leaf
+        // its order-dependent visit() collapse can't resolve. This front-end's faithful
+        // decode (value_type -> the substituted element type) would otherwise
+        // MATERIALIZE initializer_list<Item*> as a useless extra binding.
+        if (baseName == "std::initializer_list") return UNRESOLVABLE
         val args = (0u until templateArgCount.toUInt()).mapNotNull { i ->
             val arg = with(type.memScope) { templateArgAsType(type, i) }
             if (arg.typePtr() == null) null else buildWrappedType(arg)

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -203,6 +203,24 @@ class KrapperGen : CliktCommand() {
         help = "Path to the ModelIo JSON WrappedTU to load when --frontend=cpp " +
             "(required in that mode; ignored otherwise)."
     )
+    val forcingModel by option(
+        "--forcingModel",
+        help = "Instantiation forcing on the cpp path (#45 brick 3): " +
+            "'<spec>=<path>' maps an --instantiate spec (e.g. 'std::vector<Item*>') to " +
+            "the ModelIo JSON of its FORCING-PARSE WrappedTU — the tree the libclang " +
+            "path gets by synthesizing a KrapperForce_* header and re-parsing it, here " +
+            "produced by the cppfrontend binary instead. Repeatable; with --frontend=cpp " +
+            "every --instantiate spec must have a matching entry. Ignored otherwise."
+    ).multiple()
+    val dumpModels by option(
+        "--dumpModels",
+        help = "Debug/oracle flag (#45 brick 3, libclang path): write every parse's " +
+            "post-reduce WrappedTU (the main header parse AND each instantiation's " +
+            "forcing re-parse) as ModelIo JSON into the given directory " +
+            "(model_<n>_<header>.json) and continue the run. The files are directly " +
+            "consumable by --frontend=cpp --parsedModel/--forcingModel, which is how the " +
+            "file-handoff instantiation flow is proven against the in-process run."
+    )
     val fixupFile by option(
         "--fixup-file",
         help = "Path to a JSON file containing a list of Fixup directives (see Fixup.kt). " +
@@ -224,15 +242,30 @@ class KrapperGen : CliktCommand() {
         // pipeline below is otherwise unchanged — parseHeader returns a ParsedResolver
         // over the LOADED tree instead of a libclang parse, and resolution+codegen run
         // exactly as the --roundTripModel oracle proved they can on a decoded model.
+        dumpModelsDir = dumpModels
         if (frontend == Frontend.CPP) {
-            require(instantiate.isEmpty()) {
-                "--frontend=cpp does not support --instantiate yet: instantiation " +
-                    "forcing synthesizes a forcing header and re-parses it through " +
-                    "libclang (IndexedServiceImpl.requestInstantiation), which the cpp " +
-                    "front-end path skips. Scoped out of #45 brick 2."
-            }
             cppParsedModelPath = parsedModel
                 ?: error("--frontend=cpp requires --parsedModel <path>")
+            // #45 brick 3: --instantiate is supported on the cpp path when every spec has
+            // a forcing model (the cppfrontend-produced tree replacing the libclang
+            // forcing re-parse). Keys are normalized through parseInstantiation so the
+            // --forcingModel spelling matches requestInstantiation's target string
+            // regardless of arg spacing ('std::vector<Item *>' vs 'std::vector<Item*>').
+            cppForcingModelPaths = forcingModel.associate { entry ->
+                val idx = entry.indexOf('=')
+                require(idx > 0) { "--forcingModel must be '<spec>=<path>', got: $entry" }
+                val req = parseInstantiation(entry.substring(0, idx))
+                "${req.base}<${req.args.joinToString(", ")}>" to entry.substring(idx + 1)
+            }
+            val missing = instantiate.map { parseInstantiation(it) }
+                .map { "${it.base}<${it.args.joinToString(", ")}>" }
+                .filter { it !in cppForcingModelPaths }
+            require(missing.isEmpty()) {
+                "--frontend=cpp requires a --forcingModel '<spec>=<path>' for every " +
+                    "--instantiate spec; missing: $missing (instantiation forcing on " +
+                    "this path loads the cppfrontend-produced forcing-parse model " +
+                    "instead of re-parsing through libclang)."
+            }
         }
         runBlocking {
             val service = KrapperServiceImpl()

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -40,6 +40,7 @@ import com.monkopedia.krapper.generator.codegen.File
 import com.monkopedia.krapper.generator.codegen.HeaderWriter
 import com.monkopedia.krapper.generator.codegen.KotlinWriter
 import com.monkopedia.krapper.generator.codegen.NameHandler
+import com.monkopedia.krapper.generator.model.ForcingHeader
 import com.monkopedia.krapper.generator.model.WrappedClass
 import com.monkopedia.krapper.generator.model.kotlinType
 import com.monkopedia.krapper.generator.model.type.WrappedType
@@ -168,35 +169,12 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     override suspend fun requestInstantiation(req: InstantiationRequest) {
         val target = "${req.base}<${req.args.joinToString(", ")}>"
         requested.add(target)
-        val forceName = "KrapperForce_" + target
-            .replace("::", "_")
-            .replace("<", "_")
-            .replace(">", "")
-            .replace(", ", "_")
-            .replace(" ", "")
-            // A pointer/reference template arg (e.g. std::vector<Thing*>, from the T1.3
-            // range materialization) would otherwise leak `*`/`&` into the struct's
-            // identifier and the temp filename — both illegal — crashing the parse with
-            // `expected unqualified-id`. Map them to a token instead. The forcing struct's
-            // `value` member still uses the real `$target` (Thing*), so the instantiation
-            // is unaffected.
-            .replace("*", "Ptr")
-            .replace("&", "Ref")
-        val forcingContent = buildString {
-            // Every type in the instantiation must be declared, not just the
-            // outer base — previously only stdHeaderFor(req.base) was included,
-            // so std::vector<std::string> failed (basic_string undeclared).
-            // Include std headers TARGETED to the types named in `target`
-            // (scanning, so nested element types are covered) plus the
-            // consumer's own headers (for user element types like a wrapped
-            // struct in std::vector<Point>). Targeted rather than a blanket
-            // bundle: a broad include drags unrelated system structs in under
-            // INCLUDE_MISSING (e.g. <sys/timex.h>'s `timex`), which then
-            // generate invalid wrappers.
-            for (stdHeader in stdHeadersFor(target)) appendLine("#include $stdHeader")
-            for (userHeader in request.headers) appendLine("#include \"$userHeader\"")
-            appendLine("struct $forceName { $target value; };")
-        }
+        // The forcing struct's name + header content are SHARED with the cpp front-end
+        // (ForcingHeader, :krapper_model): the cppfrontend binary synthesizes the same
+        // bytes for its forcing parse, so both paths force the same specialization from
+        // the same translation unit.
+        val forceName = ForcingHeader.forceName(target)
+        val forcingContent = ForcingHeader.contentFor(target, request.headers)
         forcingHeaders[forceName] = forcingContent
         // #45 brick 3: with --frontend=cpp the forcing-parse tree was already produced by
         // the cppfrontend binary (which synthesizes the SAME forcing header and parses it
@@ -289,36 +267,6 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
                 it !is ResolvedMethod || it.forcingIdentity in boundMethodIds
             }
             ).dedupClassesLastWins()
-    }
-
-    // The std headers needed to declare the types named in an instantiation
-    // target string. Scans for type tokens so nested element types are covered
-    // (e.g. std::vector<std::string> -> <vector> + <string>). Targeted, not a
-    // blanket include, so unrelated system types aren't dragged in under
-    // INCLUDE_MISSING.
-    private fun stdHeadersFor(target: String): List<String> =
-        STD_TYPE_HEADERS.filter { (token, _) -> target.contains(token) }
-            .map { it.second }
-            .distinct()
-
-    private companion object {
-        // token (as it appears in a canonical type string) -> std header.
-        // "basic_string" matches std::__cxx11::basic_string (canonical std::string).
-        val STD_TYPE_HEADERS = listOf(
-            "basic_string" to "<string>",
-            "vector" to "<vector>",
-            "unordered_map" to "<unordered_map>",
-            "unordered_set" to "<unordered_set>",
-            "map" to "<map>",
-            "set" to "<set>",
-            "list" to "<list>",
-            "deque" to "<deque>",
-            "pair" to "<utility>",
-            "tuple" to "<tuple>",
-            "unique_ptr" to "<memory>",
-            "shared_ptr" to "<memory>",
-            "weak_ptr" to "<memory>"
-        )
     }
 
     override suspend fun writeTo(output: String) {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -198,19 +198,32 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             appendLine("struct $forceName { $target value; };")
         }
         forcingHeaders[forceName] = forcingContent
-        // Parse from a per-run temp file (cleaned in close()); the same header is
-        // re-materialized into the output dir by writeTo for the generated wrapper.
-        val tmpFile = File(tempDir(), "$forceName.h").path
-        File(tmpFile).writeText(forcingContent)
-        Log.i("Forcing instantiation of $target via $tmpFile")
-        val resolver = scope.parseHeader(
-            index,
-            listOf(tmpFile),
-            includePaths + request.headerDirectories,
-            args = parseArgs(request.headerDirectories),
-            debug = config.debug,
-            strictDiagnostics = config.strictDiagnostics
-        )
+        // #45 brick 3: with --frontend=cpp the forcing-parse tree was already produced by
+        // the cppfrontend binary (which synthesizes the SAME forcing header and parses it
+        // with the Clang C++ AST); load it instead of parsing through libclang. The
+        // forcing header content above is still recorded either way: writeTo
+        // re-materializes it so the generated wrapper can #include the specialization's
+        // declaration. Everything downstream of obtaining the resolver — the scoping,
+        // resolveForcing's 3-pass dance, cumulative forcedContainerKeys, dedup — is the
+        // SAME code on both paths.
+        val resolver = cppForcingModelPaths[target]?.let { path ->
+            Log.i("cpp front-end forcing handoff: loading $target model from $path")
+            loadParsedModel(path)
+        } ?: run {
+            // Parse from a per-run temp file (cleaned in close()); the same header is
+            // re-materialized into the output dir by writeTo for the generated wrapper.
+            val tmpFile = File(tempDir(), "$forceName.h").path
+            File(tmpFile).writeText(forcingContent)
+            Log.i("Forcing instantiation of $target via $tmpFile")
+            scope.parseHeader(
+                index,
+                listOf(tmpFile),
+                includePaths + request.headerDirectories,
+                args = parseArgs(request.headerDirectories),
+                debug = config.debug,
+                strictDiagnostics = config.strictDiagnostics
+            )
+        }
         // SCOPE THE FORCING COLLECTION. The synthetic header #includes the consumer's
         // own headers, so `findClasses { defaultFilter() }` collects EVERY class in the
         // re-parsed TU — against a large library that is the whole transitive surface

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -145,6 +145,43 @@ var roundTripParsedModel: Boolean =
 // is Phase E; what matters here is the cpp path never CALLS it.
 var cppParsedModelPath: String? = null
 
+// Instantiation forcing on the cpp path (#45 brick 3), set by KrapperGen --frontend=cpp
+// --forcingModel <spec>=<path>. Maps each normalized instantiation target (e.g.
+// "std::vector<Item*>") to the ModelIo JSON of its FORCING-PARSE WrappedTU — the tree the
+// libclang path obtains by synthesizing a `KrapperForce_*` header and re-parsing it
+// (IndexedServiceImpl.requestInstantiation). With an entry present, requestInstantiation
+// loads the tree instead of parsing, and the whole downstream flow (scoping +
+// resolveForcing's 3-pass dance + cumulative keys + dedup) runs UNCHANGED over it.
+// CLI-scoped global, same rationale as [cppParsedModelPath].
+var cppForcingModelPaths: Map<String, String> = emptyMap()
+
+// Model-dump oracle (#45 brick 3), set by KrapperGen --dumpModels <dir>. On the LIBCLANG
+// path, every [parseHeader] (the main header parse AND each instantiation's forcing parse)
+// additionally serializes its post-reduce, pre-rewrite WrappedTU as ModelIo JSON into the
+// directory (model_<n>_<firstHeaderName>.json) and CONTINUES the run. The dumped files are
+// exactly what --frontend=cpp consumes via --parsedModel/--forcingModel, so feeding them
+// back through the cpp path and diffing the generated output proves the file-handoff
+// instantiation flow (fresh instances, no cursor->element memo) reproduces the in-process
+// libclang run — isolating flow correctness from cppfrontend model-construction fidelity.
+var dumpModelsDir: String? = null
+private var dumpModelCounter = 0
+
+/**
+ * Load a ModelIo WrappedTU from [path] and prepare it for resolution exactly the way a
+ * libclang parse is prepared: run the pre-resolution rewrites, then wrap in a
+ * ParsedResolver. Shared by the --frontend=cpp base-model hook in [parseHeader] and the
+ * per-instantiation forcing-model load in IndexedServiceImpl.requestInstantiation. No
+ * cursor->element memo exists on this path (nothing was parsed in-process); identity
+ * across the separately-loaded trees is structural (type-string keys), which is all the
+ * forcing flow consults (alreadyBoundKeys / tracker keys / dedup are string-keyed).
+ */
+internal suspend fun loadParsedModel(path: String): ParsedResolver {
+    val restored = ModelIo.decodeFromString(File(path).readText())
+    rewriteViewReturns(restored)
+    rewriteUniquePtrReturns(restored)
+    return ParsedResolver(restored)
+}
+
 fun FilterDefinition.wrapperFilter(): (WrappedElement) -> Boolean {
     return when (this) {
         is AndFilter -> {
@@ -582,11 +619,8 @@ suspend fun DeferScope.parseHeader(
     // later parse ever needs to rediscover these instances. The pre-resolution rewrites
     // run on the loaded tree exactly as they do on a --roundTripModel restored tree.
     cppParsedModelPath?.let { path ->
-        val restored = ModelIo.decodeFromString(File(path).readText())
-        Log.i("cpp front-end handoff: loaded parsed model from $path (libclang parse skipped)")
-        rewriteViewReturns(restored)
-        rewriteUniquePtrReturns(restored)
-        return ParsedResolver(restored)
+        Log.i("cpp front-end handoff: loading parsed model from $path (libclang parse skipped)")
+        return loadParsedModel(path)
     }
     val builder = ResolverBuilderImpl()
     val tu = file.map {
@@ -613,6 +647,17 @@ suspend fun DeferScope.parseHeader(
         File(path).writeText(Json.encodeToString(tu.serialized()))
         Log.i("Dumped parsed model to $path (parse-only mode, exiting)")
         exitProcess(0)
+    }
+    // Model-dump oracle (#45 brick 3): serialize EVERY parse's tree (main + each forcing
+    // re-parse) as ModelIo JSON and continue. Placed at the same post-reduce, pre-rewrite
+    // point as the hooks above so the dumped file is byte-compatible with what the
+    // --frontend=cpp load path expects (loadParsedModel re-applies the rewrites itself).
+    dumpModelsDir?.let { dir ->
+        File(dir).mkdirs()
+        val name = File(file.first()).name.substringBeforeLast(".")
+        val out = File(File(dir), "model_${dumpModelCounter++}_$name.json")
+        out.writeText(ModelIo.encodeToString(tu))
+        Log.i("Dumped ModelIo model to ${out.path}")
     }
     // Round-trip oracle (#45 brick 1): serialize the parsed model to JSON, deserialize
     // it back, and hand the rest of the pipeline THE DESERIALIZED TREE. Placed at the

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ForcingHeader.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ForcingHeader.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator.model
+
+/**
+ * The synthesized forcing header for a template instantiation request (`--instantiate
+ * "std::vector<T*>"`): a `KrapperForce_*` struct whose `value` member's type IS the
+ * requested specialization, `#include`-ing the std headers the target names plus the
+ * consumer's own headers. Resolving the struct's member materializes the specialization.
+ *
+ * SHARED between the two front-ends (#45 brick 3): the libclang path
+ * (IndexedServiceImpl.requestInstantiation) re-parses this header through libclang; the
+ * cpp front-end (the cppfrontend binary) parses the SAME bytes through the Clang C++ AST
+ * and hands the resulting model off as ModelIo JSON (`--forcingModel`). One definition
+ * guarantees both front-ends force the same specialization from the same translation unit
+ * — and that the `forceName` the generated wrapper #includes by matches on both paths.
+ */
+object ForcingHeader {
+
+    /**
+     * The forcing struct's name (also the synthesized header's file name). A pointer/
+     * reference template arg (e.g. std::vector<Thing*>, from the T1.3 range
+     * materialization) would otherwise leak `*`/`&` into the struct's identifier and the
+     * filename — both illegal — crashing the parse with `expected unqualified-id`. Map
+     * them to a token instead. The forcing struct's `value` member still uses the real
+     * target (Thing*), so the instantiation is unaffected.
+     */
+    fun forceName(target: String): String = "KrapperForce_" + target
+        .replace("::", "_")
+        .replace("<", "_")
+        .replace(">", "")
+        .replace(", ", "_")
+        .replace(" ", "")
+        .replace("*", "Ptr")
+        .replace("&", "Ref")
+
+    /**
+     * The synthesized header's content. Every type in the instantiation must be declared,
+     * not just the outer base (std::vector<std::string> needs basic_string declared too),
+     * so the std includes are TARGETED to the types named in [target] (scanning, so nested
+     * element types are covered) plus the consumer's own [userHeaders] (for user element
+     * types like a wrapped struct in std::vector<Point>). Targeted rather than a blanket
+     * bundle: a broad include drags unrelated system structs in under INCLUDE_MISSING
+     * (e.g. <sys/timex.h>'s `timex`), which then generate invalid wrappers.
+     */
+    fun contentFor(target: String, userHeaders: List<String>): String = buildString {
+        for (stdHeader in stdHeadersFor(target)) appendLine("#include $stdHeader")
+        for (userHeader in userHeaders) appendLine("#include \"$userHeader\"")
+        appendLine("struct ${forceName(target)} { $target value; };")
+    }
+
+    /**
+     * The std headers needed to declare the types named in an instantiation target
+     * string. Scans for type tokens so nested element types are covered (e.g.
+     * std::vector<std::string> -> <vector> + <string>).
+     */
+    fun stdHeadersFor(target: String): List<String> =
+        STD_TYPE_HEADERS.filter { (token, _) -> target.contains(token) }
+            .map { it.second }
+            .distinct()
+
+    // token (as it appears in a canonical type string) -> std header.
+    // "basic_string" matches std::__cxx11::basic_string (canonical std::string).
+    private val STD_TYPE_HEADERS = listOf(
+        "basic_string" to "<string>",
+        "vector" to "<vector>",
+        "unordered_map" to "<unordered_map>",
+        "unordered_set" to "<unordered_set>",
+        "map" to "<map>",
+        "set" to "<set>",
+        "list" to "<list>",
+        "deque" to "<deque>",
+        "pair" to "<utility>",
+        "tuple" to "<tuple>",
+        "unique_ptr" to "<memory>",
+        "shared_ptr" to "<memory>",
+        "weak_ptr" to "<memory>"
+    )
+}


### PR DESCRIPTION
#45 brick 3 (Phase C): instantiation forcing on the cpp path — `--frontend=cpp --instantiate` works end-to-end on an instantiation-bearing fixture, the gate to Phase D.

## Design choice: (a) cppfrontend does the forcing parses — with an oracle-first proof split

Both candidate shapes were judged against the real code:

- **(b) model-side instantiation** was REJECTED on evidence: krapper's "instantiation" is *already* model-side substitution (`WrappedTemplate.typedAs`) — what the forcing re-parse actually provides is the **parsed std template declaration** (featuregen's headers don't include `<vector>`; the template only enters the model through the forcing TU's `#include <vector>`). There is no parse to delete — (b) collapses into (a) minus generality.
- **(a)**: cppfrontend synthesizes the SAME forcing header the libclang path synthesizes (`ForcingHeader`, extracted to `:krapper_model` so one definition serves both front-ends), parses it as a separate args-bearing TU (`kppbridge::buildASTWithArgs` — clang::tooling needs an explicit `-resource-dir` for the builtin headers behind `<vector>`), and emits the tree as ModelIo JSON. `krapper_gen --frontend=cpp --forcingModel '<spec>=<path>'` loads it instead of re-parsing through libclang; **everything downstream — the scoped collection, `resolveForcing`'s 3-pass policy dance, cumulative `forcedContainerKeys`, last-wins dedup — is the same code on both paths** (one seam in `requestInstantiation`).

## Cross-TU identity resolution

`Decl::getID()` is per-ASTContext (NOT stable across `buildASTFromCode` calls), so each payload is self-contained: nothing references identity ACROSS payloads, and krapper_gen merges the trees by **structural identity (type-string keys)** — `alreadyBoundKeys`, the tracker maps, and dedup are all string-keyed, which is exactly what the libclang USR memo's shared instances collapse to. Dependent param refs inside template members now key on the param **NAME** (`template<_Tp>`) — the libclang in-template fallback every member use actually hits, and the spelling baked into uniqueCNames (an identity key would leak nondeterministic `cpp:<id>` into generated symbols); `typedAs` maps name AND usr, so substitution is unaffected.

## Proven end-to-end (`:cppfrontend:handoffInstDiff`, gated `-PenableClang`)

Fixture: `Item` + `Bag::items() -> std::vector<Item*>` (featuregen's RangeHolder shape) + `--instantiate "std::vector<Item*>"`. `items()` drops on the main resolve (container unbound) and is recovered by pass-3 forcing — the full libclang flow, mirrored.

- **Gate 1 — THE FLOW PROOF (byte)**: the libclang baseline also dumps its parse trees (`--dumpModels`, main + forcing); fed back through `--frontend=cpp --forcingModel`, output is **byte-identical across all 9 files** (path-modulo .def). This isolates the file-handoff flow — fresh instances, no cursor→element memo — from front-end construction fidelity.
- **Gate 2 — the cppfrontend-model run (functional)**: the C++-AST front-end's own parses through the same flow materialize the specialization, recover `items()`, produce the SAME file set, core container surface present, wrapper compiled. `root_Bag.kt` / `root_Item.kt` / `CppBinding.kt` are **byte-identical**; `std_Vector__Item_P.kt` differs in **8 lines, all one cause**: two ctor uniqueCNames spell `const_allocator_type_and` (libclang keeps the alias-name leaf its order-dependent `visit()` collapse couldn't resolve) vs `const_template__Alloc_and` (this front-end's deterministic collapse). Public Kotlin API is identical.

**Why gate 2 is functional, not byte**: member uniqueCNames bake libclang's *lossy pre-substitution spellings* (`template<_Pointer>`, `_E*<...>`, Unexposed-fallback artifacts, order-dependent alias collapse — evidence table in the investigation). Byte-parity there means emulating that lossiness bug-for-bug, which this rewrite exists to delete. The flow itself is held to byte-parity by gate 1.

## What it took (cppfrontend fidelity work, each mirroring a cited libclang rule)
- CIndex `GetTemplateArguments` mirror (`kppbridge`): WRITTEN args preferred (`std::vector<Item*>` is ONE arg — the forcing key depends on it); dependent specializations (`vector<_Tp,_Alloc>` in member signatures) decode structurally.
- Redeclaration collapse for classes/templates (the USR-memo equivalent); params re-merge per redecl (`otherParams`), members attach from the defining redecl only.
- Protected/private BASE specifiers filtered (ModelFactories' access filter) — vector's `protected _Vector_base` would hard-fail INCLUDE reference-expansion.
- `referenceTypedefElement` mirrored (`reference`/`const_reference` -> `value_type&`) — the at/operator[]/front/back survival rule.
- Anonymous-record typedef-name rule (`max_align_t`).
- `std::initializer_list` UNRESOLVABLE by construction (the boundary can never marshal one; libclang drops the same members by spelling accident).

## Verify
- FULL default gate: krapper_gen **313/0**, featuregen **188/0** (+ kplusplusSync, ZERO krapped/ drift — the libclang path with the `ForcingHeader` refactor is byte-stable), krapper_model build, ktlintCheck — all green.
- Gated: cppfrontend self-checks ALL PASS, goldenCompare PASS (normalizer unchanged — it already rewrote both ref-key forms), handoffGenerate (base) green, handoffInstDiff both gates green.

## Remainder (filed on #45)
- Gate-2 byte-parity = the alias-collapse divergence (N5): durable convergence needs either deterministic collapse on the libclang path or alias preservation here — Phase D tail.
- `pointerTypedefElement`/`assocTypedefElement` mirrors (unique_ptr/map/set instantiations) + `WrappedTemplateParam` defaultType capture: needed for featuregen's full 17-instantiation set, not for vector.
- Multi-instantiation cumulative recovery on the cpp path is wired (`forcedContainerKeys` is front-end-agnostic) but only single-instantiation is fixture-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
