### PR TITLE
cppfrontend: D2 convergence — LinkageSpecDecl traversal + diff-line-ratcheted parity ledger (#46)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -524,8 +524,11 @@ tasks.register("featuregenParity") {
         // Byte-compare the two outputs: same file set, every file identical (the .def
         // path-modulo — it bakes the output dir's absolute path; .a excluded — derived
         // from the compared .cc). On divergence, a unified diff per file lands under
-        // diffs/<unit>/ for the worklist analysis.
-        fun diffUnit(unit: String, libclang: File, cpp: File): Pair<String, String> {
+        // diffs/<unit>/ for the worklist analysis. Third element: the diff-line count,
+        // ratcheted per-unit against the ledger's `diff:<N>` bound (D2 brick) so an
+        // intra-diff regression — more divergence while staying in the diff class —
+        // fails the task just like a class regression.
+        fun diffUnit(unit: String, libclang: File, cpp: File): Triple<String, String, Int> {
             fun files(dir: File) = dir.walkTopDown()
                 .filter { it.isFile && it.extension != "a" }
                 .map { it.relativeTo(dir).path }.toSortedSet()
@@ -560,15 +563,17 @@ tasks.register("featuregenParity") {
                 }
             }
             return if (notes.isEmpty() && diffFiles == 0) {
-                "identical" to "byte-identical (path-modulo .def) across ${a.size} files"
+                Triple("identical", "byte-identical (path-modulo .def) across ${a.size} files", 0)
             } else {
-                "diff" to (
-                    notes + "$diffLines diff line(s) across $diffFiles file(s)"
-                    ).joinToString("; ")
+                Triple(
+                    "diff",
+                    (notes + "$diffLines diff line(s) across $diffFiles file(s)").joinToString("; "),
+                    diffLines
+                )
             }
         }
 
-        data class Verdict(val unit: String, val cls: String, val detail: String)
+        data class Verdict(val unit: String, val cls: String, val detail: String, val lines: Int)
         val verdicts = mutableListOf<Verdict>()
         val units = specs.map { it to listOf(it) } + ("ALL" to specs)
         for ((unit, instSpecs) in units) {
@@ -580,13 +585,14 @@ tasks.register("featuregenParity") {
             if (libExit != 0) {
                 verdicts += Verdict(
                     unit, "fail",
-                    "LIBCLANG BASELINE failed (exit $libExit — infra, see $libLog)"
+                    "LIBCLANG BASELINE failed (exit $libExit — infra, see $libLog)",
+                    0
                 )
                 continue
             }
             val missing = instSpecs.filter { (forcingPaths[it] ?: "EMIT_FAILED") == "EMIT_FAILED" }
             if (missing.isNotEmpty()) {
-                verdicts += Verdict(unit, "fail", "cppfrontend model emit failed for $missing")
+                verdicts += Verdict(unit, "fail", "cppfrontend model emit failed for $missing", 0)
                 continue
             }
             val cppLog = File(logsDir, "${paritySlug(unit)}_cpp.log")
@@ -599,11 +605,11 @@ tasks.register("featuregenParity") {
             )
             if (cppExit != 0) {
                 val tail = cppLog.readLines().lastOrNull { it.isNotBlank() }.orEmpty()
-                verdicts += Verdict(unit, "fail", "cpp generation failed (exit $cppExit): $tail")
+                verdicts += Verdict(unit, "fail", "cpp generation failed (exit $cppExit): $tail", 0)
                 continue
             }
-            val (cls, detail) = diffUnit(unit, outLib, outCpp)
-            verdicts += Verdict(unit, cls, detail)
+            val (cls, detail, lines) = diffUnit(unit, outLib, outCpp)
+            verdicts += Verdict(unit, cls, detail, lines)
         }
 
         // Scoreboard + the regression gate against the committed expected-state ledger.
@@ -624,14 +630,30 @@ tasks.register("featuregenParity") {
         val report = buildString {
             appendLine("featuregenParity scoreboard (${verdicts.size} units):")
             for (v in verdicts) {
-                val exp = expected[v.unit] ?: "identical"
+                // A `diff` expectation may carry a line bound (`diff:<N>`): the unit
+                // regresses if it diverges MORE than recorded, and an improvement
+                // (fewer lines) prompts the ledger ratchet — same discipline as the
+                // class ranking, one level finer.
+                val expEntry = expected[v.unit] ?: "identical"
+                val exp = expEntry.substringBefore(':')
+                val expLines = expEntry.substringAfter(':', "").toIntOrNull()
                 val marker = when {
                     (rank[v.cls] ?: 2) > (rank[exp] ?: 0) -> {
                         regressions++
                         "REGRESSION (expected $exp)"
                     }
 
-                    (rank[v.cls] ?: 2) < (rank[exp] ?: 0) -> "IMPROVED (expected $exp — ratchet the ledger)"
+                    (rank[v.cls] ?: 2) < (rank[exp] ?: 0) ->
+                        "IMPROVED (expected $exp — ratchet the ledger)"
+
+                    v.cls == "diff" && expLines != null && v.lines > expLines -> {
+                        regressions++
+                        "REGRESSION (${v.lines} diff lines > ledger bound $expLines)"
+                    }
+
+                    v.cls == "diff" && expLines != null && v.lines < expLines ->
+                        "IMPROVED (${v.lines} < $expLines diff lines — ratchet the ledger)"
+
                     else -> "as expected"
                 }
                 appendLine("  [${v.cls.uppercase().padEnd(9)}] ${v.unit} — ${v.detail} [$marker]")

--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -1,41 +1,60 @@
 # featuregenParity expected-state ledger (#46 Phase D).
-# One line per parity unit: <spec>=<identical|diff|fail>. A unit with no line is
-# expected byte-identical. The task fails only when a unit's verdict is WORSE than
-# recorded here (identical < diff < fail); improvements are reported so this ledger
-# ratchets toward all-identical as Phase D converges.
+# One line per parity unit: <spec>=<identical|diff[:<maxDiffLines>]|fail>. A unit with no
+# line is expected byte-identical. The task fails when a unit's verdict is WORSE than
+# recorded here (identical < diff < fail), or when a `diff:<N>` unit diverges by MORE
+# than N diff lines; improvements are reported so this ledger ratchets toward
+# all-identical as Phase D converges.
 #
-# State as of the first full attempt (the brick that landed featuregenParity):
-# EVERY unit generates + compiles end-to-end on --frontend=cpp (0 fail), with
-# categorized diffs vs the libclang baseline. The divergence families (full
-# breakdown on issue #46):
+# State after the D2 convergence brick. EVERY unit still generates + compiles end-to-end
+# on --frontend=cpp (0 fail). Remaining divergence families (full breakdown on #46):
 #   D1 initializer_list materialization (libclang's order-dependent visit() collapse
 #      RESOLVES initializer_list at featuregen scale; the cpp front-end's documented
 #      deterministic UNRESOLVABLE rule drops the ilist ctors/assign/insert overloads
-#      and the std_Initializer_list__* bindings) — ~half the diff lines.
-#   D2 incidental INCLUDE_MISSING std surface (std::abs/wcschr/wcspbrk/wcsrchr/
-#      wcsstr/wmemchr/get_new_handler/set_new_handler + _IO_FILE bind on the
-#      libclang side only; __convert_from_v + __locale_struct on the cpp side only).
+#      and the std_Initializer_list__* bindings) — now the dominant share of the
+#      remaining diff lines (132 of Box<int>'s 174 featuregen.cc +/- lines; D2b 37, D4 5).
+#   D2 RESOLVED for the incidental-surface half (D2a): ModelBuilder now traverses
+#      LinkageSpecDecl with libclang's attach semantics, so the extern "C++"-wrapped
+#      std functions (std::abs/wcschr/wcspbrk/wcsrchr/wcsstr/wmemchr/get_new_handler/
+#      set_new_handler/div/__aligned_storage_default_alignment, __gnu_cxx::div/
+#      __is_null_pointer) and glibc's extern "C"-defined _IO_FILE members parse
+#      identically on both front-ends (root__IO_FILE.kt converged; Box<int> 955 -> 336).
+#      LEDGER-ACCEPTED residue (D2b) — libclang reference-spelling artifacts break its
+#      OWN INCLUDE_MISSING lookups where the cpp path resolves correctly:
+#       * std::__convert_from_v's __cloc arg leaf is spelled `struct __locale_struct`
+#         by libclang (the __c_locale typedef collapse keeps the elaborated keyword;
+#         USR c:c++locale.h@2318) and misses the class map key `__locale_struct`, so
+#         libclang silently DROPS the function ("Missing type const struct
+#         __locale_struct*&"); the cpp leaf is `__locale_struct`, resolves, and emits
+#         the function + root___locale_struct.kt (every unit, ~40 lines).
+#       * std::__exception_ptr::exception_ptr is misnamed `exception_ptr::exception_ptr`
+#         by the libclang walk (out-of-line-member spelling artifact in
+#         bits/exception_ptr.h), so libclang's lookup for std::current_exception/
+#         rethrow_exception's return type fails and both functions + the class are
+#         dropped; the cpp path binds them (+ std::type_info via __cxa_exception_type)
+#         — std::unique_ptr<int> and ALL only (<memory> pulls <exception>).
+#      Mirroring either spelling would be bug-for-bug lossiness emulation (the same
+#      reasoning as D4 / handoffInstDiff gate 2): accepted as diff, not converged.
 #   D3 dependent member-alias spellings baked into uniqueCNames of SURVIVING members
 #      (set::insert's `template<c:...stl_set.h@...>` USR-tref vs the cpp drop;
 #      unordered_map's `typename _Hashtable::hasher` vs `unresolveable`).
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
-Box<Box<int>>=diff
-Box<Point>=diff
-Box<int>=diff
-Pair2<int, double>=diff
-std::map<int, double>=diff
-std::map<int, int>=diff
-std::pair<int, int>=diff
-std::set<int>=diff
-std::unique_ptr<int>=diff
-std::unordered_map<int, int>=diff
-std::unordered_set<int>=diff
-std::vector<Point>=diff
-std::vector<Thing*>=diff
-std::vector<double>=diff
-std::vector<int>=diff
-std::vector<std::__cxx11::basic_string<char>>=diff
-std::vector<std::vector<int>>=diff
-ALL=diff
+Box<Box<int>>=diff:336
+Box<Point>=diff:336
+Box<int>=diff:336
+Pair2<int, double>=diff:336
+std::map<int, double>=diff:368
+std::map<int, int>=diff:368
+std::pair<int, int>=diff:336
+std::set<int>=diff:414
+std::unique_ptr<int>=diff:533
+std::unordered_map<int, int>=diff:376
+std::unordered_set<int>=diff:419
+std::vector<Point>=diff:482
+std::vector<Thing*>=diff:405
+std::vector<double>=diff:482
+std::vector<int>=diff:445
+std::vector<std::__cxx11::basic_string<char>>=diff:450
+std::vector<std::vector<int>>=diff:522
+ALL=diff:1383

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -121,16 +121,35 @@ private class ModelBuilder {
     private val classes = mutableMapOf<String, WrappedClass>()
     private val templates = mutableMapOf<String, WrappedTemplate>()
 
-    // Walk one DeclContext (the TU or a namespace) and add its children to [parent].
-    fun addContextDecls(context: DeclContext, parent: WrappedElement) {
+    // Walk one DeclContext (the TU, a namespace, or a linkage-spec block) and add its
+    // children to [parent]. [attach] mirrors libclang's LinkageSpecDecl semantics (D2,
+    // #46): mapAll's `map(parentCursor) ?: return` skips every edge whose parent cursor
+    // is a linkage spec (no map branch), so an `extern "C"/"C++" { ... }` block's DIRECT
+    // children are never attached as model children — but the walk still DESCENDS, and
+    // anything one level deeper attaches to its own mapped parent (members of `extern
+    // "C++" { namespace std { ... } }` land on the memoized nm(std); a record defined
+    // inside `extern "C" { ... }` gets its members on the USR-memoized class element,
+    // which is visible only if some NON-linkage-spec redeclaration attached it — exactly
+    // how glibc's `struct _IO_FILE` binds: forward decl at TU scope, definition inside
+    // extern "C"). With attach=false: namespaces/classes/templates are created DETACHED
+    // (memo only) and their members walked; functions and typedefs — which have no
+    // deeper attachment — produce nothing.
+    fun addContextDecls(context: DeclContext, parent: WrappedElement, attach: Boolean = true) {
         for (decl in context.decls()) {
             if (decl == null) continue
             // Skip implicit decls (the builtin TU members like __int128_t,
             // __builtin_va_list) — libclang's cursor walk never surfaces them.
             if (decl.isImplicit()) continue
+            if (decl.getKind() == Kind.LinkageSpec) {
+                val specContext = with(Decl.Companion) {
+                    decl.memScope.castToDeclContext(decl)
+                } ?: continue
+                addContextDecls(specContext, parent, attach = false)
+                continue
+            }
             val namespace = decl.asNamespaceDecl()
             if (namespace != null) {
-                addNamespace(namespace, parent)
+                addNamespace(namespace, parent, attach)
                 continue
             }
             // Brick 5: a `template <typename T> class` is a ClassTemplateDecl (NOT a
@@ -138,7 +157,7 @@ private class ModelBuilder {
             // WrappedTemplate (ModelFactories.map's CXCursor_ClassTemplate branch).
             val classTemplate = decl.asClassTemplateDeclOrNull()
             if (classTemplate != null) {
-                addTemplate(classTemplate, decl, parent)
+                addTemplate(classTemplate, decl, parent, attach)
                 continue
             }
             // A ClassTemplateSpecializationDecl IS-A CXXRecordDecl, but libclang's cursor
@@ -152,20 +171,23 @@ private class ModelBuilder {
             }
             val record = decl.asCXXRecordDecl()
             if (record != null) {
-                addClass(record, decl, parent)
+                addClass(record, decl, parent, attach)
                 continue
             }
             // Brick 5: a `typedef` is a WrappedTypedef element at ANY level — TU,
             // namespace, class, template (ModelFactories.map's CXCursor_TypedefDecl
             // branch is level-agnostic); a `using` alias produces no element (no
             // CXCursor_TypeAliasDecl branch) — the Kind.Typedef gate mirrors that split.
+            // A typedef or free function DIRECTLY inside a linkage spec has no deeper
+            // structure that could attach via the memo, so under attach=false both
+            // produce nothing — exactly libclang's skipped LinkageSpec->child edge.
             val typedef = decl.asTypedefDeclOrNull()
             if (typedef != null) {
-                buildTypedef(typedef)?.let { parent.addChild(it) }
+                if (attach) buildTypedef(typedef)?.let { parent.addChild(it) }
                 continue
             }
             val function = decl.asFunctionDecl()
-            if (function != null && decl.asCXXMethodDecl() == null) {
+            if (function != null && decl.asCXXMethodDecl() == null && attach) {
                 // A deleted free function: libclang surfaces `= delete` as
                 // CXAvailability_NotAvailable and filters the decl out
                 // (ModelFactories.map's availability check).
@@ -207,14 +229,14 @@ private class ModelBuilder {
     private fun addTemplate(
         templateDecl: ClassTemplateDecl,
         decl: Decl,
-        parent: WrappedElement
+        parent: WrappedElement,
+        attach: Boolean
     ) {
         val record = templateDecl.getTemplatedDecl()
             ?.let { CXXRecordDecl(it.ptr, templateDecl.memScope) } ?: return
         val name = record.asNamedDecl().getNameAsString() ?: return
-        val template = templates.getOrPut(decl.cppUsr()) {
-            WrappedTemplate(name).also { parent.addChild(it) }
-        }
+        val template = templates.getOrPut(decl.cppUsr()) { WrappedTemplate(name) }
+        attachIfNew(template, parent, attach)
         template.templateArgCounter = 0
         // getTemplateParameters() lives on TemplateDecl — ClassTemplateDecl's
         // address-identical primary base chain, so the same-pointer re-view is exact.
@@ -259,19 +281,32 @@ private class ModelBuilder {
         }
     }
 
-    private fun addNamespace(decl: NamespaceDecl, parent: WrappedElement) {
+    private fun addNamespace(decl: NamespaceDecl, parent: WrappedElement, attach: Boolean) {
         val name = decl.asNamedDecl().getNameAsString() ?: error("namespace without a name")
         // An anonymous namespace has an empty spelling; its members have TU-internal
         // linkage and can't cross the C ABI, so it is skipped transitively
         // (ModelFactories.map's CXCursor_Namespace branch).
         if (name.isEmpty()) return
-        val namespace = namespaces.getOrPut(decl.asDecl().cppUsr()) {
-            WrappedNamespace(name).also { parent.addChild(it) }
-        }
+        val namespace = namespaces.getOrPut(decl.asDecl().cppUsr()) { WrappedNamespace(name) }
+        // Attach at the first sighting outside a linkage spec — including an element
+        // created DETACHED inside one earlier (libclang's lazy `parent.addChild` on the
+        // first edge whose parent cursor maps).
+        attachIfNew(namespace, parent, attach)
+        // Members of a linkage-spec-wrapped namespace block DO attach: they are one
+        // level below the skipped edge (their parent is the namespace element).
         addContextDecls(decl.asDeclContext(), namespace)
     }
 
-    private fun addClass(record: CXXRecordDecl, decl: Decl, parent: WrappedElement) {
+    private fun attachIfNew(element: WrappedElement, parent: WrappedElement, attach: Boolean) {
+        if (attach && element.parent == null) parent.addChild(element)
+    }
+
+    private fun addClass(
+        record: CXXRecordDecl,
+        decl: Decl,
+        parent: WrappedElement,
+        attach: Boolean
+    ) {
         // An ANONYMOUS record is spelled by its typedef name when one exists (`typedef
         // struct { ... } max_align_t;` — libclang's cursor-spelling rule, which is how
         // max_align_t binds on that path); a truly anonymous record (libclang spells
@@ -289,8 +324,8 @@ private class ModelBuilder {
         // to one element via the memo; members attach from the defining redecl only.
         val cls = classes.getOrPut(decl.cppUsr()) {
             WrappedClass(name, isAbstract = record.hasDefinition() && record.isAbstract())
-                .also { parent.addChild(it) }
         }
+        attachIfNew(cls, parent, attach)
         if (record.isThisDeclarationADefinition()) {
             addBasesAndMembers(record, cls, cls.metadata)
         }

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -419,7 +419,7 @@ private class ModelBuilder {
             decl.getKind() != Kind.ClassTemplatePartialSpecialization
         ) {
             decl.asCXXRecordDecl()?.let { record ->
-                addClass(record, decl, parent)
+                addClass(record, decl, parent, attach = true)
                 return
             }
         }


### PR DESCRIPTION
Phase D convergence brick for #46: family **D2 — the incidental INCLUDE_MISSING std surface** (~40% of the parity diff lines at entry).

## Root causes pinned (per mechanism)

**D2a — the cpp walk skipped `LinkageSpecDecl` (FIXED).** ModelBuilder.addContextDecls never descended into `extern "C"`/`extern "C++"` blocks, so the cpp model was missing every std function libstdc++ declares inside one — `<cwchar>`'s `std::wcschr/wcspbrk/wcsrchr/wcsstr/wmemchr`, `<bits/std_abs.h>`'s `std::abs` x7, `<new>`'s `get/set_new_handler`, `<type_traits>`' `__aligned_storage_default_alignment` (all wrapped in `extern "C++" { namespace std { ... } }`), plus `std::div`/`__gnu_cxx::div`/`__gnu_cxx::__is_null_pointer` — AND glibc's `struct _IO_FILE`, whose *definition* sits inside `extern "C"`: the cpp model carried only the TU-scope forward decl, so the directly-bound class was EMPTY (32 members on the libclang side) and dropped as "Empty class", which is exactly the `root__IO_FILE.kt` file-set divergence.

The fix mirrors libclang's semantics precisely: mapAll's `map(parentCursor) ?: return` has no LinkageSpec branch, so a linkage spec's DIRECT children never attach — but the walk descends, and anything one level deeper attaches to its own mapped parent. `addContextDecls(attach=false)` therefore creates namespaces/classes/templates DETACHED (memo only, members still walked) and skips typedefs/free functions; `attachIfNew` reproduces the lazy `parent.addChild` at the first sighting outside a linkage spec. Post-fix parse-model diff: free functions/templates/typedefs are at **zero set-difference** between the two front-ends on the featuregen TU (was 12 missing free-function entries), and `_IO_FILE` carries 32 children on both sides.

**D2b — libclang reference-spelling artifacts break its OWN INCLUDE_MISSING lookups (LEDGER-ACCEPTED, cpp side is more correct).** Two instances, both cited in the ledger:
* `std::__convert_from_v`'s `__cloc` arg leaf is spelled `struct __locale_struct` by libclang (the `__c_locale` typedef collapse keeps the elaborated keyword; USR `c:c++locale.h@2318`), which misses the class-map key `__locale_struct` — KRAPPER_DEBUG_RESOLVE shows `Method failed from argument __cloc: const struct __locale_struct*&: Missing type`, so libclang silently DROPS the function. The cpp leaf is `__locale_struct`, resolves, and emits the function + `root___locale_struct.kt` (every unit).
* `std::__exception_ptr::exception_ptr` is misnamed **`exception_ptr::exception_ptr`** in the libclang model (out-of-line-member spelling artifact in `bits/exception_ptr.h`), so libclang's lookup for `std::current_exception`/`rethrow_exception`'s return type fails and both functions + the class are dropped; the cpp path binds them (+ `std::type_info` via `__cxa_exception_type`) — `std::unique_ptr<int>` and ALL units only (`<memory>` pulls `<exception>`).

Mirroring either spelling would be bug-for-bug emulation of the lossiness the bootstrap exists to delete (same reasoning as D4 and handoffInstDiff gate 2), so these are accepted as diffs with citations, not converged.

## The ratchet (diff lines, before -> after)

| unit | before | after |
|---|---|---|
| Box&lt;int&gt; / Box&lt;Point&gt; / Box&lt;Box&lt;int&gt;&gt; / Pair2&lt;int, double&gt; / std::unique_ptr&lt;int&gt; | 955 | 336 / 336 / 336 / 336 / 533* |
| std::pair&lt;int, int&gt; | 933 | 336 |
| std::map&lt;int, double&gt; / std::map&lt;int, int&gt; | 955 | 368 |
| std::set&lt;int&gt; | 1001 | 414 |
| std::unordered_map&lt;int, int&gt; | 963 | 376 |
| std::unordered_set&lt;int&gt; | 1006 | 419 |
| std::vector&lt;Point&gt; / &lt;double&gt; | 1069 | 482 |
| std::vector&lt;Thing*&gt; | 992 | 405 |
| std::vector&lt;int&gt; | 1032 | 445 |
| std::vector&lt;string&gt; | 1069 | 450 |
| std::vector&lt;vector&lt;int&gt;&gt; | 1109 | 522 |
| **ALL** | **3037** | **1383** |

\* unique_ptr carries the exception_ptr/type_info D2b residue (the two extra cpp-side files).

Total across the 17 per-spec units: 16,936 -> 6,648 diff lines (ALL: 3,037 -> 1,383, **-54%**). `root__IO_FILE.kt` is gone from every unit's file-set diff. Per-family decomposition of a representative unit (Box&lt;int&gt; featuregen.cc): D1 initializer_list 132, D2b 37, D4 5, other 0 — D2a residue is **zero**.

**Ledger hardening:** `parity-expectations.txt` now carries a per-unit `diff:<N>` bound and featuregenParity enforces it — a unit that stays in the diff class but diverges by MORE lines than recorded is a regression; fewer lines prompts the ratchet. Intra-diff improvements were previously invisible to the gate.

## Entanglements noted
The remaining diff lines decompose into D1 (initializer_list — dominant share), D3 (alias spellings in basic_string uniqueCNames), D4 (ledgered) and the two D2b accepts above. No D2 work was deferred into D1/D3.

## Verify
* FULL gate: krapper_gen nativeTest **313/0**, featuregen nativeTest **188/0**, kplusplusSync + krapper_model build green, ktlintCheck green, **zero krapped/ drift** (no shared krapper_gen/krapper_model code touched).
* Gated: self-checks **100 PASS / 0 FAIL**, goldenCompare green, handoffGenerate green, handoffInstDiff oracle **byte-identical across 9 files** + functional gate green, featuregenParity **0 fail / 18 diff / 0 identical, 0 regressions** against the ratcheted ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
