### PR TITLE
cppfrontend: D3 convergence — dependent member aliases keep the deterministic WRITTEN typename spelling (#46)

### DIFF
--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -5,7 +5,7 @@
 # than N diff lines; improvements are reported so this ledger ratchets toward
 # all-identical as Phase D converges.
 #
-# State after the D2 convergence brick. EVERY unit still generates + compiles end-to-end
+# State after the D3 convergence brick. EVERY unit still generates + compiles end-to-end
 # on --frontend=cpp (0 fail). Remaining divergence families (full breakdown on #46):
 #   D1 initializer_list materialization (libclang's order-dependent visit() collapse
 #      RESOLVES initializer_list at featuregen scale; the cpp front-end's documented
@@ -34,9 +34,27 @@
 #         — std::unique_ptr<int> and ALL only (<memory> pulls <exception>).
 #      Mirroring either spelling would be bug-for-bug lossiness emulation (the same
 #      reasoning as D4 / handoffInstDiff gate 2): accepted as diff, not converged.
-#   D3 dependent member-alias spellings baked into uniqueCNames of SURVIVING members
-#      (set::insert's `template<c:...stl_set.h@...>` USR-tref vs the cpp drop;
-#      unordered_map's `typename _Hashtable::hasher` vs `unresolveable`).
+#   D3 dependent member-alias spellings baked into uniqueCNames of SURVIVING members —
+#      CONVERGED on the cpp side to the deterministic rule (D3 brick): a DependentNameType
+#      member alias no reducer claims keeps its WRITTEN `typename <qual>::<name>` spelling
+#      as a WrappedTypename leaf, '<'-truncated exactly like TypeFactories' else-branch
+#      (goldenCompare's MiniHash shapes pin both qualifier forms against the live oracle).
+#      That is libclang's UNCACHED default, so unordered_set<int>'s (size_t, const hasher&,
+#      const key_equal&, const allocator_type&) ctor converges in the ALL unit (1383->1375).
+#      LEDGER-ACCEPTED residue: libclang's remaining spellings of the SAME aliases are
+#      PROVEN parse-context-dependent (the seenNames cache, N5) — the same ctor spells
+#      `typename_EXP__Hashtable_*` x3 under the ALL worklist, `typename hasher` +
+#      `template__Equal`/`template__Alloc` in its own single-spec unit, and yet another
+#      variant (`allocator_type` name leaf) under a minimal two-include header. A spelling
+#      that changes with unrelated parse content is not a convergence target; the cpp
+#      spelling is the stable member of the family (the Phase E reference). Affected:
+#      unordered_map<int,int> ALL+unit, unordered_set<int> unit (the cpp side spells the
+#      deterministic typename forms either way).
+#      D1-ENTANGLED (deferred with D1): the USR-tref overload suffixes (set::insert's
+#      `template_c_stl_set_h_3743` vs the cpp name-tref `template<_Key>`) only surface
+#      because the initializer_list insert/ctor/assign overloads survive on libclang and
+#      force disambiguation; cpp's single survivor needs no suffix. Converging D1 will
+#      expose them as the residual name-vs-USR tref-key spelling choice.
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
@@ -57,4 +75,4 @@ std::vector<double>=diff:482
 std::vector<int>=diff:445
 std::vector<std::__cxx11::basic_string<char>>=diff:450
 std::vector<std::vector<int>>=diff:522
-ALL=diff:1383
+ALL=diff:1375

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -213,6 +213,14 @@ private val FIXTURE_HEADER = """
         void insert(const value_type& v);
     };
 
+    template <typename H> struct HashTraits { typedef H hash_fn; };
+
+    template <typename K, typename H>
+    struct MiniHash {
+        typedef typename HashTraits<H>::hash_fn hasher;
+        void rehash(const hasher& h);
+    };
+
     template <typename T> struct DefAlloc {};
 
     template <typename T, typename A = DefAlloc<T>>
@@ -634,10 +642,10 @@ fun main(args: Array<String>): Unit = memScoped {
     val holders = tu.children.filterIsInstance<WrappedTemplate>()
     val holder = holders.find { it.name == "Holder" }
     check(
-        "TU contains the 10 WrappedTemplates in source order (Holder + the Phase D shapes)",
+        "TU contains the 12 WrappedTemplates in source order (Holder + the Phase D shapes)",
         holders.map { it.name } == listOf(
             "Holder", "PtrTrait", "SmartPtr", "MapTraits", "MiniMap",
-            "SetTraits", "MiniSet", "DefAlloc", "DefBox", "DefPair"
+            "SetTraits", "MiniSet", "HashTraits", "MiniHash", "DefAlloc", "DefBox", "DefPair"
         ),
         "got ${holders.map { it.name }}"
     )
@@ -999,6 +1007,26 @@ fun main(args: Array<String>): Unit = memScoped {
         miniSet?.methods?.find { it.name == "insert" }?.args?.singleOrNull()
             ?.type?.toString() == "const template<K>&",
         "got ${miniSet?.methods?.find { it.name == "insert" }?.args}"
+    )
+    // The D3 dependent-typename leaf (unordered_map/set's hasher shape): a member
+    // typedef whose underlying is a DependentNameType NO reducer claims keeps the
+    // WRITTEN `typename <qual>::<name>` spelling as a WrappedTypename — the
+    // deterministic mirror of TypeFactories' `WrappedType(spelling)` else-branch
+    // (the libclang cache's order-dependent remappings are ledger-accepted, D3).
+    val miniHash = holders.find { it.name == "MiniHash" }
+    check(
+        "MiniHash's dependent `hasher` alias keeps the WRITTEN typename spelling",
+        miniHash?.children?.filterIsInstance<WrappedTypedef>()
+            ?.find { it.name == "hasher" }?.targetType
+            ?.toString() == "typename!<HashTraits<H>::hash_fn>",
+        "got ${miniHash?.children?.filterIsInstance<WrappedTypedef>()
+            ?.map { "${it.name}=${it.targetType}" }}"
+    )
+    check(
+        "MiniHash::rehash(const hasher&) arg carries the typename leaf (not unresolveable)",
+        miniHash?.methods?.find { it.name == "rehash" }?.args?.singleOrNull()
+            ?.type?.toString() == "const typename!<HashTraits<H>::hash_fn>&",
+        "got ${miniHash?.methods?.find { it.name == "rehash" }?.args}"
     )
     // WrappedTemplateParam.defaultType: the cursor-walk residue shapes, pinned against
     // the libclang oracle (see TypeBuilder.defaultTypeResidue).

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -217,8 +217,11 @@ private val FIXTURE_HEADER = """
 
     template <typename K, typename H>
     struct MiniHash {
+        typedef HashTraits<H> traits_type;
         typedef typename HashTraits<H>::hash_fn hasher;
+        typedef typename traits_type::hash_fn key_equal;
         void rehash(const hasher& h);
+        void requal(const key_equal& q);
     };
 
     template <typename T> struct DefAlloc {};
@@ -1014,19 +1017,24 @@ fun main(args: Array<String>): Unit = memScoped {
     // deterministic mirror of TypeFactories' `WrappedType(spelling)` else-branch
     // (the libclang cache's order-dependent remappings are ledger-accepted, D3).
     val miniHash = holders.find { it.name == "MiniHash" }
+    val miniHashTypedefs = miniHash?.children?.filterIsInstance<WrappedTypedef>().orEmpty()
     check(
-        "MiniHash's dependent `hasher` alias keeps the WRITTEN typename spelling",
-        miniHash?.children?.filterIsInstance<WrappedTypedef>()
-            ?.find { it.name == "hasher" }?.targetType
-            ?.toString() == "typename!<HashTraits<H>::hash_fn>",
-        "got ${miniHash?.children?.filterIsInstance<WrappedTypedef>()
-            ?.map { "${it.name}=${it.targetType}" }}"
+        "MiniHash's dependent aliases keep the WRITTEN typename spelling, '<'-truncated " +
+            "(template-id qualifier collapses; bare-typedef qualifier survives whole)",
+        miniHashTypedefs.find { it.name == "hasher" }?.targetType
+            ?.toString() == "typename!<HashTraits>" &&
+            miniHashTypedefs.find { it.name == "key_equal" }?.targetType
+            ?.toString() == "typename!<traits_type::hash_fn>",
+        "got ${miniHashTypedefs.map { "${it.name}=${it.targetType}" }}"
     )
     check(
-        "MiniHash::rehash(const hasher&) arg carries the typename leaf (not unresolveable)",
+        "MiniHash::rehash/requal args carry the typename leaves (not unresolveable)",
         miniHash?.methods?.find { it.name == "rehash" }?.args?.singleOrNull()
-            ?.type?.toString() == "const typename!<HashTraits<H>::hash_fn>&",
-        "got ${miniHash?.methods?.find { it.name == "rehash" }?.args}"
+            ?.type?.toString() == "const typename!<HashTraits>&" &&
+            miniHash?.methods?.find { it.name == "requal" }?.args?.singleOrNull()
+            ?.type?.toString() == "const typename!<traits_type::hash_fn>&",
+        "got rehash=${miniHash?.methods?.find { it.name == "rehash" }?.args} " +
+            "requal=${miniHash?.methods?.find { it.name == "requal" }?.args}"
     )
     // WrappedTemplateParam.defaultType: the cursor-walk residue shapes, pinned against
     // the libclang oracle (see TypeBuilder.defaultTypeResidue).

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -724,8 +724,8 @@ fun main(args: Array<String>): Unit = memScoped {
     // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
     // pinned against the libclang oracle for this fixture.
     check(
-        "TU has exactly 22 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
-        tu.children.size == 22,
+        "TU has exactly 24 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
+        tu.children.size == 24,
         "got ${tu.children.size}"
     )
     val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -208,10 +208,16 @@ fun buildWrappedType(type: QualType): WrappedType {
     // across parse contexts: `typename _Hashtable::hasher` under featuregen's header,
     // `_Equal`/`allocator_type` leaks in minimal parses). This front-end always emits
     // the typename leaf — the stable spelling, matching libclang's uncached case.
+    // One createForType string step is load-bearing here: the spelling is TRUNCATED at
+    // the first '<' before wrapping, so a template-id qualifier collapses to its bare
+    // name (`typename HashTraits<H>::hash_fn` -> `typename!<HashTraits>`) while the
+    // bare-typedef qualifier of the unordered containers survives whole
+    // (`typename _Hashtable::hasher` -> `typename!<_Hashtable::hasher>`) — both pinned
+    // against the live oracle by goldenCompare's MiniHash shapes.
     if (ty.isDependentType()) {
         val written = type.getUnqualifiedType().getAsString()?.trim()
         if (written != null && written.startsWith("typename ")) {
-            return WrappedType(written).maybeConst(isConst)
+            return WrappedType(written.substringBefore('<')).maybeConst(isConst)
         }
     }
 

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -196,6 +196,25 @@ fun buildWrappedType(type: QualType): WrappedType {
         return WrappedTemplateRef(name).maybeConst(isConst)
     }
 
+    // Dependent member alias clang leaves unresolved (`typename _Hashtable::hasher`,
+    // a DependentNameType): TypeFactories' `else -> WrappedType(spelling)` wraps the
+    // WRITTEN spelling, and the WrappedType string factory peels the `typename ` prefix
+    // into a WrappedTypename leaf — read off the SUGARED type, since visit() returns a
+    // NoDeclFound type unchanged and canonicalization would leak `type-parameter-N-M`.
+    // DETERMINISTIC-RULE divergence (D3, parity-expectations.txt): the libclang path
+    // only produces this shape when its order-dependent visit() cache hasn't already
+    // remapped the alias's spelling to an earlier-seen type — PROVEN context-dependent
+    // (the same unordered_set<int> ctor spells `const hasher&` three different ways
+    // across parse contexts: `typename _Hashtable::hasher` under featuregen's header,
+    // `_Equal`/`allocator_type` leaks in minimal parses). This front-end always emits
+    // the typename leaf — the stable spelling, matching libclang's uncached case.
+    if (ty.isDependentType()) {
+        val written = type.getUnqualifiedType().getAsString()?.trim()
+        if (written != null && written.startsWith("typename ")) {
+            return WrappedType(written).maybeConst(isConst)
+        }
+    }
+
     // ---- createForType leaf dispatch (post-visit, i.e. against the canonical type) ----
 
     if (canonTy != null && canonTy.isConstantArrayType()) {
@@ -240,13 +259,11 @@ fun buildWrappedType(type: QualType): WrappedType {
     // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,
     // spelled from the canonical type — the structural equivalent of visit()'s collapse.
     val spelling = spellingOf(canonical) ?: return UNRESOLVABLE
-    // A canonical spelling still carrying a dependent-parameter placeholder (a
-    // DependentNameType member alias clang can't reduce, e.g. unordered_map's
-    // `_Hashtable<type-parameter-0-0,...>::hasher`) is unmodelable: the libclang path
-    // leaves these CXType_Unexposed and the member referencing them DROPS, while a
-    // surviving leaf here baked `type-parameter-0-0` (an illegal C identifier fragment)
-    // into uniqueCNames and broke the wrapper compile (#46 Phase D finding —
-    // unordered_map's hasher/key_equal/allocator_type ctor).
+    // A canonical spelling still carrying a dependent-parameter placeholder (residual
+    // dependent shapes that aren't `typename `-prefixed sugar, e.g. an unsugared
+    // `_Hashtable<type-parameter-0-0,...>::hasher`) is unmodelable: a surviving leaf
+    // here baked `type-parameter-0-0` (an illegal C identifier fragment) into
+    // uniqueCNames and broke the wrapper compile (#46 Phase D finding).
     if (spelling.contains("type-parameter-")) return UNRESOLVABLE
     return WrappedTypeReference(spelling).maybeConst(isConst)
 }


### PR DESCRIPTION
Phase D convergence brick for #46: **D3 — dependent member-alias spellings baked into uniqueCNames of SURVIVING members.**

## Where D3 actually lives post-D2

Decomposing the 1383-line ALL diff: the surviving-member D3 family is exactly **two declarations** — the `(size_type, const hasher&, const key_equal&, const allocator_type&)` ctors of `std::unordered_map<int,int>` and `std::unordered_set<int>` (defaulted args dropped from the Kotlin signature, the alias spellings baked into the uniqueCName). Everything else that looks D3-ish is D1-entangled (below). The vector `allocator_type` exemplar from #63 does not recur in featuregen — all vector/basic_string/set .kt diffs are pure D1 ilist lines.

## Per-exemplar root cause + disposition

**Converged — the deterministic rule.** The cpp path previously sent these aliases (`typename _Hashtable::hasher` etc., DependentNameTypes no reducer claims) through the canonical-spelling leaf, where the `type-parameter-` guard collapsed them to `unresolveable`. The libclang path's *uncached* default is TypeFactories' `else -> WrappedType(spelling)`: the WRITTEN spelling, '<'-truncated, peeled into a `WrappedTypename` leaf (`typename_EXP__Hashtable_hasher`). TypeBuilder now mirrors that rule structurally: a dependent type whose sugared spelling starts with `typename ` becomes `WrappedTypename(written.substringBefore('<'))`. The '<'-truncation and both qualifier shapes (template-id collapses to bare name; bare-typedef qualifier survives whole) are pinned against the **live libclang oracle** by goldenCompare's new MiniHash fixture + 2 self-checks.

**Ledger-accepted with proof — libclang's remaining spellings are parse-context-dependent.** The same `unordered_set<int>` ctor spells THREE different ways on the libclang path depending on unrelated parse content (the seenNames cache, the N5 family):
- ALL worklist: `typename_EXP__Hashtable_{hasher,key_equal,allocator_type}`
- its own single-spec parity unit: `typename_EXP__Hashtable_hasher` + `template__Equal` + `template__Alloc`
- a minimal `<unordered_map>+<unordered_set>` header (either include order): `typename_EXP__Hashtable_hasher` + `template__Equal` + `allocator_type` (a bare name leaf)

A spelling that changes with unrelated parse content is not a convergence target; the cpp spelling is the stable member of the family and matches libclang's uncached case — the right reference for the Phase E flip. Mirroring the cache would be emulating order-dependence.

**Deferred — D1-entangled.** The USR-tref overload suffixes (`std_set_int_insert__const_template_c_stl_set_h_3743_and`, unordered_set's insert) only exist because the initializer_list overloads SURVIVE on libclang and force uniqueCName disambiguation; the cpp side's single survivor needs no suffix. Converging D1 will expose the residual name-vs-USR tref-key spelling choice — recorded in the ledger.

## Ratchet

| unit | before | after |
|---|---|---|
| ALL | **1383** | **1375** (unordered_set ctor converges: 4 .kt + 2 .h + 2 .cc lines) |
| all 17 per-spec units | unchanged bounds | unchanged (the per-unit libclang spellings differ from the ALL-context ones — the order-dependence proof itself) |

0 fail / 18 diff, no regressions, ledger ratcheted.

## Verify

- FULL gate: `:krapper_gen:nativeTest :krapper_model:build :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck` — green, **zero krapped/ drift** (cppfrontend-only change; no shared code touched).
- Gated: self-checks ALL PASS (incl. the 2 new MiniHash pins), goldenCompare PASS (live oracle), handoffGenerate + handoffInstDiff byte-identical, featuregenParity green against the ratcheted ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
