### PR TITLE
cppfrontend: D1b — name-tref dependent initializer_list overloads converge (basic_string + vector families) (#46)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -718,9 +718,19 @@ tasks.register("handoffInstDiff") {
         // wrapper COMPILED (writeTo's CppCompiler step already failed the generate
         // task otherwise). Spelling deltas are tracked on #45.
         val cpp = File(handoffInstDir, "out_cpp")
-        check(names == files(cpp)) {
+        // D1b (#46): the cpp model resolves std::initializer_list<Item*> DIRECTLY (its
+        // faithful in-model initializer_list class), so vector's surviving ilist
+        // ctor/op=/assign members materialize the specialization's binding on this
+        // path; the libclang model only reaches that class through INCLUDE_MISSING's
+        // re-parse — OFF on this default-policy flow — so its members drop. Production
+        // INCLUDE_MISSING proves the two CONVERGE byte-identically (featuregenParity:
+        // every std_Initializer_list__* file-set gap closed); this gate accepts the
+        // cpp-side faithfulness surplus, the same rationale as the spelling deltas.
+        val cppOnly = files(cpp) - names
+        val unexplained = cppOnly.filter { !it.startsWith("src/std_Initializer_list__") }
+        check((names - files(cpp)).isEmpty() && unexplained.isEmpty()) {
             "handoffInstDiff[functional]: file sets differ — only-libclang=" +
-                "${names - files(cpp)} only-cpp=${files(cpp) - names}"
+                "${names - files(cpp)} unexplained-only-cpp=$unexplained"
         }
         val bag = File(cpp, "src/root_Bag.kt").readText()
         check(bag.contains("fun items(): Vector__Item_P")) {

--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -5,9 +5,9 @@
 # than N diff lines; improvements are reported so this ledger ratchets toward
 # all-identical as Phase D converges.
 #
-# State after the D1a convergence brick. EVERY unit still generates + compiles end-to-end
+# State after the D1b convergence brick. EVERY unit still generates + compiles end-to-end
 # on --frontend=cpp (0 fail). Remaining divergence families (full breakdown on #46):
-#   D1 initializer_list materialization — decomposed + partially converged (D1a brick):
+#   D1 initializer_list materialization — decomposed, D1a+D1b converged:
 #      D1a CONVERGED: a CONCRETE element (DefaultArgs::sumIlist's initializer_list<int>)
 #          decodes faithfully, the member survives, and INCLUDE_MISSING materializes
 #          std_Initializer_list__Int byte-identically (-49 diff lines in EVERY unit).
@@ -15,20 +15,35 @@
 #          reference shape (`typedef const _E* const_iterator`) collapses to libclang's
 #          bare-NAME spelling leaf (never a substitutable tref), so the materialized
 #          class's begin()/end() drop exactly like the live oracle.
-#      D1b remaining: dependent-element member overloads whose libclang spelling is a
-#          NAME tref (basic_string's `std_initializer_list_template__CharT` ctor/op=/
-#          +=/append/assign, vector's `template__Tp` ctor/op=/assign, + the per-element
-#          std_Initializer_list__* materializations they imply) — the same name-tref
-#          convention this front-end uses, so mirrorable deterministically; now the
-#          dominant remaining share (~110/unit basic_string + ~50/vector unit).
+#      D1b CONVERGED: a dependent element that is a bare NAME-tref of an enclosing
+#          template param — written directly (basic_string's
+#          `std_initializer_list_template__CharT` ctor/op=/+=/append/assign) or through
+#          a plain typedef-to-param (vector's `template__Tp` ctor/op=/assign over
+#          `typedef _Tp value_type`) — decodes faithfully (TypeBuilder's
+#          isEnclosingParamIlistElement gate): the libclang survivor spells exactly this
+#          front-end's name-tref convention, so member sets + uniqueCNames converge and
+#          INCLUDE_MISSING materializes every per-element std_Initializer_list__* class
+#          byte-identically (Char/Wchar_t/Int/Double/Point/Thing_P/Vector_int_/
+#          Basic_string_char_ — the only-libclang file-set gap is GONE in all 18 units;
+#          -204 to -318 diff lines per unit, ALL 1326 -> 697). The discrimination is
+#          exact: an ASSOC-REDUCED alias (assocTypedef — set/unordered_set's key-only
+#          value_type) and non-tref dependent shapes (map's pair value_type,
+#          unordered_map's _Hashtable typename) stay UNRESOLVABLE, since their libclang
+#          counterparts are USR-keyed (D1c) or drop at resolution anyway. Fixture pins:
+#          MiniStr's two surviving shapes (param deliberately named T — the libclang
+#          typedef-to-param collapse spells the FIRST-SEEN param-0 name from the
+#          seenNames cache, the N5-family order-dependence; libstdc++'s uniform _Tp
+#          naming keeps production convergent, and these ratchet numbers pin it).
 #      D1c remaining: set/unordered_set's surviving overloads spell the element by the
 #          param's USR (`template_c_stl_set_h_3743` = c:stl_set.h@3743 — a header BYTE
 #          OFFSET): libclang's assocTypedefElement keys its reconstructed value_type
 #          tref by param USR where this front-end deliberately keys by NAME. Mirroring
 #          means synthesizing file@offset USRs into symbol names (decision brick).
+#          Post-D1b these are the ONLY initializer_list diff lines left (set 161,
+#          unordered_set 166, + their ALL share).
 #      D1d downstream: the disambiguation-suffix renames on UNRELATED members
 #          (set::insert(const value_type&) -> `__const_template_c_stl_set_h_3743_and`)
-#          have no independent fix — they collapse into D1b+D1c.
+#          have no independent fix — they collapse into D1c.
 #   D2 RESOLVED for the incidental-surface half (D2a): ModelBuilder now traverses
 #      LinkageSpecDecl with libclang's attach semantics, so the extern "C++"-wrapped
 #      std functions (std::abs/wcschr/wcspbrk/wcsrchr/wcsstr/wmemchr/get_new_handler/
@@ -75,21 +90,21 @@
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
-Box<Box<int>>=diff:287
-Box<Point>=diff:287
-Box<int>=diff:287
-Pair2<int, double>=diff:287
-std::map<int, double>=diff:319
-std::map<int, int>=diff:319
-std::pair<int, int>=diff:287
-std::set<int>=diff:365
-std::unique_ptr<int>=diff:484
-std::unordered_map<int, int>=diff:327
-std::unordered_set<int>=diff:370
-std::vector<Point>=diff:433
-std::vector<Thing*>=diff:356
-std::vector<double>=diff:433
-std::vector<int>=diff:396
-std::vector<std::__cxx11::basic_string<char>>=diff:401
-std::vector<std::vector<int>>=diff:473
-ALL=diff:1326
+Box<Box<int>>=diff:83
+Box<Point>=diff:83
+Box<int>=diff:83
+Pair2<int, double>=diff:83
+std::map<int, double>=diff:115
+std::map<int, int>=diff:115
+std::pair<int, int>=diff:83
+std::set<int>=diff:161
+std::unique_ptr<int>=diff:280
+std::unordered_map<int, int>=diff:123
+std::unordered_set<int>=diff:166
+std::vector<Point>=diff:115
+std::vector<Thing*>=diff:115
+std::vector<double>=diff:115
+std::vector<int>=diff:115
+std::vector<std::__cxx11::basic_string<char>>=diff:83
+std::vector<std::vector<int>>=diff:115
+ALL=diff:697

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -82,6 +82,10 @@ import platform.posix.popen
 // scopes — unordered_map's and set's shapes, assocTypedefElement), and DefBox/DefPair
 // (defaulted template params — the cursor-walk residue WrappedTemplateParam.defaultType
 // reads; expected shapes pinned against the libclang oracle for this exact fixture).
+// D1b (#46) grows it with MiniStr + an in-fixture std::initializer_list declaration: the
+// two name-tref dependent initializer_list element shapes (direct param — basic_string's
+// family; typedef-to-param — vector's) whose members must SURVIVE with the libclang
+// survivor's exact name-tref spelling.
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -234,6 +238,20 @@ private val FIXTURE_HEADER = """
 
     template <typename T, typename U = T>
     struct DefPair {};
+
+    namespace std {
+        template <typename E> class initializer_list {
+            const E* items;
+            unsigned long len;
+        };
+    }
+
+    template <typename C>
+    struct MiniStr {
+        typedef C value_type;
+        void append(std::initializer_list<C> l);
+        void assignAll(std::initializer_list<value_type> l);
+    };
 """.trimIndent()
 
 // #45 brick 3: the INSTANTIATION-FORCING fixture — a SIBLING of FIXTURE_HEADER (extending
@@ -645,10 +663,11 @@ fun main(args: Array<String>): Unit = memScoped {
     val holders = tu.children.filterIsInstance<WrappedTemplate>()
     val holder = holders.find { it.name == "Holder" }
     check(
-        "TU contains the 12 WrappedTemplates in source order (Holder + the Phase D shapes)",
+        "TU contains the 13 WrappedTemplates in source order (Holder + the Phase D shapes)",
         holders.map { it.name } == listOf(
             "Holder", "PtrTrait", "SmartPtr", "MapTraits", "MiniMap",
-            "SetTraits", "MiniSet", "HashTraits", "MiniHash", "DefAlloc", "DefBox", "DefPair"
+            "SetTraits", "MiniSet", "HashTraits", "MiniHash", "DefAlloc", "DefBox",
+            "DefPair", "MiniStr"
         ),
         "got ${holders.map { it.name }}"
     )
@@ -1052,6 +1071,30 @@ fun main(args: Array<String>): Unit = memScoped {
             ?.toString() == "template<T><template<T>>",
         "got ${holders.find { it.name == "DefPair" }?.templateArgs
             ?.map { "${it.name}=${it.defaultType}" }}"
+    )
+    // D1b (#46): a dependent initializer_list element that is a bare ref to an enclosing
+    // template param — written DIRECTLY (basic_string's ctor/op=/op+=/append/assign shape)
+    // or through a plain TYPEDEF-TO-PARAM (vector's `typedef _Tp value_type` shape) —
+    // decodes faithfully as the NAME-tref the libclang survivor spells
+    // (`std::initializer_list<template<_CharT>>` in the live oracle's --dumpParsedModel),
+    // so the member survives with a converging uniqueCName. The negative half of the
+    // discrimination (assoc-reduced D1c elements + non-tref dependent shapes stay
+    // UNRESOLVABLE) is pinned by the parity ratchet: set/unordered_set's libclang
+    // survivors are USR-keyed, so any cpp-side leak-through grows their unit diffs.
+    val miniStr = holders.find { it.name == "MiniStr" }
+    check(
+        "MiniStr::append(initializer_list<C>): the DIRECT dependent element survives " +
+            "as the name-tref shape (D1b)",
+        miniStr?.methods?.find { it.name == "append" }?.args?.singleOrNull()
+            ?.type?.toString() == "std::initializer_list<template<C>>",
+        "got ${miniStr?.methods?.find { it.name == "append" }?.args}"
+    )
+    check(
+        "MiniStr::assignAll(initializer_list<value_type>): the typedef-to-param element " +
+            "survives as the same name-tref shape (D1b)",
+        miniStr?.methods?.find { it.name == "assignAll" }?.args?.singleOrNull()
+            ?.type?.toString() == "std::initializer_list<template<C>>",
+        "got ${miniStr?.methods?.find { it.name == "assignAll" }?.args}"
     )
 
     check("JSON is non-empty", json.length > 2)

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -247,17 +247,23 @@ private val FIXTURE_HEADER = """
 
     // Guarded with libstdc++'s own include guard: the generated wrapper #includes this
     // fixture BEFORE its <vector>/<string> boilerplate (handoffGenerate's compile step),
-    // so defining _INITIALIZER_LIST here makes the real header a no-op there — layout-
-    // compatible (pointer + length), and nothing on that path INSTANTIATES an
-    // initializer_list member (MiniStr is a never-instantiated template, so the stl
-    // headers' ilist-taking declarations are never bodied). Standalone parses (BOTH
-    // front-ends, the same bytes) see this declaration — the macro is never defined there.
+    // so defining _INITIALIZER_LIST here makes the real header a no-op there. The class
+    // must then be REAL-equivalent enough for the stl headers compiled after it:
+    // layout-compatible (pointer + length) and carrying begin()/end()/size(), which
+    // vector<bool>'s inline bodies call on the CONCRETE initializer_list<bool> (checked
+    // at parse, no instantiation needed). The param is named T for the same seenNames
+    // reason as MiniStr's. Standalone parses (BOTH front-ends, the same bytes) see this
+    // declaration — the macro is never defined there.
     #ifndef _INITIALIZER_LIST
     #define _INITIALIZER_LIST
     namespace std {
-        template <typename E> class initializer_list {
-            const E* items;
+        template <typename T> class initializer_list {
+            const T* items;
             unsigned long len;
+        public:
+            constexpr unsigned long size() const noexcept { return len; }
+            constexpr const T* begin() const noexcept { return items; }
+            constexpr const T* end() const noexcept { return items + len; }
         };
     }
     #endif

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -245,12 +245,22 @@ private val FIXTURE_HEADER = """
     template <typename T, typename U = T>
     struct DefPair {};
 
+    // Guarded with libstdc++'s own include guard: the generated wrapper #includes this
+    // fixture BEFORE its <vector>/<string> boilerplate (handoffGenerate's compile step),
+    // so defining _INITIALIZER_LIST here makes the real header a no-op there — layout-
+    // compatible (pointer + length), and nothing on that path INSTANTIATES an
+    // initializer_list member (MiniStr is a never-instantiated template, so the stl
+    // headers' ilist-taking declarations are never bodied). Standalone parses (BOTH
+    // front-ends, the same bytes) see this declaration — the macro is never defined there.
+    #ifndef _INITIALIZER_LIST
+    #define _INITIALIZER_LIST
     namespace std {
         template <typename E> class initializer_list {
             const E* items;
             unsigned long len;
         };
     }
+    #endif
 
     template <typename T>
     struct MiniStr {

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -85,7 +85,13 @@ import platform.posix.popen
 // D1b (#46) grows it with MiniStr + an in-fixture std::initializer_list declaration: the
 // two name-tref dependent initializer_list element shapes (direct param — basic_string's
 // family; typedef-to-param — vector's) whose members must SURVIVE with the libclang
-// survivor's exact name-tref spelling.
+// survivor's exact name-tref spelling. MiniStr's param is deliberately named T: the
+// libclang typedef-to-param collapse spells the FIRST-SEEN param-0 name from visit()'s
+// seenNames cache (here Holder's "T"; probed — a "C"-named param diverged as
+// cpp=template<C> vs libclang=template<T>), the same N5-family order-dependence D3
+// ledger-accepts. libstdc++'s uniform `_Tp`-style naming keeps production on the
+// convergent path (vector's survivors spell `template__Tp` on both sides — the parity
+// ratchet pins the actuals); naming the fixture param T pins that same path.
 private val FIXTURE_HEADER = """
     void freeFunction(int);
 
@@ -246,10 +252,10 @@ private val FIXTURE_HEADER = """
         };
     }
 
-    template <typename C>
+    template <typename T>
     struct MiniStr {
-        typedef C value_type;
-        void append(std::initializer_list<C> l);
+        typedef T value_type;
+        void append(std::initializer_list<T> l);
         void assignAll(std::initializer_list<value_type> l);
     };
 """.trimIndent()
@@ -746,8 +752,8 @@ fun main(args: Array<String>): Unit = memScoped {
     // WrappedEnumType (TypeFactories' CXCursor_EnumDecl branch). Underlyings + values are
     // pinned against the libclang oracle for this fixture.
     check(
-        "TU has exactly 24 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
-        tu.children.size == 24,
+        "TU has exactly 26 children (the 3 enum DECLs + 2 `using` aliases contribute NONE)",
+        tu.children.size == 26,
         "got ${tu.children.size}"
     )
     val palette = tu.children.filterIsInstance<WrappedClass>().find { it.name == "Palette" }
@@ -1083,17 +1089,17 @@ fun main(args: Array<String>): Unit = memScoped {
     // survivors are USR-keyed, so any cpp-side leak-through grows their unit diffs.
     val miniStr = holders.find { it.name == "MiniStr" }
     check(
-        "MiniStr::append(initializer_list<C>): the DIRECT dependent element survives " +
+        "MiniStr::append(initializer_list<T>): the DIRECT dependent element survives " +
             "as the name-tref shape (D1b)",
         miniStr?.methods?.find { it.name == "append" }?.args?.singleOrNull()
-            ?.type?.toString() == "std::initializer_list<template<C>>",
+            ?.type?.toString() == "std::initializer_list<template<T>>",
         "got ${miniStr?.methods?.find { it.name == "append" }?.args}"
     )
     check(
         "MiniStr::assignAll(initializer_list<value_type>): the typedef-to-param element " +
             "survives as the same name-tref shape (D1b)",
         miniStr?.methods?.find { it.name == "assignAll" }?.args?.singleOrNull()
-            ?.type?.toString() == "std::initializer_list<template<C>>",
+            ?.type?.toString() == "std::initializer_list<template<T>>",
         "got ${miniStr?.methods?.find { it.name == "assignAll" }?.args}"
     )
 

--- a/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/TypeBuilder.kt
@@ -158,19 +158,35 @@ fun buildWrappedType(type: QualType): WrappedType {
     if (templateArgCount > 0) {
         val baseName = with(type.memScope) { templateBaseName(type) }
             ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
-        // std::initializer_list (D1a, #46): a CONCRETE use (`initializer_list<int>` —
-        // featuregen's DefaultArgs::sumIlist) is an ordinary template specialization on
-        // the libclang path — the member survives and INCLUDE_MISSING materializes the
-        // std_Initializer_list__Int binding — so it decodes faithfully here too. A
-        // DEPENDENT element (`initializer_list<_CharT>` / `<value_type>` inside a
-        // template's own member signatures) stays UNRESOLVABLE by construction: those
-        // members survive on libclang only through its order-dependent visit() collapse
-        // (name-tref on basic_string/vector, USR-tref on set/unordered_set — the
-        // D1b/D1c residue in parity-expectations.txt), and this front-end's documented
-        // deterministic rule drops them instead of emulating the cache.
+        // std::initializer_list (D1a/D1b, #46): a CONCRETE use (`initializer_list<int>`
+        // — featuregen's DefaultArgs::sumIlist) is an ordinary template specialization
+        // on the libclang path — the member survives and INCLUDE_MISSING materializes
+        // the std_Initializer_list__Int binding — so it decodes faithfully here too.
+        // D1b: a DEPENDENT element that is a bare reference to one of the ENCLOSING
+        // template's own params — written directly (`initializer_list<_CharT>`,
+        // basic_string's ctor/op=/op+=/append/assign) or through a plain
+        // typedef-to-param (`initializer_list<value_type>` over vector's
+        // `typedef _Tp value_type`) — ALSO decodes faithfully: libclang's survivor
+        // spells exactly the NAME tref this front-end's in-template convention
+        // produces (`std::initializer_list<template<_CharT>>`, proven by the live
+        // oracle's --dumpParsedModel), so the member sets + uniqueCNames converge
+        // deterministically (the args fall through to the normal decode below). Every
+        // OTHER dependent element stays UNRESOLVABLE by construction:
+        //  - an ASSOC-REDUCED member alias (set/unordered_set's key-only `value_type`,
+        //    [assocTypedef]) is keyed by the param's USR on the libclang side
+        //    (`template_c_stl_set_h_3743` — assocTypedefElement), a spelling this
+        //    front-end deliberately does not synthesize (the D1c decision brick in
+        //    parity-expectations.txt);
+        //  - non-tref dependent shapes (map's `value_type` = `pair<const _Key, _Tp>`,
+        //    unordered_map's `typename _Hashtable::value_type`) drop here where
+        //    libclang drops them at resolution / the shared
+        //    dropMistypedInitializerListMembers pass — same final output either way.
         if (baseName == "std::initializer_list") {
             val element = with(type.memScope) { templateArgAsType(type, 0u) }
-            if (element.typePtr()?.isDependentType() != false) return UNRESOLVABLE
+            val elementTy = element.typePtr() ?: return UNRESOLVABLE
+            if (elementTy.isDependentType() && !isEnclosingParamIlistElement(elementTy)) {
+                return UNRESOLVABLE
+            }
         }
         val args = (0u until templateArgCount.toUInt()).map { i ->
             val arg = with(type.memScope) { templateArgAsType(type, i) }
@@ -277,6 +293,23 @@ fun buildWrappedType(type: QualType): WrappedType {
     // uniqueCNames and broke the wrapper compile (#46 Phase D finding).
     if (spelling.contains("type-parameter-")) return UNRESOLVABLE
     return WrappedTypeReference(spelling).maybeConst(isConst)
+}
+
+// D1b's discrimination (#46): a dependent initializer_list ELEMENT qualifies for the
+// faithful decode only when it is a bare NAME-tref of an enclosing template param —
+// the family whose libclang survivor spelling matches this front-end's own name-keying:
+//  - the param written directly (TemplateTypeParmType — basic_string's `_CharT`);
+//  - a typedef that the assoc reducer does NOT claim and whose reduction collapses to a
+//    bare tref (vector's `typedef _Tp value_type` — libclang's visit() lands on the same
+//    name via the Unexposed-param fallback). The [assocTypedef] exclusion is the exact
+//    D1b/D1c fault line: an assoc-reduced alias reduces to a name-tref HERE but to a
+//    USR-keyed tref on the libclang side (assocTypedefElement), so its survivor
+//    uniqueCNames can never converge without USR synthesis — it keeps dropping.
+private fun isEnclosingParamIlistElement(elementTy: Type): Boolean {
+    if (elementTy.asTemplateTypeParmType() != null) return true
+    val typedef = elementTy.asTypedefTypeOrNull()?.getDecl() ?: return false
+    if (assocTypedef(typedef) != null) return false
+    return buildTypedefTargetType(typedef) is WrappedTemplateRef
 }
 
 /**


### PR DESCRIPTION
Phase D brick D1b of #46 — the name-tref dependent `initializer_list` overload family, the dominant remaining parity share per the D1a decomposition. Scope is exactly this family; D1c (USR-tref — set/unordered_set) is untouched and remains the separate decision brick.

## Mechanics confirmed (live oracle)
`--dumpParsedModel` on the libclang front-end shows every surviving dependent-element overload spells the element as a **name-keyed tref**: basic_string's ctor/`operator=`/`operator+=`/`append`/`assign` carry `std::initializer_list<template<_CharT>>` (the param written directly), vector's ctor/`operator=`/`assign` carry `template<_Tp>` (visit() collapsing `typedef _Tp value_type` to the param name). That is byte-for-byte the cpp front-end's own in-template name-keying convention (PR #63's param-NAME decision), so the family is mirrorable deterministically.

## The rule (TypeBuilder)
A dependent `initializer_list<T>` element now decodes faithfully **iff it is a bare name-tref of an enclosing template param** (`isEnclosingParamIlistElement`):
- the param written directly (`TemplateTypeParmType` — basic_string's shape), or
- a plain typedef-to-param: a typedef the **assoc reducer does NOT claim** whose reduction collapses to a bare `WrappedTemplateRef` (vector's `typedef _Tp value_type`).

Discrimination is exact:
- **concrete** elements keep the D1a faithful decode;
- **assoc-reduced** aliases (set/unordered_set's key-only `value_type`) stay UNRESOLVABLE — their libclang survivors are USR-keyed (`template_c_stl_set_h_3743`), the D1b/D1c fault line;
- **non-tref dependent** shapes (map's `pair<const _Key, _Tp>` value_type, unordered_map's `typename _Hashtable::value_type`) stay UNRESOLVABLE — libclang drops those at resolution / via the shared `dropMistypedInitializerListMembers` pass (verified unchanged, resolution-side, both paths), so final output is identical either way.

## Ratchet (featuregenParity, 0 regressions, 0 fail)
The only-libclang `std_Initializer_list__*.kt` file-set gap is **gone in all 18 units** (Char/Wchar_t/Int/Double/Point/Thing_P/Vector_int_/Basic_string_char_ all materialize byte-identically via INCLUDE_MISSING on the cpp side too):

| unit | before | after |
|---|---|---|
| Box(x3) / Pair2 / std::pair / vector\<string\> | 287 / 401 | **83** |
| map(x2) / vector\<int,double,Point,Thing*,vector\<int\>\> | 319–473 | **115** |
| unordered_map | 327 | **123** |
| set | 365 | **161** (residue = pure D1c) |
| unordered_set | 370 | **166** (residue = pure D1c) |
| unique_ptr | 484 | **280** |
| **ALL** | **1326** | **697** (−47%) |

Post-D1b, set/unordered_set's USR-tref lines are the ONLY initializer_list diff lines left (the D1c decision brick); everything else is the ledger-accepted D2b/D4 residue.

## Pins
- Fixture: `MiniStr` + a guarded in-fixture `std::initializer_list` pin both surviving shapes through self-checks + goldenCompare (param deliberately named `T` — the libclang typedef-to-param collapse spells the FIRST-SEEN param-0 name from the seenNames cache, probed: a `C`-named param diverged; libstdc++'s uniform `_Tp` naming keeps production convergent and the ratchet pins the actuals). The declaration carries libstdc++'s `_INITIALIZER_LIST` guard + `begin()/end()/size()` so handoffGenerate's wrapper compile (fixture before the `<vector>` boilerplate; vector<bool> checks its concrete ilist bodies at parse) stays green.
- handoffInstDiff gate 2 (functional): documented acceptance of the cpp-side materialization surplus — the faithful cpp model resolves `std::initializer_list<Item*>` directly where libclang needs INCLUDE_MISSING (off on that default-policy flow); production INCLUDE_MISSING proves byte-convergence. Gate 1 (oracle) stays byte-identical (9 files).
- Negative-half pin: any cpp leak-through of the D1c family grows set/unordered_set's ratcheted diffs.

## Verify
Full gate green: krapper_gen nativeTest 313/0, featuregen kplusplusSync zero krapped/ drift, featuregen nativeTest 188/0, krapper_model build, ktlintCheck. Gated green: self-checks (all PASS incl. the 2 new D1b pins), goldenCompare PASS, handoffGenerate (wrapper compiles), handoffInstDiff (oracle byte-identical + functional), featuregenParity 18/18 as-expected against the ratcheted ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
