### PR TITLE
cppfrontend+krapper_gen: D1c USR-tref ledger-accept + O1 forcing-order convergence — Phase D endpoint (#46)

### DIFF
--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -99,8 +99,8 @@
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
-#   O1 forcing-round std-function ORDER (identified by the D1c endpoint sweep — the
-#      last family, the ONLY one that was uncited): in each instantiation ROUND's
+#   O1 forcing-round std-function ORDER — CONVERGED (D1c brick, 79474d0): the last
+#      family the endpoint sweep found, and the ONLY one that had been uncited. In each round's
 #      emitted "std Functions" block, the cpp path places set/get_new_handler before
 #      the wcs* group while libclang keeps base order. Mechanism: ForcingHeader
 #      prepends the target's std includes (e.g. `#include <vector>`) BEFORE the user
@@ -111,25 +111,26 @@
 #      order wins), while the cpp path's per-payload forcing model keeps the forcing
 #      TU's own lexical order. Spec-dependent on the cpp side today (<vector>/<set>/
 #      <map>/<memory> prepends flip it; <string>-first and non-std specs don't), so
-#      libclang's first-seen order is the SPEC-INVARIANT member of the family — this
-#      is a convergence target (mirror the memo's first-seen ordering when loading a
-#      forcing model), NOT an accept. 32 lines in each flipped unit (vector x5,
-#      map x2, set, unordered_set, unordered_map, unique_ptr), 352 in ALL.
+#      libclang's first-seen order is the SPEC-INVARIANT member of the family, so the
+#      fix mirrors the memo: loadForcingModel (Parsing.kt) reorders a forcing model's
+#      namespace-level children into the base model's first-seen order (unseen children
+#      append in TU order). -32 lines in each flipped unit (vector x5, map x2, set,
+#      unordered_set, unordered_map, unique_ptr), -352 in ALL (697 -> 345).
 Box<Box<int>>=diff:83
 Box<Point>=diff:83
 Box<int>=diff:83
 Pair2<int, double>=diff:83
-std::map<int, double>=diff:115
-std::map<int, int>=diff:115
+std::map<int, double>=diff:83
+std::map<int, int>=diff:83
 std::pair<int, int>=diff:83
-std::set<int>=diff:161
-std::unique_ptr<int>=diff:280
-std::unordered_map<int, int>=diff:123
-std::unordered_set<int>=diff:166
-std::vector<Point>=diff:115
-std::vector<Thing*>=diff:115
-std::vector<double>=diff:115
-std::vector<int>=diff:115
+std::set<int>=diff:129
+std::unique_ptr<int>=diff:248
+std::unordered_map<int, int>=diff:91
+std::unordered_set<int>=diff:134
+std::vector<Point>=diff:83
+std::vector<Thing*>=diff:83
+std::vector<double>=diff:83
+std::vector<int>=diff:83
 std::vector<std::__cxx11::basic_string<char>>=diff:83
-std::vector<std::vector<int>>=diff:115
-ALL=diff:697
+std::vector<std::vector<int>>=diff:83
+ALL=diff:345

--- a/cppfrontend/parity-expectations.txt
+++ b/cppfrontend/parity-expectations.txt
@@ -34,16 +34,25 @@
 #          typedef-to-param collapse spells the FIRST-SEEN param-0 name from the
 #          seenNames cache, the N5-family order-dependence; libstdc++'s uniform _Tp
 #          naming keeps production convergent, and these ratchet numbers pin it).
-#      D1c remaining: set/unordered_set's surviving overloads spell the element by the
-#          param's USR (`template_c_stl_set_h_3743` = c:stl_set.h@3743 — a header BYTE
-#          OFFSET): libclang's assocTypedefElement keys its reconstructed value_type
-#          tref by param USR where this front-end deliberately keys by NAME. Mirroring
-#          means synthesizing file@offset USRs into symbol names (decision brick).
-#          Post-D1b these are the ONLY initializer_list diff lines left (set 161,
-#          unordered_set 166, + their ALL share).
-#      D1d downstream: the disambiguation-suffix renames on UNRELATED members
-#          (set::insert(const value_type&) -> `__const_template_c_stl_set_h_3743_and`)
-#          have no independent fix — they collapse into D1c.
+#      D1c LEDGER-ACCEPTED (D1c brick, #46): set/unordered_set's surviving overloads
+#          spell the element by the param's USR — libclang's assocTypedefElement keys
+#          the reconstructed value_type tref by WrappedTemplateRef(param.usr), and for
+#          these params clang_getCursorUSR falls back to USRGeneration's printLoc form
+#          `c:<header basename>@<byte offset>`. Exemplars VERIFIED against the dumps and
+#          the installed libstdc++ (gcc 16.1.1): `template_c_stl_set_h_3743` = byte 3743
+#          of bits/stl_set.h = the `_Key` param of `template<typename _Key, ...> class
+#          set`; `template_c_unordered_set_h_3824` = byte 3824 of bits/unordered_set.h =
+#          unordered_set's `_Value` param. Mirroring is REJECTED: (a) not cheap — the
+#          cpp front-end keys identity on Decl::getID() and its binding surface has NO
+#          SourceLocation/SourceManager family at all; mirroring needs that whole new
+#          surface PLUS a byte-exact reimplementation of USRGeneration's printLoc
+#          fallback (when it fires and how it prints); (b) maximally version-fragile —
+#          the offsets are libstdc++ header BYTES, so any upstream edit above the
+#          template (a comment, whitespace) renames every generated symbol; Phase E
+#          makes cpp the stable reference, and a name-keyed tref is exactly the spelling
+#          the reference should keep. 46 lines in set, 43 in unordered_set (+ the same
+#          in ALL). D1d (the `__const_template_c_stl_set_h_3743_and` disambiguation
+#          renames on UNRELATED members) collapses into this accept.
 #   D2 RESOLVED for the incidental-surface half (D2a): ModelBuilder now traverses
 #      LinkageSpecDecl with libclang's attach semantics, so the extern "C++"-wrapped
 #      std functions (std::abs/wcschr/wcspbrk/wcsrchr/wcsstr/wmemchr/get_new_handler/
@@ -90,6 +99,22 @@
 #   D4 out-of-line virtual destructor: the libclang cursor walk REPARENTS
 #      Drawable's dtor to the TU and loses it ("Can't find parent type"); the cpp
 #      path keeps it and emits dispose()/owned() (correct-by-construction).
+#   O1 forcing-round std-function ORDER (identified by the D1c endpoint sweep — the
+#      last family, the ONLY one that was uncited): in each instantiation ROUND's
+#      emitted "std Functions" block, the cpp path places set/get_new_handler before
+#      the wcs* group while libclang keeps base order. Mechanism: ForcingHeader
+#      prepends the target's std includes (e.g. `#include <vector>`) BEFORE the user
+#      header, so in the forcing TU <new> materializes lexically before <cwchar> —
+#      BOTH front-ends parse that same flipped TU, but libclang's session-scoped USR
+#      memo (elementLookup, one Index across base + forcing parses) collapses the std
+#      namespace onto the element ALREADY populated by the base parse (first-seen
+#      order wins), while the cpp path's per-payload forcing model keeps the forcing
+#      TU's own lexical order. Spec-dependent on the cpp side today (<vector>/<set>/
+#      <map>/<memory> prepends flip it; <string>-first and non-std specs don't), so
+#      libclang's first-seen order is the SPEC-INVARIANT member of the family — this
+#      is a convergence target (mirror the memo's first-seen ordering when loading a
+#      forcing model), NOT an accept. 32 lines in each flipped unit (vector x5,
+#      map x2, set, unordered_set, unordered_map, unique_ptr), 352 in ALL.
 Box<Box<int>>=diff:83
 Box<Point>=diff:83
 Box<int>=diff:83

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -186,7 +186,7 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         // SAME code on both paths.
         val resolver = cppForcingModelPaths[target]?.let { path ->
             Log.i("cpp front-end forcing handoff: loading $target model from $path")
-            loadParsedModel(path)
+            loadForcingModel(path)
         } ?: run {
             // Parse from a per-run temp file (cleaned in close()); the same header is
             // re-materialized into the output dir by writeTo for the generated wrapper.

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -182,6 +182,65 @@ internal suspend fun loadParsedModel(path: String): ParsedResolver {
     return ParsedResolver(restored)
 }
 
+// The base-model tree loaded by [parseHeader]'s --parsedModel hook, kept so each
+// forcing-model load can mirror libclang's first-seen ordering against it (O1, #46).
+internal var cppBaseModelTu: WrappedTU? = null
+
+/**
+ * Load a FORCING model (#46 O1): [loadParsedModel], then reorder its namespace-level
+ * children into the BASE model's first-seen order. On the libclang path the base parse
+ * and every forcing re-parse share one Index, so ModelFactories' USR-keyed elementLookup
+ * memo collapses each namespace onto the element the base parse already populated —
+ * re-encountered decls keep their base position and only NEW decls append. The forcing
+ * TU's own lexical order DIFFERS from the base TU's whenever ForcingHeader prepends a
+ * std include (e.g. `#include <vector>` pulls <new> in front of the user header's
+ * <cwchar>), so a per-payload tree loaded as-is would emit that round's std functions
+ * in a SPEC-DEPENDENT order. First-seen base order is the spec-invariant choice.
+ */
+internal suspend fun loadForcingModel(path: String): ParsedResolver {
+    val resolver = loadParsedModel(path)
+    cppBaseModelTu?.let { base -> reorderToFirstSeen(resolver.tu, base) }
+    return resolver
+}
+
+// The structural identity used ONLY for the first-seen ordering above — the same
+// name/signature granularity the forcing flow's string-keyed merge consults
+// (alreadyBoundKeys / forcingIdentity / last-wins dedup).
+private fun WrappedElement.firstSeenKey(): String? = when (this) {
+    is WrappedNamespace -> "n:$namespace"
+    is WrappedTemplate -> "T:$name"
+    is WrappedClass -> "c:$name"
+    is WrappedTypedef -> "t:$name"
+    is WrappedMethod -> "m:$name(${args.joinToString(",") { it.type.toString() }})"
+    else -> null
+}
+
+// Stable-sort [forcing]'s children by their first occurrence in [base]'s children
+// (children with no base counterpart — the KrapperForce_* struct, new decls — keep
+// their own relative order AFTER every base-seen child, exactly where the libclang
+// memo would APPEND them), then recurse into namespaces. Class members are untouched:
+// they attach from the defining redeclaration on both paths.
+private fun reorderToFirstSeen(forcing: WrappedElement, base: WrappedElement) {
+    val baseOrder = mutableMapOf<String, Int>()
+    val baseByKey = mutableMapOf<String, WrappedElement>()
+    base.children.forEachIndexed { index, child ->
+        val key = child.firstSeenKey() ?: return@forEachIndexed
+        if (key !in baseOrder) {
+            baseOrder[key] = index
+            baseByKey[key] = child
+        }
+    }
+    val reordered = forcing.children
+        .sortedBy { baseOrder[it.firstSeenKey()] ?: Int.MAX_VALUE }
+    forcing.clearChildren()
+    forcing.addAllChildren(reordered)
+    for (child in reordered) {
+        if (child !is WrappedNamespace) continue
+        (baseByKey[child.firstSeenKey()] as? WrappedNamespace)
+            ?.let { reorderToFirstSeen(child, it) }
+    }
+}
+
 fun FilterDefinition.wrapperFilter(): (WrappedElement) -> Boolean {
     return when (this) {
         is AndFilter -> {
@@ -620,7 +679,8 @@ suspend fun DeferScope.parseHeader(
     // run on the loaded tree exactly as they do on a --roundTripModel restored tree.
     cppParsedModelPath?.let { path ->
         Log.i("cpp front-end handoff: loading parsed model from $path (libclang parse skipped)")
-        return loadParsedModel(path)
+        // Stashed for the forcing loads' first-seen reorder (O1, #46 — loadForcingModel).
+        return loadParsedModel(path).also { cppBaseModelTu = it.tu }
     }
     val builder = ResolverBuilderImpl()
     val tu = file.map {


### PR DESCRIPTION
Phase D's final convergence brick + the endpoint assessment. After this, every remaining parity diff line is a CITED, justified divergence where the cpp front-end is equal-or-more-correct than libclang.

## D1c — USR-tref overloads: LEDGER-ACCEPTED (with verified offsets)
set/unordered_set's surviving overloads spell the element by the param's **USR**. libclang's `assocTypedefElement` keys the reconstructed `value_type` tref by `WrappedTemplateRef(param.usr)`, and for these params `clang_getCursorUSR` falls back to USRGeneration's printLoc form `c:<header basename>@<byte offset>`. Exemplars VERIFIED against the dumps + the installed libstdc++ (gcc 16.1.1):
- `template_c_stl_set_h_3743` = byte 3743 of `bits/stl_set.h` = the `_Key` param of `set`
- `template_c_unordered_set_h_3824` = byte 3824 of `bits/unordered_set.h` = unordered_set's `_Value`

**Mirroring REJECTED:** (a) not cheap — the cpp front-end keys identity on `Decl::getID()` and has NO SourceLocation/SourceManager binding surface; mirroring needs that whole surface PLUS a byte-exact reimplementation of USRGeneration's printLoc fallback; (b) maximally version-fragile — the offsets are header BYTES, so any upstream edit above the template renames every generated symbol. Phase E makes cpp the stable reference, and a name-keyed tref (`template<_Key>`) is exactly the spelling the reference should keep. D1d (the `__const_template_..._and` disambiguation renames) collapses into this accept.

## O1 — forcing-round std-function ORDER: CONVERGED (the last uncited family)
The endpoint sweep found one uncited family. `ForcingHeader` prepends the target's std includes before the user header, so in a container-spec forcing TU `<new>` materializes lexically before `<cwchar>`. libclang's session-scoped USR memo (one Index across base + forcing parses) collapses the std namespace onto the base parse's first-seen order; the cpp per-payload forcing model kept the forcing TU's own order. **Fix:** `loadForcingModel` (Parsing.kt) reorders a forcing model's namespace-level children into the base model's first-seen order (unseen children append in TU order), mirroring the memo. This is a **cpp-forcing-load-path-only** seam — the libclang path is untouched (proven by zero featuregen drift).

## Ratchet — ALL 697 → 345 (−50%)
Every flipped unit −32 (O1). Final per-unit bounds: the vector/map/pair/Box family at **83**, set **129**, unordered_set **134**, unordered_map **91**, unique_ptr **248**, **ALL 345**. featuregenParity reports all 18 units **[as expected]** (0 improved / 0 regression / 0 fail).

## Phase D endpoint — every remaining line is cited
The endpoint sweep bucketed ALL remaining diff lines; **zero uncited residue**. The full ledger families (prose in `parity-expectations.txt`):
- **D2b** (libclang spelling-defect drops where cpp resolves correctly: `__locale_struct` every unit ~40 lines; `std::__exception_ptr` in unique_ptr/ALL) — ledger-accept, cpp more correct
- **D3** ledger-accept (parse-context-dependent libclang spellings, N5) + D1c
- **D4** (libclang reparents+loses Drawable's out-of-line virtual dtor; cpp keeps it) — ledger-accept, cpp more correct
The recurring theme: every "divergence" is either converged or a libclang defect we get to DELETE at the flip, not emulate.

## Verify (JDK 17)
- Full gate green: `:krapper_gen:nativeTest` 313/0, `:krapper_model:build`, `:featuregen:kplusplusSync` **zero krapped/ drift** (default-path purity — the Parsing.kt change is cpp-forcing-load only), `:featuregen:nativeTest` 188/0, `:krapper_gen:ktlintCheck`.
- Gated (`-PenableClang`): `goldenCompare`, `handoffGenerate`, `handoffInstDiff` (oracle byte-identical 9 files + functional), `featuregenParity` 18/18 [as expected], ALL=345.

Closes the Phase D convergence work; the parity oracle is satisfied for the flip decision (Phase E #47).