### PR TITLE
cppfrontend: Phase D entry — remaining fidelity mirrors + the first full featuregen parity attempt (#46)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -181,6 +181,10 @@ kplusplus {
         // Lexer::getSourceText over ParmVarDecl::getDefaultArgRange() (see clang_slice.h
         // for why Lexer/SourceManager/LangOptions aren't bound wholesale yet).
         "kppbridge::defaultArgText",
+        // NEW for Phase D (#46): WrappedTemplateParam.defaultType capture — the
+        // TemplateArgumentLoc unwrap for TemplateTypeParmDecl::getDefaultArgument()
+        // (see clang_slice.h).
+        "kppbridge::defaultArgType",
         // NEW for #45 brick 3 (instantiation forcing): the forcing-parse entry point —
         // buildASTFromCode with REAL driver args ('\n'-joined; -resource-dir + -std), the
         // smallest bridge until std::vector<std::string> params are bindable (see
@@ -409,6 +413,239 @@ val handoffOracleGenerate = tasks.register<Exec>("handoffOracleGenerate") {
             ).absolutePath
         ) + instGenerateArgs(outDir)
     )
+}
+
+// ---- Phase D entry (#46): FEATUREGEN PARITY ----
+// The first full featuregen parity attempt under --frontend=cpp: for EACH of featuregen's
+// instantiation requests (krapped/requested.txt + the build's seeded instantiate() calls —
+// the same worklist kplusplusSync hands krapper_gen), generate featuregen's bindings
+// through BOTH front-ends and diff: the libclang baseline vs --frontend=cpp over
+// cppfrontend-emitted models, with an IDENTICAL CLI tail so the diff isolates the
+// front-end swap. One unit per spec (header + that single instantiation — per-spec
+// failure isolation) plus the ALL unit (every spec at once, the real sync's shape).
+// Verdicts: identical (byte-identical, path-modulo .def) / diff (N lines, the categorized
+// worklist) / fail (generation failed). The task exits nonzero only on REGRESSION against
+// parity-expectations.txt (the committed expected-state ledger, like a test-skip list —
+// CI-able while Phase D converges); improvements are reported so the ledger ratchets.
+val parityDir = layout.buildDirectory.dir("parity").get().asFile
+val parityHeader = rootProject.layout.projectDirectory
+    .file("featuregen/src/cppMain/include/strings_feature.h").asFile
+val parityManifest = rootProject.layout.projectDirectory
+    .file("featuregen/krapped/requested.txt").asFile
+val parityExpectations = layout.projectDirectory.file("parity-expectations.txt").asFile
+
+// featuregen's seeded instantiate() calls (featuregen/build.gradle.kts kplusplus{}) — the
+// manifest only carries the compiler-plugin-requested specs, seeds are build config.
+val paritySeeds = listOf(
+    "Box<int>",
+    "Box<Point>",
+    "Box<Box<int>>",
+    "Pair2<int, double>",
+    "std::unique_ptr<int>",
+    "std::vector<Thing*>"
+)
+
+// The same merge the gradle plugin's kplusplusSync performs: manifest + seeds, deduped,
+// sorted (the deterministic instantiation order).
+fun paritySpecs(): List<String> = (
+    parityManifest.readLines().map { it.trim() }.filter { it.isNotEmpty() } + paritySeeds
+    ).distinct().sorted()
+
+fun runLogged(args: List<String>, log: File): Int {
+    log.parentFile.mkdirs()
+    return ProcessBuilder(args)
+        .redirectErrorStream(true)
+        .redirectOutput(log)
+        .start()
+        .waitFor()
+}
+
+fun paritySlug(unit: String) = unit.replace(Regex("[^A-Za-z0-9]+"), "_").trim('_')
+
+val parityEmit = tasks.register("parityEmit") {
+    dependsOn("linkReleaseExecutableKlinker")
+    doLast {
+        val modelsDir = File(parityDir, "models").apply { mkdirs() }
+        val logsDir = File(parityDir, "logs")
+        // One binary invocation per payload: a crash on one spec's parse (expected while
+        // Phase D converges) never takes the other models down.
+        fun emit(specs: List<String>, log: File): Int = runLogged(
+            listOf(
+                cppfrontendBinary.absolutePath, "--parity-emit",
+                modelsDir.absolutePath, parityHeader.absolutePath, "c++14"
+            ) + specs,
+            log
+        )
+        check(emit(emptyList(), File(logsDir, "emit_base.log")) == 0) {
+            "parityEmit: base model emit failed (see $logsDir/emit_base.log)"
+        }
+        val map = StringBuilder()
+        for ((i, spec) in paritySpecs().withIndex()) {
+            val log = File(logsDir, "emit_$i.log")
+            val line = if (emit(listOf(spec), log) == 0) {
+                log.readLines().firstOrNull { it.startsWith("PARITY_MODEL ") }
+                    ?.removePrefix("PARITY_MODEL ")
+            } else {
+                null
+            }
+            map.appendLine(line ?: "$spec=EMIT_FAILED")
+        }
+        File(parityDir, "forcing_map.txt").writeText(map.toString())
+        println("parityEmit: base + ${paritySpecs().size} forcing model(s) under $modelsDir")
+    }
+}
+
+tasks.register("featuregenParity") {
+    dependsOn(parityEmit, ":krapper_gen:linkReleaseExecutableNative")
+    doLast {
+        val specs = paritySpecs()
+        val forcingPaths = File(parityDir, "forcing_map.txt").readLines()
+            .filter { it.isNotEmpty() }
+            .associate { it.substringBefore('=') to it.substringAfter('=') }
+        val baseModel = File(parityDir, "models/base_model.json")
+        val logsDir = File(parityDir, "logs")
+        val diffsDir = File(parityDir, "diffs").apply { deleteRecursively() }
+
+        // The featuregen CLI tail, mirroring kplusplusSync's invocation (module name,
+        // INCLUDE_MISSING, krapper.featuregen package, --header) — identical on both
+        // sides so the diff isolates the front-end swap.
+        fun genArgs(outDir: File, instSpecs: List<String>) = listOf(
+            krapperGenKexe.absolutePath, "featuregen",
+            "-r", "INCLUDE_MISSING",
+            "-p", "krapper.featuregen",
+            "-c", "clang++",
+            "-o", outDir.absolutePath
+        ) + instSpecs.flatMap { listOf("--instantiate", it) } +
+            listOf("--header", parityHeader.absolutePath)
+
+        // Byte-compare the two outputs: same file set, every file identical (the .def
+        // path-modulo — it bakes the output dir's absolute path; .a excluded — derived
+        // from the compared .cc). On divergence, a unified diff per file lands under
+        // diffs/<unit>/ for the worklist analysis.
+        fun diffUnit(unit: String, libclang: File, cpp: File): Pair<String, String> {
+            fun files(dir: File) = dir.walkTopDown()
+                .filter { it.isFile && it.extension != "a" }
+                .map { it.relativeTo(dir).path }.toSortedSet()
+            val a = files(libclang)
+            val b = files(cpp)
+            val notes = mutableListOf<String>()
+            if (a != b) notes += "file sets differ: only-libclang=${a - b} only-cpp=${b - a}"
+            var diffLines = 0
+            var diffFiles = 0
+            for (rel in a intersect b) {
+                fun read(dir: File) =
+                    File(dir, rel).readText().replace(dir.absolutePath, "@OUT@")
+                val ta = read(libclang)
+                val tb = read(cpp)
+                if (ta == tb) continue
+                diffFiles++
+                val diffFile = File(diffsDir, "${paritySlug(unit)}/$rel.diff")
+                diffFile.parentFile.mkdirs()
+                val tmpA = File(diffFile.parentFile, "a.tmp").apply { writeText(ta) }
+                val tmpB = File(diffFile.parentFile, "b.tmp").apply { writeText(tb) }
+                val proc = ProcessBuilder(
+                    "diff", "-u", tmpA.absolutePath, tmpB.absolutePath
+                ).redirectErrorStream(true).start()
+                val out = proc.inputStream.readBytes().toString(Charsets.UTF_8)
+                proc.waitFor()
+                tmpA.delete()
+                tmpB.delete()
+                diffFile.writeText(out)
+                diffLines += out.lineSequence().count {
+                    (it.startsWith("+") && !it.startsWith("+++")) ||
+                        (it.startsWith("-") && !it.startsWith("---"))
+                }
+            }
+            return if (notes.isEmpty() && diffFiles == 0) {
+                "identical" to "byte-identical (path-modulo .def) across ${a.size} files"
+            } else {
+                "diff" to (
+                    notes + "$diffLines diff line(s) across $diffFiles file(s)"
+                    ).joinToString("; ")
+            }
+        }
+
+        data class Verdict(val unit: String, val cls: String, val detail: String)
+        val verdicts = mutableListOf<Verdict>()
+        val units = specs.map { it to listOf(it) } + ("ALL" to specs)
+        for ((unit, instSpecs) in units) {
+            val unitDir = File(parityDir, "out/${paritySlug(unit)}")
+            val outLib = File(unitDir, "libclang").apply { deleteRecursively(); mkdirs() }
+            val outCpp = File(unitDir, "cpp").apply { deleteRecursively(); mkdirs() }
+            val libLog = File(logsDir, "${paritySlug(unit)}_libclang.log")
+            val libExit = runLogged(genArgs(outLib, instSpecs), libLog)
+            if (libExit != 0) {
+                verdicts += Verdict(
+                    unit, "fail",
+                    "LIBCLANG BASELINE failed (exit $libExit — infra, see $libLog)"
+                )
+                continue
+            }
+            val missing = instSpecs.filter { (forcingPaths[it] ?: "EMIT_FAILED") == "EMIT_FAILED" }
+            if (missing.isNotEmpty()) {
+                verdicts += Verdict(unit, "fail", "cppfrontend model emit failed for $missing")
+                continue
+            }
+            val cppLog = File(logsDir, "${paritySlug(unit)}_cpp.log")
+            val cppExit = runLogged(
+                genArgs(outCpp, instSpecs) + listOf(
+                    "--frontend", "cpp",
+                    "--parsedModel", baseModel.absolutePath
+                ) + instSpecs.flatMap { listOf("--forcingModel", "$it=${forcingPaths[it]}") },
+                cppLog
+            )
+            if (cppExit != 0) {
+                val tail = cppLog.readLines().lastOrNull { it.isNotBlank() }.orEmpty()
+                verdicts += Verdict(unit, "fail", "cpp generation failed (exit $cppExit): $tail")
+                continue
+            }
+            val (cls, detail) = diffUnit(unit, outLib, outCpp)
+            verdicts += Verdict(unit, cls, detail)
+        }
+
+        // Scoreboard + the regression gate against the committed expected-state ledger.
+        val rank = mapOf("identical" to 0, "diff" to 1, "fail" to 2)
+        val expected = if (parityExpectations.exists()) {
+            parityExpectations.readLines().mapNotNull { line ->
+                val t = line.trim()
+                if (t.isEmpty() || t.startsWith("#")) {
+                    null
+                } else {
+                    t.substringBeforeLast('=').trim() to t.substringAfterLast('=').trim()
+                }
+            }.toMap()
+        } else {
+            emptyMap()
+        }
+        var regressions = 0
+        val report = buildString {
+            appendLine("featuregenParity scoreboard (${verdicts.size} units):")
+            for (v in verdicts) {
+                val exp = expected[v.unit] ?: "identical"
+                val marker = when {
+                    (rank[v.cls] ?: 2) > (rank[exp] ?: 0) -> {
+                        regressions++
+                        "REGRESSION (expected $exp)"
+                    }
+
+                    (rank[v.cls] ?: 2) < (rank[exp] ?: 0) -> "IMPROVED (expected $exp — ratchet the ledger)"
+                    else -> "as expected"
+                }
+                appendLine("  [${v.cls.uppercase().padEnd(9)}] ${v.unit} — ${v.detail} [$marker]")
+            }
+            appendLine(
+                "totals: ${verdicts.count { it.cls == "identical" }} identical / " +
+                    "${verdicts.count { it.cls == "diff" }} diff / " +
+                    "${verdicts.count { it.cls == "fail" }} fail " +
+                    "(of ${verdicts.size}; unit diffs under $diffsDir, logs under $logsDir)"
+            )
+        }
+        File(parityDir, "report.txt").writeText(report)
+        println(report)
+        check(regressions == 0) {
+            "featuregenParity: $regressions regression(s) vs $parityExpectations"
+        }
+    }
 }
 
 tasks.register("handoffInstDiff") {

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -185,6 +185,9 @@ kplusplus {
         // TemplateArgumentLoc unwrap for TemplateTypeParmDecl::getDefaultArgument()
         // (see clang_slice.h).
         "kppbridge::defaultArgType",
+        // NEW for Phase D (#46): inline-namespace-preserving qualified names
+        // (std::__cxx11::basic_string — see clang_slice.h).
+        "kppbridge::qualifiedName",
         // NEW for #45 brick 3 (instantiation forcing): the forcing-parse entry point —
         // buildASTFromCode with REAL driver args ('\n'-joined; -resource-dir + -std), the
         // smallest bridge until std::vector<std::string> params are bindable (see

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -100,18 +100,37 @@ inline clang::QualType templateArgAsType(const clang::QualType &type, unsigned i
     return clang::QualType();
 }
 
+// Phase D BRIDGE (#46): the "::"-joined qualified name INCLUDING inline namespaces.
+// libclang's fullyQualified walk joins every named semantic parent — `std::string`'s
+// template spells `std::__cxx11::basic_string` — but NamedDecl::getQualifiedNameAsString
+// suppresses redundant inline namespaces by default (SuppressInlineNamespaceMode::
+// Redundant), spelling `std::basic_string`. The mismatch breaks resolution on the cpp
+// path: the basic_string ClassTemplate element's qualified name (built from the model's
+// REAL namespace chain, which includes the inline __cxx11) never matches the type-use
+// spelling, so std::string members silently drop. Print with None instead.
+inline std::string qualifiedName(const clang::NamedDecl *decl) {
+    if (!decl) return std::string();
+    clang::PrintingPolicy policy(decl->getASTContext().getLangOpts());
+    policy.SuppressInlineNamespace =
+        llvm::to_underlying(clang::PrintingPolicy::SuppressInlineNamespaceMode::None);
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    decl->printQualifiedName(os, policy);
+    return out;
+}
+
 // The specialization's TEMPLATE name, qualified — the decl-side equivalent of
 // createForType(forTemplateBase=true)'s referencedDecl.fullyQualified (libclang's
 // clang_getTypeDeclaration resolves a TST to its ClassTemplateDecl and a resolved
 // specialization to its ClassTemplateSpecializationDecl; both spell the "::"-joined
-// semantic-parent chain).
+// semantic-parent chain — inline namespaces included, hence qualifiedName above).
 inline std::string templateBaseName(const clang::QualType &type) {
     if (type.isNull()) return std::string();
     if (const auto *spec = type->getAs<clang::TemplateSpecializationType>())
         if (const auto *decl = spec->getTemplateName().getAsTemplateDecl())
-            return decl->getQualifiedNameAsString();
+            return qualifiedName(decl);
     if (const auto *record = type->getAsCXXRecordDecl())
-        return record->getQualifiedNameAsString();
+        return qualifiedName(record);
     return std::string();
 }
 

--- a/cppfrontend/include/clang_slice.h
+++ b/cppfrontend/include/clang_slice.h
@@ -115,6 +115,19 @@ inline std::string templateBaseName(const clang::QualType &type) {
     return std::string();
 }
 
+// Phase D BRIDGE (#46): a template type parameter's default TYPE argument
+// (`typename _Alloc = std::allocator<_Tp>`). hasDefaultArgument() itself IS bound;
+// getDefaultArgument() returns a TemplateArgumentLoc (clang 19+), which isn't a bindable
+// surface yet — this helper unwraps it to the QualType the model decode consumes. A null
+// QualType signals "no default / not a type default" (mirroring templateArgAsType's
+// convention above).
+inline clang::QualType defaultArgType(const clang::TemplateTypeParmDecl *parm) {
+    if (!parm || !parm->hasDefaultArgument()) return clang::QualType();
+    const clang::TemplateArgument &arg = parm->getDefaultArgument().getArgument();
+    if (arg.getKind() != clang::TemplateArgument::Type) return clang::QualType();
+    return arg.getAsType();
+}
+
 inline std::string defaultArgText(clang::ParmVarDecl *parm) {
     if (!parm || !parm->hasDefaultArg()) {
         return std::string();

--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -4,4 +4,38 @@
 # recorded here (identical < diff < fail); improvements are reported so this ledger
 # ratchets toward all-identical as Phase D converges.
 #
-# (Populated from the first honest run — see the PR that landed featuregenParity.)
+# State as of the first full attempt (the brick that landed featuregenParity):
+# EVERY unit generates + compiles end-to-end on --frontend=cpp (0 fail), with
+# categorized diffs vs the libclang baseline. The divergence families (full
+# breakdown on issue #46):
+#   D1 initializer_list materialization (libclang's order-dependent visit() collapse
+#      RESOLVES initializer_list at featuregen scale; the cpp front-end's documented
+#      deterministic UNRESOLVABLE rule drops the ilist ctors/assign/insert overloads
+#      and the std_Initializer_list__* bindings) — ~half the diff lines.
+#   D2 incidental INCLUDE_MISSING std surface (std::abs/wcschr/wcspbrk/wcsrchr/
+#      wcsstr/wmemchr/get_new_handler/set_new_handler + _IO_FILE bind on the
+#      libclang side only; __convert_from_v + __locale_struct on the cpp side only).
+#   D3 dependent member-alias spellings baked into uniqueCNames of SURVIVING members
+#      (set::insert's `template<c:...stl_set.h@...>` USR-tref vs the cpp drop;
+#      unordered_map's `typename _Hashtable::hasher` vs `unresolveable`).
+#   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
+#      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
+#      path keeps it and emits dispose()/owned() (correct-by-construction).
+Box<Box<int>>=diff
+Box<Point>=diff
+Box<int>=diff
+Pair2<int, double>=diff
+std::map<int, double>=diff
+std::map<int, int>=diff
+std::pair<int, int>=diff
+std::set<int>=diff
+std::unique_ptr<int>=diff
+std::unordered_map<int, int>=diff
+std::unordered_set<int>=diff
+std::vector<Point>=diff
+std::vector<Thing*>=diff
+std::vector<double>=diff
+std::vector<int>=diff
+std::vector<std::__cxx11::basic_string<char>>=diff
+std::vector<std::vector<int>>=diff
+ALL=diff

--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -1,0 +1,7 @@
+# featuregenParity expected-state ledger (#46 Phase D).
+# One line per parity unit: <spec>=<identical|diff|fail>. A unit with no line is
+# expected byte-identical. The task fails only when a unit's verdict is WORSE than
+# recorded here (identical < diff < fail); improvements are reported so this ledger
+# ratchets toward all-identical as Phase D converges.
+#
+# (Populated from the first honest run — see the PR that landed featuregenParity.)

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -716,8 +716,8 @@ fun main(args: Array<String>): Unit = memScoped {
     // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
     // pinned against the libclang oracle for this fixture.
     check(
-        "TU has exactly 21 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
-        tu.children.size == 21,
+        "TU has exactly 22 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
+        tu.children.size == 22,
         "got ${tu.children.size}"
     )
     val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -75,6 +75,13 @@ import platform.posix.popen
 // carries the five default-arg value shapes (int literal, negative, enum constant,
 // nullptr, constructed) plus a multi-default trailing run (configure). Expected
 // defaultValue strings are the libclang token-join contract (ModelFactories.defaultValue).
+// Phase D (#46) grows it with the REMAINING typedef-reducer mirrors and defaultType:
+// SmartPtr (a dependent `pointer` alias + `using element_type` — unique_ptr's shape,
+// pointerTypedefElement), RawHolder (a CONCRETE pointer typedef that must NOT be
+// rewritten), MiniMap/MiniSet (dependent key_type/mapped_type/value_type through trait
+// scopes — unordered_map's and set's shapes, assocTypedefElement), and DefBox/DefPair
+// (defaulted template params — the cursor-walk residue WrappedTemplateParam.defaultType
+// reads; expected shapes pinned against the libclang oracle for this exact fixture).
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -173,6 +180,49 @@ private val FIXTURE_HEADER = """
         void blend(Palette p = Palette());
         void configure(int a, int b = 1, Shape* c = nullptr);
     };
+
+    template <typename T> struct PtrTrait { typedef T type; };
+
+    template <typename T>
+    struct SmartPtr {
+        using element_type = T;
+        typedef typename PtrTrait<T>::type pointer;
+        pointer get() const;
+    };
+
+    struct RawHolder {
+        typedef int* pointer;
+        pointer raw();
+    };
+
+    template <typename K, typename V> struct MapTraits { typedef K key; typedef V mapped; };
+
+    template <typename K, typename V>
+    struct MiniMap {
+        typedef typename MapTraits<K, V>::key key_type;
+        typedef typename MapTraits<K, V>::mapped mapped_type;
+        mapped_type& at(const key_type& k);
+    };
+
+    template <typename K> struct SetTraits { typedef K stored; };
+
+    template <typename K>
+    struct MiniSet {
+        typedef typename SetTraits<K>::stored key_type;
+        typedef typename SetTraits<K>::stored value_type;
+        void insert(const value_type& v);
+    };
+
+    template <typename T> struct DefAlloc {};
+
+    template <typename T, typename A = DefAlloc<T>>
+    struct DefBox {
+        T item;
+        A alloc() const;
+    };
+
+    template <typename T, typename U = T>
+    struct DefPair {};
 """.trimIndent()
 
 // #45 brick 3: the INSTANTIATION-FORCING fixture — a SIBLING of FIXTURE_HEADER (extending
@@ -232,6 +282,17 @@ fun main(args: Array<String>): Unit = memScoped {
     if (args.firstOrNull() == "--handoff-emit") {
         val dir = args.getOrNull(1) ?: fail("--handoff-emit <dir>")
         handoffEmit(dir)
+        return@memScoped
+    }
+    if (args.firstOrNull() == "--parity-emit") {
+        // --parity-emit <dir> <header> <std> [spec...] — Phase D (#46), see parityEmit.
+        val usage = "--parity-emit <dir> <header> <std> [spec...]"
+        parityEmit(
+            args.getOrNull(1) ?: fail(usage),
+            args.getOrNull(2) ?: fail(usage),
+            args.getOrNull(3) ?: fail(usage),
+            args.drop(4)
+        )
         return@memScoped
     }
     // The virtual filename must spell a C++ extension: buildASTFromCode infers the language
@@ -573,14 +634,17 @@ fun main(args: Array<String>): Unit = memScoped {
     val holders = tu.children.filterIsInstance<WrappedTemplate>()
     val holder = holders.find { it.name == "Holder" }
     check(
-        "TU contains exactly one WrappedTemplate: Holder",
-        holders.size == 1 && holder != null,
+        "TU contains the 10 WrappedTemplates in source order (Holder + the Phase D shapes)",
+        holders.map { it.name } == listOf(
+            "Holder", "PtrTrait", "SmartPtr", "MapTraits", "MiniMap",
+            "SetTraits", "MiniSet", "DefAlloc", "DefBox", "DefPair"
+        ),
         "got ${holders.map { it.name }}"
     )
     check(
-        "no WrappedClass shadows Holder (implicit specialization never surfaced)",
+        "no WrappedClass shadows a template (implicit specialization never surfaced)",
         tu.children.filterIsInstance<WrappedClass>().map { it.name }.sorted() ==
-            listOf("Dispatcher", "Palette", "Scene", "Shape"),
+            listOf("Dispatcher", "Palette", "RawHolder", "Scene", "Shape"),
         "got ${tu.children.filterIsInstance<WrappedClass>().map { it.name }}"
     )
     val tParam = holder?.templateArgs?.singleOrNull()
@@ -652,8 +716,8 @@ fun main(args: Array<String>): Unit = memScoped {
     // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
     // pinned against the libclang oracle for this fixture.
     check(
-        "TU has exactly 12 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
-        tu.children.size == 12,
+        "TU has exactly 21 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
+        tu.children.size == 21,
         "got ${tu.children.size}"
     )
     val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }
@@ -871,6 +935,89 @@ fun main(args: Array<String>): Unit = memScoped {
             dMethods.find { it.name == "onEvent" }?.args?.none { it.hasDefault } == true
     )
 
+    // -- Phase D (#46): the remaining typedef-reducer mirrors + defaultType capture.
+    // pointerTypedefElement: a DEPENDENT `pointer` alias (unique_ptr's shape — the
+    // underlying routes through a trait scope) reduces to element_type* so get()
+    // survives; the `using element_type` sibling is found through the dual-kind filter.
+    val smartPtr = holders.find { it.name == "SmartPtr" }
+    val smartPointerTypedef = smartPtr?.children?.filterIsInstance<WrappedTypedef>()
+        ?.find { it.name == "pointer" }
+    check(
+        "SmartPtr's dependent `pointer` typedef reduces to element_type*: *(template<T>)",
+        (smartPointerTypedef?.targetType as? WrappedModifiedType)?.let {
+            it.modifier == "*" && (it.baseType as? WrappedTemplateRef)?.target == "T"
+        } == true,
+        "got ${smartPointerTypedef?.targetType}"
+    )
+    check(
+        "SmartPtr::get() survives: const-method pointer return gains the G8 outer const",
+        smartPtr?.methods?.find { it.name == "get" }
+            ?.returnType?.toString() == "const template<T>*",
+        "got ${smartPtr?.methods?.find { it.name == "get" }?.returnType}"
+    )
+    // The negative gate: a CONCRETE pointer typedef must fall through to normal collapse.
+    val rawHolder = tu.children.filterIsInstance<WrappedClass>().find { it.name == "RawHolder" }
+    check(
+        "RawHolder's CONCRETE `typedef int* pointer` is NOT rewritten: collapses to 'int*'",
+        rawHolder?.children?.filterIsInstance<WrappedTypedef>()?.singleOrNull()
+            ?.targetType?.toString() == "int*",
+        "got ${rawHolder?.children?.filterIsInstance<WrappedTypedef>()}"
+    )
+    // assocTypedefElement, key→value shape (unordered_map's): dependent key_type/
+    // mapped_type reduce to the enclosing template's params 0/1.
+    val miniMap = holders.find { it.name == "MiniMap" }
+    val miniMapTypedefs = miniMap?.children?.filterIsInstance<WrappedTypedef>().orEmpty()
+    check(
+        "MiniMap's dependent key_type/mapped_type reduce to params 0/1 (assoc map shape)",
+        (miniMapTypedefs.find { it.name == "key_type" }?.targetType as? WrappedTemplateRef)
+            ?.target == "K" &&
+            (miniMapTypedefs.find { it.name == "mapped_type" }?.targetType as? WrappedTemplateRef)
+                ?.target == "V",
+        "got ${miniMapTypedefs.map { "${it.name}=${it.targetType}" }}"
+    )
+    val atMethod = miniMap?.methods?.find { it.name == "at" }
+    check(
+        "MiniMap::at survives: 'template<V>&' return, 'const template<K>&' arg",
+        atMethod?.returnType?.toString() == "template<V>&" &&
+            atMethod?.args?.singleOrNull()?.type?.toString() == "const template<K>&",
+        "got ret=${atMethod?.returnType} args=${atMethod?.args}"
+    )
+    // assocTypedefElement, key-only shape (set's): key_type AND the self-referential
+    // value_type both reduce to param 0.
+    val miniSet = holders.find { it.name == "MiniSet" }
+    val miniSetTypedefs = miniSet?.children?.filterIsInstance<WrappedTypedef>().orEmpty()
+    check(
+        "MiniSet's dependent key_type AND value_type reduce to the key param (key-only shape)",
+        (miniSetTypedefs.find { it.name == "key_type" }?.targetType as? WrappedTemplateRef)
+            ?.target == "K" &&
+            (miniSetTypedefs.find { it.name == "value_type" }?.targetType as? WrappedTemplateRef)
+                ?.target == "K",
+        "got ${miniSetTypedefs.map { "${it.name}=${it.targetType}" }}"
+    )
+    check(
+        "MiniSet::insert(const value_type&) arg carries the reduced shape",
+        miniSet?.methods?.find { it.name == "insert" }?.args?.singleOrNull()
+            ?.type?.toString() == "const template<K>&",
+        "got ${miniSet?.methods?.find { it.name == "insert" }?.args}"
+    )
+    // WrappedTemplateParam.defaultType: the cursor-walk residue shapes, pinned against
+    // the libclang oracle (see TypeBuilder.defaultTypeResidue).
+    val defBox = holders.find { it.name == "DefBox" }
+    check(
+        "DefBox param T carries NO default; param A captures 'unresolveable<template<T>>'",
+        defBox?.templateArgs?.getOrNull(0)?.defaultType == null &&
+            defBox?.templateArgs?.getOrNull(1)?.defaultType
+            ?.toString() == "unresolveable<template<T>>",
+        "got ${defBox?.templateArgs?.map { "${it.name}=${it.defaultType}" }}"
+    )
+    check(
+        "DefPair param U = T: defaultType is the self-residue 'template<T><template<T>>'",
+        holders.find { it.name == "DefPair" }?.templateArgs?.getOrNull(1)?.defaultType
+            ?.toString() == "template<T><template<T>>",
+        "got ${holders.find { it.name == "DefPair" }?.templateArgs
+            ?.map { "${it.name}=${it.defaultType}" }}"
+    )
+
     check("JSON is non-empty", json.length > 2)
 
     if (failures > 0) fail("$failures self-check(s) failed")
@@ -912,6 +1059,44 @@ private fun MemScope.handoffEmit(dir: String) {
         emitted.add("$forceName.json")
     }
     println("cppfrontend: handoff-emit -> $dir/{${emitted.joinToString(", ")}}")
+}
+
+/**
+ * Phase D entry (#46) — FEATUREGEN PARITY EMIT: the cpp front-end's half of
+ * :cppfrontend:featuregenParity, generalizing handoffEmit from the fixed bag fixture to
+ * an ARBITRARY user header + instantiation specs (featuregen's strings_feature.h + its
+ * 17-spec worklist). One invocation per payload, so a crash on one spec's parse never
+ * takes the others down (the gradle task records it as a per-spec emit failure):
+ *  - no specs: parse [headerPath]'s bytes (the base model) -> base_model.json, print
+ *    `PARITY_BASE <path>`;
+ *  - per spec: synthesize the SAME ForcingHeader the libclang path synthesizes
+ *    (#include-ing [headerPath] by the same path string krapper_gen gets via --header),
+ *    parse it, emit <forceName>.json, print `PARITY_MODEL <spec>=<path>` — the line the
+ *    gradle task turns into krapper_gen's --forcingModel argument.
+ * [std] pins the SAME standard featuregen's sync parses under (krapper_gen's default).
+ */
+private fun MemScope.parityEmit(
+    dir: String,
+    headerPath: String,
+    std: String,
+    specs: List<String>
+) {
+    val parseArgs = "-std=$std\n-resource-dir=" + commandOutput("clang++ -print-resource-dir")
+    if (specs.isEmpty()) {
+        val baseTu = parseToWrappedTU(readFile(headerPath), "parity_base.cc", parseArgs)
+        val path = "$dir/base_model.json"
+        writeFile(path, ModelIo.encodeToString(baseTu))
+        println("PARITY_BASE $path")
+        return
+    }
+    for (spec in specs) {
+        val forceName = ForcingHeader.forceName(spec)
+        val content = ForcingHeader.contentFor(spec, listOf(headerPath))
+        val tu = parseToWrappedTU(content, "$forceName.cc", parseArgs)
+        val path = "$dir/$forceName.json"
+        writeFile(path, ModelIo.encodeToString(tu))
+        println("PARITY_MODEL $spec=$path")
+    }
 }
 
 // Parse [code] with the '\n'-joined driver [args] (kppbridge.buildASTWithArgs — see

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -29,6 +29,7 @@ import clang.ParmVarDecl
 import clang.RecordDecl
 import clang.TemplateDecl
 import clang.TemplateParameterList
+import clang.TemplateTypeParmDecl
 import clang.TranslationUnitDecl
 import clang.TypedefNameDecl
 import clang.decl.Kind
@@ -49,6 +50,7 @@ import com.monkopedia.krapper.generator.model.WrappedTypedef
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import kppbridge.defaultArgText
+import kppbridge.defaultArgType
 
 // The C++-AST front-end's model construction (#44 bricks 2-5): walk a parsed Clang AST on
 // the kplusplus-generated libclang-cpp bindings and build :krapper_model's parse-output
@@ -223,6 +225,7 @@ private class ModelBuilder {
             .getTemplateParameters()
             ?.let { TemplateParameterList(it.ptr, templateDecl.memScope) }
             ?: return
+        var typeParamIndex = 0
         for (i in 0u until params.size()) {
             val param = params.getParam(i)
                 ?.let { NamedDecl(it.ptr, templateDecl.memScope) } ?: continue
@@ -235,6 +238,21 @@ private class ModelBuilder {
                     Decl(param.ptr, templateDecl.memScope).cppUsr()
                 )
             )
+            // defaultType capture (#46 Phase D): the model derives defaultType from the
+            // param element's children (TypeBuilder.defaultTypeResidue — the libclang
+            // cursor-walk residue, reproduced structurally). Attached to the CANONICAL
+            // instance (a re-walked redeclaration's params route into otherParams), so a
+            // default declared on a LATER redeclaration (basic_string is forward-declared
+            // default-less in <iosfwd> first) still lands — clang reports the inherited
+            // default on every subsequent redecl's param, mirroring how the libclang
+            // memo accumulates the residue cursors onto its one USR-keyed instance.
+            val canonical = template.templateArgs.getOrNull(typeParamIndex)
+            typeParamIndex++
+            if (canonical == null || canonical.children.isNotEmpty()) continue
+            val parmDecl = TemplateTypeParmDecl(param.ptr, templateDecl.memScope)
+            if (!parmDecl.hasDefaultArgument()) continue
+            val default = with(templateDecl.memScope) { defaultArgType(parmDecl) }
+            for (residue in defaultTypeResidue(default)) canonical.addChild(residue)
         }
         if (templateDecl.isThisDeclarationADefinition()) {
             addBasesAndMembers(record, template, template.metadata)

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -374,9 +374,22 @@ private class ModelBuilder {
             buildTypedef(typedef)?.let { parent.addChild(it) }
             return
         }
+        // NESTED record (#46 Phase D): a class nested in a PLAIN class binds as a
+        // WrappedClass child (`Outer::Inner` — ModelFactories.map's ClassDecl/StructDecl
+        // branch applies at any level); a class nested in a class TEMPLATE produces NO
+        // element (featuregen's T-typename rows: `Wrapper<T>::Inner` must NOT bind —
+        // matching the libclang tree, which carries no class under a template).
+        if (parent is WrappedClass &&
+            decl.getKind() != Kind.ClassTemplateSpecialization &&
+            decl.getKind() != Kind.ClassTemplatePartialSpecialization
+        ) {
+            decl.asCXXRecordDecl()?.let { record ->
+                addClass(record, decl, parent)
+                return
+            }
+        }
         // Anything else (static data members, nested enums) falls through
-        // ModelFactories.map's `else -> return null` and is dropped; nested record decls
-        // are brick-6+ (together with the nested-in-class-template skip).
+        // ModelFactories.map's `else -> return null` and is dropped.
     }
 
     // Mirror of the metadata side-effects ModelFactories.map records for a member it
@@ -462,10 +475,15 @@ private class ModelBuilder {
     private fun buildMethod(method: CXXMethodDecl): WrappedMethod {
         val name = method.asNamedDecl().getNameAsString() ?: error("method without a name")
         val isConst = method.isConst()
+        // T1.3 mirror (#46): an `iterator_range<It>` return is materialized into
+        // `std::vector<Elem*>` at construction, exactly like ModelFactories.WrappedMethod
+        // (see TypeBuilder.rangeVectorReturn). The G8 const rule never applies to it
+        // (the materialized vector is a by-value template type).
+        val range = rangeVectorReturn(method.getReturnType())
         // Mirror the libclang front-end's return-const rule (ModelFactories.WrappedMethod):
         // a `const` method's constness only carries to a pointer/reference return; const on
         // a by-value return is meaningless for the temporary and breaks the Holder path (G8).
-        val returnType = buildWrappedType(method.getReturnType()).let {
+        val returnType = range?.first ?: buildWrappedType(method.getReturnType()).let {
             if (isConst && (it.isPointer || it.isReference)) WrappedType.const(it) else it
         }
         // ModelFactories.WrappedMethod: STATIC for a static member (or a non-class-parent
@@ -474,6 +492,7 @@ private class ModelBuilder {
         return WrappedMethod(name, returnType, methodType).also {
             it.isConst = isConst
             it.isVirtual = method.isVirtual()
+            it.rangeElementType = range?.second
             it.addArgs(method.asFunctionDecl())
         }
     }

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -216,7 +216,7 @@ fun buildWrappedType(type: QualType): WrappedType {
         // getQualifiedNameAsString suppresses `__cxx11`, breaking the std::string
         // template-element match — see clang_slice.h).
         val qualified = with(canonTy.memScope) { qualifiedName(record.asNamedDecl()) }
-            .takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
+            ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {
@@ -475,7 +475,7 @@ private fun functionPointerTypedef(typedef: TypedefNameDecl): WrappedType? {
 // Qualified the same inline-namespace-preserving way as the record leaf.
 private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
     val qualified = with(enumDecl.memScope) { qualifiedName(enumDecl.asNamedDecl()) }
-        .takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
+        ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
     // Constants: the decl's EnumConstantDecl children as (spelling, value) pairs, a
     // missing name dropping just that constant (TypeFactories' mapNotNull).
     val constants = enumDecl.asDeclContext().decls()

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -16,7 +16,11 @@
 import clang.CXXRecordDecl
 import clang.Decl
 import clang.EnumDecl
+import clang.NamedDecl
 import clang.QualType
+import clang.TagDecl
+import clang.TemplateDecl
+import clang.TemplateParameterList
 import clang.Type
 import clang.TypedefNameDecl
 import clang.TypedefType
@@ -245,8 +249,11 @@ fun buildWrappedType(type: QualType): WrappedType {
  *    CXCursor_TypedefDecl only; here they apply to either alias kind — a `using size_t =
  *    ...` is vanishingly rare and the name is the contract either way.)
  *  - referenceTypedefElement / pointerTypedefElement / assocTypedefElement reduce
- *    std-container member aliases whose underlyings are DEPENDENT trait expressions; they
- *    only fire on the std headers, so they ride with the std-scale brick (brick-6+).
+ *    std-container member aliases whose underlyings are DEPENDENT trait expressions —
+ *    [referenceTypedef] / [pointerTypedef] / [assocTypedef] below. pointerTypedefElement
+ *    runs for BOTH alias kinds on the libclang path (createForType's TypeAliasDecl block
+ *    exists for unique_ptr's `using pointer`); assocTypedefElement is only reached from
+ *    the CXCursor_TypedefDecl branches, hence the Kind.Typedef gate.
  *  - Everything else collapses to the underlying type, mirroring ResolverBuilderImpl
  *    .visit()'s CXCursor_TypedefDecl branch (recursive typedefDeclUnderlyingType walk) —
  *    which is also how an in-template `typedef T value_type` lands on the dependent
@@ -267,6 +274,10 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
         functionPointerTypedef(typedef)?.let { return it }
     }
     referenceTypedef(typedef)?.let { return it }
+    pointerTypedef(typedef)?.let { return it }
+    if (typedef.asDecl().getKind() == Kind.Typedef) {
+        assocTypedef(typedef)?.let { return it }
+    }
     val name = typedef.getNameAsString() ?: ""
     when (name) {
         "size_type" -> return WrappedTypeReference("size_t")
@@ -306,13 +317,105 @@ private fun referenceTypedef(typedef: TypedefNameDecl): WrappedType? {
     return referenceTo(if (isConstRef) const(elementType) else elementType)
 }
 
+/**
+ * TypeFactories.pointerTypedefElement (#46 Phase D): a smart pointer's `pointer` /
+ * `const_pointer` member alias whose underlying is a DEPENDENT trait expression
+ * (libstdc++ routes unique_ptr's through `__uniq_ptr_impl<...>::pointer`, which libclang
+ * reports as CXType_Unexposed) is rewritten to a pointer to the sibling `element_type`
+ * alias's underlying — what keeps unique_ptr's get()/release()/operator->() alive. Gates
+ * mirrored from the libclang reducer:
+ *  - only when the underlying is dependent AND not itself a concrete pointer/reference
+ *    shape (the Unexposed-kind test: a real `T*` pointer typedef — even a dependent
+ *    `_Tp*` — spells CXType_Pointer, NOT Unexposed, and must fall through);
+ *  - the `element_type` sibling may be EITHER alias kind (the libclang reducer's
+ *    `TypedefDecl || TypeAliasDecl` sibling filter — unique_ptr uses `using`).
+ * Unlike the other reducers, the libclang path runs this one for both alias KINDS of the
+ * reduced typedef too (createForType lines 147-149), so no Kind gate at the call site.
+ */
+private fun pointerTypedef(typedef: TypedefNameDecl): WrappedType? {
+    val name = typedef.getNameAsString()
+    val isConstPtr = name == "const_pointer"
+    if (name != "pointer" && !isConstPtr) return null
+    val underlying = typedef.getUnderlyingType().typePtr() ?: return null
+    if (!underlying.isDependentType() ||
+        underlying.isPointerType() || underlying.isReferenceType()
+    ) {
+        return null
+    }
+    val elementTypedef = siblingTypedef(typedef, "element_type", allowAlias = true)
+        ?: return null
+    val elementType = buildWrappedType(elementTypedef.getUnderlyingType())
+    if (elementType == UNRESOLVABLE) return null
+    return pointerTo(if (isConstPtr) const(elementType) else elementType)
+}
+
+/**
+ * TypeFactories.assocTypedefElement (#46 Phase D): associative containers' `key_type` /
+ * `mapped_type` / `value_type` member aliases that libclang leaves as unresolvable
+ * dependent expressions (unordered_map defines them through its `_Hashtable` base;
+ * set's `value_type` is a dependent self-reference of `_Key`) are rewritten to a
+ * [WrappedTemplateRef] of the enclosing template's corresponding TYPE parameter, so the
+ * existing param->concrete substitution engine maps them. Two container shapes,
+ * distinguished by sibling typedefs exactly like the libclang reducer:
+ *  - key→value map (`key_type` AND `mapped_type` present): key_type→param 0,
+ *    mapped_type→param 1;
+ *  - key-only set (`key_type`, NO `mapped_type`): key_type and value_type→param 0.
+ * The ref keys on the param's NAME (this front-end's in-template convention — the
+ * spelling member uniqueCNames bake; the libclang reducer keys the same param by USR,
+ * which the resolver accepts interchangeably, Parsing.typedAs). The dependent gate
+ * mirrors referenceTypedef/pointerTypedef's Unexposed equivalence; a concretely-resolved
+ * alias falls through to normal handling.
+ */
+private fun assocTypedef(typedef: TypedefNameDecl): WrappedType? {
+    val name = typedef.getNameAsString()
+    if (name != "key_type" && name != "mapped_type" && name != "value_type") return null
+    val underlying = typedef.getUnderlyingType().typePtr() ?: return null
+    if (!underlying.isDependentType() ||
+        underlying.isPointerType() || underlying.isReferenceType()
+    ) {
+        return null
+    }
+    fun hasTypedef(n: String) = siblingTypedef(typedef, n) != null
+    val isMap = hasTypedef("key_type") && hasTypedef("mapped_type")
+    val isKeyOnly = hasTypedef("key_type") && !hasTypedef("mapped_type")
+    val paramIndex = when {
+        isMap && name == "key_type" -> 0
+        isMap && name == "mapped_type" -> 1
+        isKeyOnly && (name == "key_type" || name == "value_type") -> 0
+        else -> return null
+    }
+    // The libclang reducer reads the params as SIBLINGS (the ClassTemplate cursor's
+    // children mix params and members); on the decl walk the typedef's context is the
+    // PATTERN record, whose described class template carries the parameter list.
+    val context = typedef.asDecl().getDeclContext() ?: return null
+    val record = with(Decl.Companion) { typedef.memScope.castFromDeclContext(context) }
+        ?.let { Decl(it.ptr, typedef.memScope) }?.asCXXRecordDecl() ?: return null
+    val params = record.getDescribedClassTemplate()
+        ?.let { TemplateDecl(it.ptr, typedef.memScope) }
+        ?.getTemplateParameters()
+        ?.let { TemplateParameterList(it.ptr, typedef.memScope) } ?: return null
+    val typeParams = (0u until params.size()).mapNotNull { i ->
+        params.getParam(i)?.let { NamedDecl(it.ptr, typedef.memScope) }
+            ?.takeIf { it.getKind() == Kind.TemplateTypeParm }
+    }
+    val param = typeParams.getOrNull(paramIndex) ?: return null
+    return WrappedTemplateRef(param.getNameAsString() ?: return null)
+}
+
 // The sibling typedef of [typedef]'s parent context with the given [name] (the
-// `semanticParent.children` walk of the libclang reducers). `typedef`-kind only,
-// mirroring the CXCursor_TypedefDecl filter.
-private fun siblingTypedef(typedef: TypedefNameDecl, name: String): TypedefNameDecl? {
+// `semanticParent.children` walk of the libclang reducers). `typedef`-kind only by
+// default, mirroring the CXCursor_TypedefDecl filter; [allowAlias] widens to `using`
+// aliases for the lookups whose libclang filter accepts both kinds (element_type).
+private fun siblingTypedef(
+    typedef: TypedefNameDecl,
+    name: String,
+    allowAlias: Boolean = false
+): TypedefNameDecl? {
     val context = typedef.asDecl().getDeclContext() ?: return null
     for (decl in context.decls()) {
-        if (decl == null || decl.getKind() != Kind.Typedef) continue
+        if (decl == null) continue
+        val kind = decl.getKind()
+        if (kind != Kind.Typedef && !(allowAlias && kind == Kind.TypeAlias)) continue
         val sibling = decl.asTypedefNameDecl() ?: continue
         if (sibling.getNameAsString() == name) return sibling
     }
@@ -386,6 +489,67 @@ private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
         buildWrappedType(enumDecl.getIntegerType()),
         constants
     )
+}
+
+/**
+ * WrappedTemplateParam.defaultType capture (#46 Phase D). The model derives a param's
+ * defaultType from its CHILDREN (the first WrappedType child as the base + every
+ * WrappedTemplateRef child as the args — WrappedTemplateParam.defaultType), and on the
+ * libclang path those children are CURSOR-WALK RESIDUE: ModelFactories.mapAll attaches
+ * whatever TypeRef/TemplateRef cursors appear under the TemplateTypeParameter cursor.
+ * Probed against the live libclang oracle (krapper_gen --dumpModels):
+ *  - `U = Alloc<T>`  -> [UNRESOLVABLE, tref("T")] — a TemplateRef cursor's type is
+ *    CXType_Invalid, so the child is the UNRESOLVABLE leaf (once; the memo dedups);
+ *  - `U = T` / `U = T*` -> [tref("T")] — only the TypeRef survives (the pointer is LOST);
+ *  - `U = Shape`     -> [tref("struct Shape")] — the TypeRef spells tag-keyword + name;
+ *  - `U = int`       -> no children (no default captured for a builtin).
+ * This walk reproduces those shapes structurally from the default's QualType
+ * (kppbridge::defaultArgType): template-specialization -> the UNRESOLVABLE leaf + its
+ * args recursed, pointer/reference -> recurse (the lossy collapse), template param ->
+ * tref(name), record/enum leaf -> tref("<tag-kind> <qualified>"), builtin -> nothing.
+ * Faithful-lossy by design: typedAs consumes defaultType through the SAME mapping either
+ * way, so emulating the residue is what byte-parity requires (a faithful rich decode is
+ * a Phase D tail item once parity is locked).
+ */
+fun defaultTypeResidue(default: QualType): List<WrappedType> {
+    val residue = mutableListOf<WrappedType>()
+    val seenRefs = mutableSetOf<String>()
+    var unresolvable = false
+    fun addRef(target: String) {
+        if (seenRefs.add(target)) residue.add(WrappedTemplateRef(target))
+    }
+    fun walk(type: QualType) {
+        val ty = type.typePtr() ?: return
+        val argCount = with(type.memScope) { numTemplateArgs(type) }
+        if (argCount >= 0) {
+            if (!unresolvable) {
+                unresolvable = true
+                residue.add(UNRESOLVABLE)
+            }
+            for (i in 0u until argCount.toUInt()) {
+                val arg = with(type.memScope) { templateArgAsType(type, i) }
+                if (arg.typePtr() != null) walk(arg)
+            }
+            return
+        }
+        if (ty.isPointerType() || ty.isReferenceType()) {
+            walk(ty.getPointeeType())
+            return
+        }
+        ty.asTemplateTypeParmType()?.let { parm ->
+            parm.getDecl()?.asNamedDecl()?.getNameAsString()?.let { addRef(it) }
+            return
+        }
+        val canonTy = type.getCanonicalType().typePtr() ?: return
+        canonTy.getAsTagDecl()?.let { tag ->
+            val kindName = TagDecl(tag.ptr, canonTy.memScope).getKindName() ?: return
+            val qualified = NamedDecl(tag.ptr, canonTy.memScope).getQualifiedNameAsString()
+                ?: return
+            addRef("$kindName $qualified")
+        }
+    }
+    walk(default)
+    return residue
 }
 
 // Leaf spelling, mirroring createForType's const-stripped spelling read (the constness is

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -558,13 +558,19 @@ private fun elementOfIterator(iterator: QualType): String? {
     return null
 }
 
-// ModelFactories.stripDecoration, verbatim: reduce a spelling to its bare class name.
+// ModelFactories.stripDecoration: reduce a spelling to its bare class name. One bridge
+// beyond the libclang original: getAsString()'s default policy prints a canonical record
+// ELABORATED ("struct Thing" — the same C-LangOptions policy as the `_Bool` bridge in
+// spellingOf), where libclang spells the bare name — strip the tag keyword too.
 private fun stripDecoration(spelling: String?): String? {
     var s = (spelling ?: return null).trim()
     if (s.isEmpty()) return null
     while (true) {
         val before = s
         if (s.startsWith("const ")) s = s.substring("const ".length).trim()
+        for (tag in listOf("struct ", "class ", "union ", "enum ")) {
+            if (s.startsWith(tag)) s = s.substring(tag.length).trim()
+        }
         if (s.endsWith("*") || s.endsWith("&")) s = s.dropLast(1).trim()
         if (s.endsWith("const")) s = s.dropLast("const".length).trim()
         if (s == before) break

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -497,6 +497,82 @@ private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
 }
 
 /**
+ * T1.3 RANGE-RETURN mirror (#46 Phase D; ModelFactories.rangeVectorReturn +
+ * extractRangeReturn + elementOfIterator): a method returning `llvm::iterator_range<It>`
+ * (featuregen's RangeHolder::items, and every Clang `decls()`-style accessor) is
+ * materialized at MODEL CONSTRUCTION into a `std::vector<Elem*>` return — a real
+ * template type that resolves through the existing vector-instantiation path — with the
+ * element spelling recorded for CppWriter's materialization loop
+ * (WrappedMethod.rangeElementType). Matching + extraction mirror the libclang factory
+ * rule-for-rule, off the CANONICAL return (seeing through the `using X_range = ...`
+ * member aliases): the iterator is the range's first template argument, and the element
+ * is what `*it` dereferences to — pointer iterator (peel one level, two for `Elem**`),
+ * a `value_type` member alias (either alias kind), or the iterator's own first template
+ * argument — stripped to the bare class name. Returns null for any non-range return
+ * (normal construction applies; an unextractable element drops the method the same way
+ * the libclang path does).
+ */
+fun rangeVectorReturn(returnType: QualType): Pair<WrappedType, String>? {
+    val canonical = returnType.getCanonicalType()
+    val spelling = canonical.getAsString() ?: return null
+    if (!spelling.contains("iterator_range<")) return null
+    if (with(returnType.memScope) { numTemplateArgs(canonical) } < 1) return null
+    val iterator = with(returnType.memScope) { templateArgAsType(canonical, 0u) }
+    val element = elementOfIterator(iterator) ?: return null
+    return WrappedTemplateType(
+        WrappedTypeReference("std::vector"),
+        listOf(pointerTo(WrappedTypeReference(element)))
+    ) to element
+}
+
+// ModelFactories.elementOfIterator, structurally: pointer iterator -> the (doubly-)peeled
+// pointee; class iterator -> the `value_type` alias's canonical underlying; else the
+// iterator's own first template argument.
+private fun elementOfIterator(iterator: QualType): String? {
+    val canon = iterator.getCanonicalType()
+    val ty = canon.typePtr() ?: return null
+    if (ty.isPointerType()) {
+        val pointee = ty.getPointeeType().getCanonicalType()
+        val pointeeTy = pointee.typePtr() ?: return null
+        val element = if (pointeeTy.isPointerType()) {
+            pointeeTy.getPointeeType().getCanonicalType()
+        } else {
+            pointee
+        }
+        return stripDecoration(element.getAsString())
+    }
+    ty.asRecord()?.let { record ->
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            val kind = decl.getKind()
+            if (kind != Kind.Typedef && kind != Kind.TypeAlias) continue
+            val alias = decl.asTypedefNameDecl() ?: continue
+            if (alias.getNameAsString() != "value_type") continue
+            return stripDecoration(alias.getUnderlyingType().getCanonicalType().getAsString())
+        }
+    }
+    if (with(iterator.memScope) { numTemplateArgs(canon) } >= 1) {
+        val arg = with(iterator.memScope) { templateArgAsType(canon, 0u) }
+        return stripDecoration(arg.getAsString())
+    }
+    return null
+}
+
+// ModelFactories.stripDecoration, verbatim: reduce a spelling to its bare class name.
+private fun stripDecoration(spelling: String?): String? {
+    var s = (spelling ?: return null).trim()
+    if (s.isEmpty()) return null
+    while (true) {
+        val before = s
+        if (s.startsWith("const ")) s = s.substring("const ".length).trim()
+        if (s.endsWith("*") || s.endsWith("&")) s = s.dropLast(1).trim()
+        if (s.endsWith("const")) s = s.dropLast("const".length).trim()
+        if (s == before) break
+    }
+    return s.ifEmpty { null }
+}
+
+/**
  * WrappedTemplateParam.defaultType capture (#46 Phase D). The model derives a param's
  * defaultType from its CHILDREN (the first WrappedType child as the base + every
  * WrappedTemplateRef child as the args — WrappedTemplateParam.defaultType), and on the

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -37,6 +37,7 @@ import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.pointer
 import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referenceTo
 import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
 import kppbridge.numTemplateArgs
+import kppbridge.qualifiedName
 import kppbridge.templateArgAsType
 import kppbridge.templateBaseName
 
@@ -211,8 +212,11 @@ fun buildWrappedType(type: QualType): WrappedType {
     canonTy?.asRecord()?.let { record ->
         // Record leaf: createForType's CXCursor_ClassDecl/StructDecl branches ->
         // WrappedType(referencedDecl.fullyQualified) — the "::"-joined semantic-parent
-        // chain, which is exactly NamedDecl::getQualifiedNameAsString().
-        val qualified = record.getQualifiedNameAsString() ?: return UNRESOLVABLE
+        // chain INCLUDING inline namespaces (kppbridge::qualifiedName; plain
+        // getQualifiedNameAsString suppresses `__cxx11`, breaking the std::string
+        // template-element match — see clang_slice.h).
+        val qualified = with(canonTy.memScope) { qualifiedName(record.asNamedDecl()) }
+            .takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {
@@ -468,8 +472,10 @@ private fun functionPointerTypedef(typedef: TypedefNameDecl): WrappedType? {
 }
 
 // The WrappedEnumType payload for [enumDecl] (TypeFactories' CXCursor_EnumDecl branch).
+// Qualified the same inline-namespace-preserving way as the record leaf.
 private fun buildEnumType(enumDecl: EnumDecl): WrappedType {
-    val qualified = enumDecl.getQualifiedNameAsString() ?: return UNRESOLVABLE
+    val qualified = with(enumDecl.memScope) { qualifiedName(enumDecl.asNamedDecl()) }
+        .takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
     // Constants: the decl's EnumConstantDecl children as (spelling, value) pairs, a
     // missing name dropping just that constant (TypeFactories' mapNotNull).
     val constants = enumDecl.asDeclContext().decls()

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -143,9 +143,14 @@ fun buildWrappedType(type: QualType): WrappedType {
     // signatures), which have no canonical record and previously fell through to a
     // canonical-spelling leaf ("vector<type-parameter-0-0,...>"). Checked BEFORE the
     // typedef handling for the same reason invoke checks it before createForType: an
-    // alias over a template type still collapses to the template shape. A non-type
-    // argument decodes to a null QualType and is dropped (TypeFactories' CXType_Invalid
-    // filterNotNull).
+    // alias over a template type still collapses to the template shape. A NON-TYPE
+    // argument decodes to a null QualType and becomes the UNRESOLVABLE leaf — probed on
+    // the live libclang oracle (featuregen's `Mask<4>`/`Flags<true>` T-defarg rows):
+    // clang_Type_getTemplateArgumentAsType yields a type WrappedType() can't model, so
+    // the libclang arg lands UNRESOLVABLE (NOT filterNotNull-dropped) and the
+    // specialization spells `Flags<unresolveable>`, failing resolution so the member
+    // referencing it drops. Dropping the arg instead materialized a broken zero-arg
+    // `Flags<>` binding that the wrapper compile rejects (#46 Phase D finding).
     val canonical = type.getCanonicalType()
     val canonTy = canonical.typePtr()
     val templateArgCount = with(type.memScope) { numTemplateArgs(type) }
@@ -161,9 +166,9 @@ fun buildWrappedType(type: QualType): WrappedType {
         // decode (value_type -> the substituted element type) would otherwise
         // MATERIALIZE initializer_list<Item*> as a useless extra binding.
         if (baseName == "std::initializer_list") return UNRESOLVABLE
-        val args = (0u until templateArgCount.toUInt()).mapNotNull { i ->
+        val args = (0u until templateArgCount.toUInt()).map { i ->
             val arg = with(type.memScope) { templateArgAsType(type, i) }
-            if (arg.typePtr() == null) null else buildWrappedType(arg)
+            if (arg.typePtr() == null) UNRESOLVABLE else buildWrappedType(arg)
         }
         return WrappedTemplateType(WrappedTypeReference(baseName), args).maybeConst(isConst)
     }

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -240,6 +240,14 @@ fun buildWrappedType(type: QualType): WrappedType {
     // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,
     // spelled from the canonical type — the structural equivalent of visit()'s collapse.
     val spelling = spellingOf(canonical) ?: return UNRESOLVABLE
+    // A canonical spelling still carrying a dependent-parameter placeholder (a
+    // DependentNameType member alias clang can't reduce, e.g. unordered_map's
+    // `_Hashtable<type-parameter-0-0,...>::hasher`) is unmodelable: the libclang path
+    // leaves these CXType_Unexposed and the member referencing them DROPS, while a
+    // surviving leaf here baked `type-parameter-0-0` (an illegal C identifier fragment)
+    // into uniqueCNames and broke the wrapper compile (#46 Phase D finding —
+    // unordered_map's hasher/key_equal/allocator_type ctor).
+    if (spelling.contains("type-parameter-")) return UNRESOLVABLE
     return WrappedTypeReference(spelling).maybeConst(isConst)
 }
 


### PR DESCRIPTION
Phase D entry brick (#46): the remaining cppfrontend fidelity mirrors (#45 tail) + the FIRST full featuregen parity attempt under `--frontend=cpp`.

## Part 1 — the remaining mirrors (each citing its TypeFactories/ModelFactories source)
- **pointerTypedefElement** → `TypeBuilder.pointerTypedef`: a DEPENDENT `pointer`/`const_pointer` member alias reduces to `element_type*` (unique_ptr's `get()`/`release()`/`operator->` survival); dual-kind `element_type` sibling lookup (`using` included), concrete pointer typedefs fall through untouched.
- **assocTypedefElement** → `TypeBuilder.assocTypedef`: dependent `key_type`/`mapped_type`/`value_type` reduce to the enclosing template's params (map shape: 0/1; key-only set shape: both → 0), params reached through `getDescribedClassTemplate()`; name-keyed per this front-end's in-template convention (typedAs accepts name or USR).
- **WrappedTemplateParam.defaultType** → `kppbridge::defaultArgType` (the TemplateArgumentLoc unwrap) + `TypeBuilder.defaultTypeResidue`: reproduces the libclang CURSOR-WALK RESIDUE shapes the model's `defaultType` getter reads, pinned against the live oracle (`U = Alloc<T>` → `[UNRESOLVABLE, tref(T)]`; `U = T`/`U = T*` → `[tref(T)]`; builtin → none); attached to the canonical param instance so a default first declared on a later redeclaration (basic_string after `<iosfwd>`) still lands.
- Fixture + self-checks grown 91 → **100** (SmartPtr/RawHolder/MiniMap/MiniSet/DefBox/DefPair, all pre-validated against the libclang parse of the same fixture).

## Part 1.5 — fixes that fell out of the parity run (cheap single-cause items, fixed inline)
- **Non-type template args decode to UNRESOLVABLE** (probed: libclang gives `Mask<4>` → `Mask<unresolveable>`, member drops); dropping the arg materialized a broken zero-arg `Flags<>` binding that failed the wrapper compile.
- **T1.3 range rewrite mirrored** (`rangeVectorReturn`/`elementOfIterator`/`stripDecoration`): `iterator_range<It>` returns materialize into `std::vector<Elem*>` at model construction — RangeHolder::items() now byte-matches.
- **Nested classes** (`Outer::Inner` binds; `Wrapper<T>::Inner` correctly does NOT — the nested-in-class-template skip).
- **Inline-namespace-preserving qualified names** (`kppbridge::qualifiedName`): `std::__cxx11::basic_string` now spells with the inline namespace, so std::string members resolve and Basic_string__Char/Wchar_t materialize on the cpp path.
- **`type-parameter-` leaf guard**: a canonical spelling still carrying a dependent placeholder is UNRESOLVABLE (was baking `type-parameter-0-0` into uniqueCNames → unordered_map wrapper-compile crash).

## Part 2 — the parity worklist generator
- `cppfrontend --parity-emit`: arbitrary header + per-spec ForcingHeader-shared forcing parses, ONE process per payload (crash isolation).
- `:cppfrontend:featuregenParity`: for each of featuregen's REAL 17 instantiation requests (requested.txt + the 6 seeded `instantiate()` calls) PLUS the ALL unit (the real sync's shape), generate through BOTH front-ends with an identical CLI tail and diff (byte-compare, `.def` path-modulo, unified diffs persisted per unit). Exits nonzero only on REGRESSION vs the committed `parity-expectations.txt` ledger — CI-able while Phase D converges; improvements print "ratchet the ledger".

## THE SCOREBOARD (first honest run)
**0 byte-identical / 18 diff / 0 generation-failed** — every unit (including ALL with all 17 instantiations) generates AND compiles end-to-end on `--frontend=cpp`. Per-spec: all 17 specs land in the small-categorized-diff class (~930–1100 diff lines each, dominated by one shared header-wide baseline; ALL = 3037 lines across 16 files).

### Categorized divergence families (the Phase D worklist, also filed on #46)
- **D1 initializer_list materialization** (~50% of diff lines): libclang's order-dependent `visit()` collapse RESOLVES `initializer_list` at featuregen scale (materializing `std_Initializer_list__*` + the ilist ctor/assign/insert overloads); the cpp front-end's documented deterministic UNRESOLVABLE rule drops them (the same rule that keeps the bag-fixture gate byte-identical, where libclang DROPS them — the order-dependence is the wall; convergence = deterministic collapse on the libclang side or scale-aware handling, tracked with N5).
- **D2 incidental INCLUDE_MISSING std surface** (~40%): `std::abs`×5/`wcschr`/`wcspbrk`/`wcsrchr`/`wcsstr`/`wmemchr`/`get_new_handler`/`set_new_handler` + `_IO_FILE` bind on libclang only; `__convert_from_v` + `__locale_struct` on cpp only — suspected LinkageSpecDecl/using-decl walk differences in ModelBuilder.addContextDecls + reference-graph deltas.
- **D3 dependent member-alias spellings on surviving members** (small): both sides keep a member but bake different pre-substitution arg spellings into its uniqueCName (set::insert's USR-keyed `template<c:...stl_set.h@3743>` vs the cpp overload set; unordered_map's `typename _Hashtable::hasher` vs `unresolveable`).
- **D4 out-of-line virtual destructor**: the libclang cursor walk REPARENTS `Drawable`'s out-of-line-defined dtor to the TU and loses it ("Can't find parent type" → no dispose()); the cpp path keeps it and emits dispose()/owned() — correct-by-construction; decide normalizer vs libclang-side fix.

## Verify
- FULL gate: krapper_gen nativeTest **313/0**, featuregen kplusplusSync + nativeTest **188/0**, krapper_model build, ktlintCheck — green, ZERO krapped/ drift.
- Gated: **100/100** self-checks, goldenCompare PASS (N1–N5), handoffGenerate, handoffInstDiff (oracle byte-identical + functional), featuregenParity green vs ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
