### PR TITLE
cppfrontend: D1a — concrete initializer_list materialization converges (+ the dependent-pointer typedef lossy-collapse mirror) (#46)

### DIFF
--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -5,13 +5,30 @@
 # than N diff lines; improvements are reported so this ledger ratchets toward
 # all-identical as Phase D converges.
 #
-# State after the D3 convergence brick. EVERY unit still generates + compiles end-to-end
+# State after the D1a convergence brick. EVERY unit still generates + compiles end-to-end
 # on --frontend=cpp (0 fail). Remaining divergence families (full breakdown on #46):
-#   D1 initializer_list materialization (libclang's order-dependent visit() collapse
-#      RESOLVES initializer_list at featuregen scale; the cpp front-end's documented
-#      deterministic UNRESOLVABLE rule drops the ilist ctors/assign/insert overloads
-#      and the std_Initializer_list__* bindings) — now the dominant share of the
-#      remaining diff lines (132 of Box<int>'s 174 featuregen.cc +/- lines; D2b 37, D4 5).
+#   D1 initializer_list materialization — decomposed + partially converged (D1a brick):
+#      D1a CONVERGED: a CONCRETE element (DefaultArgs::sumIlist's initializer_list<int>)
+#          decodes faithfully, the member survives, and INCLUDE_MISSING materializes
+#          std_Initializer_list__Int byte-identically (-49 diff lines in EVERY unit).
+#          Required the LOSSY-COLLAPSE mirror: a typedef over a DEPENDENT pointer/
+#          reference shape (`typedef const _E* const_iterator`) collapses to libclang's
+#          bare-NAME spelling leaf (never a substitutable tref), so the materialized
+#          class's begin()/end() drop exactly like the live oracle.
+#      D1b remaining: dependent-element member overloads whose libclang spelling is a
+#          NAME tref (basic_string's `std_initializer_list_template__CharT` ctor/op=/
+#          +=/append/assign, vector's `template__Tp` ctor/op=/assign, + the per-element
+#          std_Initializer_list__* materializations they imply) — the same name-tref
+#          convention this front-end uses, so mirrorable deterministically; now the
+#          dominant remaining share (~110/unit basic_string + ~50/vector unit).
+#      D1c remaining: set/unordered_set's surviving overloads spell the element by the
+#          param's USR (`template_c_stl_set_h_3743` = c:stl_set.h@3743 — a header BYTE
+#          OFFSET): libclang's assocTypedefElement keys its reconstructed value_type
+#          tref by param USR where this front-end deliberately keys by NAME. Mirroring
+#          means synthesizing file@offset USRs into symbol names (decision brick).
+#      D1d downstream: the disambiguation-suffix renames on UNRELATED members
+#          (set::insert(const value_type&) -> `__const_template_c_stl_set_h_3743_and`)
+#          have no independent fix — they collapse into D1b+D1c.
 #   D2 RESOLVED for the incidental-surface half (D2a): ModelBuilder now traverses
 #      LinkageSpecDecl with libclang's attach semantics, so the extern "C++"-wrapped
 #      std functions (std::abs/wcschr/wcspbrk/wcsrchr/wcsstr/wmemchr/get_new_handler/
@@ -58,21 +75,21 @@
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
-Box<Box<int>>=diff:336
-Box<Point>=diff:336
-Box<int>=diff:336
-Pair2<int, double>=diff:336
-std::map<int, double>=diff:368
-std::map<int, int>=diff:368
-std::pair<int, int>=diff:336
-std::set<int>=diff:414
-std::unique_ptr<int>=diff:533
-std::unordered_map<int, int>=diff:376
-std::unordered_set<int>=diff:419
-std::vector<Point>=diff:482
-std::vector<Thing*>=diff:405
-std::vector<double>=diff:482
-std::vector<int>=diff:445
-std::vector<std::__cxx11::basic_string<char>>=diff:450
-std::vector<std::vector<int>>=diff:522
-ALL=diff:1375
+Box<Box<int>>=diff:287
+Box<Point>=diff:287
+Box<int>=diff:287
+Pair2<int, double>=diff:287
+std::map<int, double>=diff:319
+std::map<int, int>=diff:319
+std::pair<int, int>=diff:287
+std::set<int>=diff:365
+std::unique_ptr<int>=diff:484
+std::unordered_map<int, int>=diff:327
+std::unordered_set<int>=diff:370
+std::vector<Point>=diff:433
+std::vector<Thing*>=diff:356
+std::vector<double>=diff:433
+std::vector<int>=diff:396
+std::vector<std::__cxx11::basic_string<char>>=diff:401
+std::vector<std::vector<int>>=diff:473
+ALL=diff:1326

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -158,15 +158,20 @@ fun buildWrappedType(type: QualType): WrappedType {
     if (templateArgCount > 0) {
         val baseName = with(type.memScope) { templateBaseName(type) }
             ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
-        // std::initializer_list is compiler magic the C boundary can never marshal (a
-        // Kotlin caller cannot construct one), so it is UNRESOLVABLE by construction —
-        // members taking one drop in resolution (or have the defaulted arg omitted),
-        // matching the libclang path, where the same members drop because that
-        // front-end's `initializer_list<value_type>` spelling keeps the alias-name leaf
-        // its order-dependent visit() collapse can't resolve. This front-end's faithful
-        // decode (value_type -> the substituted element type) would otherwise
-        // MATERIALIZE initializer_list<Item*> as a useless extra binding.
-        if (baseName == "std::initializer_list") return UNRESOLVABLE
+        // std::initializer_list (D1a, #46): a CONCRETE use (`initializer_list<int>` —
+        // featuregen's DefaultArgs::sumIlist) is an ordinary template specialization on
+        // the libclang path — the member survives and INCLUDE_MISSING materializes the
+        // std_Initializer_list__Int binding — so it decodes faithfully here too. A
+        // DEPENDENT element (`initializer_list<_CharT>` / `<value_type>` inside a
+        // template's own member signatures) stays UNRESOLVABLE by construction: those
+        // members survive on libclang only through its order-dependent visit() collapse
+        // (name-tref on basic_string/vector, USR-tref on set/unordered_set — the
+        // D1b/D1c residue in parity-expectations.txt), and this front-end's documented
+        // deterministic rule drops them instead of emulating the cache.
+        if (baseName == "std::initializer_list") {
+            val element = with(type.memScope) { templateArgAsType(type, 0u) }
+            if (element.typePtr()?.isDependentType() != false) return UNRESOLVABLE
+        }
         val args = (0u until templateArgCount.toUInt()).map { i ->
             val arg = with(type.memScope) { templateArgAsType(type, i) }
             if (arg.typePtr() == null) UNRESOLVABLE else buildWrappedType(arg)
@@ -324,7 +329,28 @@ fun buildTypedefTargetType(typedef: TypedefNameDecl): WrappedType {
         "difference_type" -> return WrappedTypeReference("ptrdiff_t")
     }
     if (name in C_ALIAS_TYPEDEFS) return WrappedTypeReference(name)
-    return buildWrappedType(typedef.getUnderlyingType())
+    // LOSSY-COLLAPSE mirror (D1a, #46): a typedef whose followed underlying is a
+    // DEPENDENT pointer/reference shape (initializer_list's `typedef const _E*
+    // const_iterator`, allocator's `typedef _Tp* pointer`) collapses on the libclang
+    // path to createForType's `else -> WrappedType(spelling)` — visit() returns the
+    // underlying POINTER type (kind CXType_Pointer, not Unexposed, decl NoDeclFound),
+    // so the spelling parses into pointerTo/referenceTo of a bare NAME leaf ("_E"),
+    // never a substitutable WrappedTemplateRef — and every member using the alias
+    // drops at resolution (initializer_list<int>'s begin()/end() in the live
+    // featuregen oracle: "Couldn't resolve return: const _E*"). The structural decode
+    // below would produce pointerTo(const(tref(_E))) instead, which SUBSTITUTES and
+    // would surface begin()/end() libclang never binds. Concrete underlyings keep the
+    // structural path (identical result, no spelling parse). A chained alias falls
+    // through to the recursion (asTypedefTypeOrNull), matching visit()'s follow.
+    val underlying = typedef.getUnderlyingType()
+    val underTy = underlying.typePtr()
+    if (underTy != null && underTy.asTypedefTypeOrNull() == null && underTy.isDependentType() &&
+        (underTy.isPointerType() || underTy.isReferenceType())
+    ) {
+        val spelling = underlying.getAsString()?.trim() ?: return UNRESOLVABLE
+        return WrappedType(spelling.removePrefix("const ").substringBefore('<').trim())
+    }
+    return buildWrappedType(underlying)
 }
 
 /**


### PR DESCRIPTION
D1a brick of the Phase D parity convergence (#46): characterize the initializer_list divergence family (full decomposition posted on #46) and land its cheapest sub-cause — the CONCRETE-element materialization.

Two surgical TypeBuilder rules:

1. **Concrete initializer_list decodes faithfully.** `DefaultArgs::sumIlist(std::initializer_list<int>)` is an ordinary specialization on the libclang path — the member survives and INCLUDE_MISSING materializes `std_Initializer_list__Int` — so a NON-DEPENDENT element now passes through the normal template decode. Dependent elements (`initializer_list<_CharT>` / `<value_type>` inside template member signatures) keep the documented deterministic UNRESOLVABLE drop (the D1b/D1c residue).

2. **Lossy-collapse mirror for dependent pointer/reference typedefs.** The materialized class's `begin()/end()` return `const_iterator` (`typedef const _E*`), which the libclang path collapses to a bare-NAME spelling leaf — never a substitutable tref — so they FAIL resolution and drop (live oracle log: `fun begin(): const _E* — Couldn't resolve return`). The cpp structural decode produced `pointerTo(const(tref(_E)))`, which would substitute and surface methods libclang never binds; the fall-through now mirrors visit()+createForType's spelling-leaf collapse for typedefs over dependent pointer/reference shapes (concrete underlyings keep the structural path; chained aliases keep the recursive follow).

Ratchet (diff-line bounds, parity-expectations.txt):

| unit | before | after |
|---|---|---|
| Box/Pair2/std::pair units | 336 | 287 |
| std::map units | 368 | 319 |
| std::set\<int\> | 414 | 365 |
| std::unique_ptr\<int\> | 533 | 484 |
| std::unordered_map / _set | 376 / 419 | 327 / 370 |
| std::vector units | 405-522 | 356-473 |
| ALL | 1375 | 1326 |

Every unit -49 diff lines (zero regressions); `std_Initializer_list__Int.kt` converged byte-identically out of every only-libclang file-set note.

Verified: full gate (krapper_gen nativeTest, krapper_model build, featuregen kplusplusSync zero-drift + nativeTest, ktlintCheck) + gated clang suite (cppfrontend self-checks, goldenCompare, handoffGenerate, handoffInstDiff, featuregenParity ratcheted, zero regressions).
