### PR TITLE
krapper_gen: hermeticity globals audit + reset the cursor->element parse memo per run (#11a)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -42,6 +42,7 @@ import com.monkopedia.krapper.generator.codegen.KotlinWriter
 import com.monkopedia.krapper.generator.codegen.NameHandler
 import com.monkopedia.krapper.generator.model.ForcingHeader
 import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.kotlinType
 import com.monkopedia.krapper.generator.model.type.WrappedType
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
@@ -108,13 +109,18 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             index.dispose()
         }
         // Start each generation run from clean process-scoped state so its output and
-        // report reflect only this run: the drop ledger (shared with any prior run) and
-        // the GenerationContext (the WrappedType intern cache + the rootPackage). Both
-        // must be reset BEFORE any resolution (requestInstantiation / filterAndResolve):
+        // report reflect only this run: the drop ledger (shared with any prior run), the
+        // GenerationContext (the WrappedType intern cache + the rootPackage), and the
+        // parse memo (the cursor->element interning map). All must be reset BEFORE any
+        // resolution (requestInstantiation / filterAndResolve):
         // a type's Kotlin package is baked into its ResolvedKotlinType at resolve time,
         // so rooting it later (e.g. in writeTo) would be too late.
         DropLedger.reset()
         GenerationContext.reset(config.rootPackage)
+        // The libclang-path cursor->element memo: cleared so a reused service process
+        // (kplusplusSync) never builds a later run on a prior run's resolved/mutated
+        // elements (#11 hermeticity).
+        WrappedElement.resetElementMemo()
     }
 
     private val includePaths = generateIncludes(config.compiler)

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelFactories.kt
@@ -75,6 +75,24 @@ fun WrappedElement.Companion.setDroppedUsrs(usrs: Set<String>) {
 }
 
 /**
+ * Clear the process-global parse memo before a fresh generation run (#11 hermeticity).
+ *
+ * [elementLookup] interns parsed elements by USR-tag so a declaration re-encountered
+ * across the base parse and every forcing re-parse WITHIN one run collapses onto a single
+ * instance — resolution then mutates that instance in place (metadata, synthetic children,
+ * dedup). That identity must NOT survive across runs: in service mode the v2 plugin's
+ * kplusplusSync reuses one krapper_gen process, so a later run re-parsing the same header
+ * would otherwise find the prior run's already-RESOLVED, mutated elements and build on
+ * them, diverging from a fresh-process run. [droppedUsrs] is overwritten before each
+ * [mapAll], but is reset here too so a fresh run never inherits a stale dropped set.
+ * Called from `IndexedServiceImpl.init`, next to [DropLedger.reset]/[GenerationContext.reset].
+ */
+fun WrappedElement.Companion.resetElementMemo() {
+    elementLookup.clear()
+    droppedUsrs = emptySet()
+}
+
+/**
  * Round-trip oracle support (#45 brick 1): after `--roundTripModel` replaces a parsed
  * tree with its deserialized copy, point every [elementLookup] memo entry that referenced
  * an element of the ORIGINAL tree at its RESTORED counterpart. The memo is what carries

--- a/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.ErrorPolicy
+import com.monkopedia.krapper.IndexRequest
+import com.monkopedia.krapper.InstantiationRequest
+import com.monkopedia.krapper.KrapperConfig
+import com.monkopedia.krapper.ReferencePolicy
+import com.monkopedia.krapper.generator.codegen.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Hermeticity lock (issue #11a, process-global determinism): two sequential generation
+ * runs IN ONE PROCESS over the SAME input must produce byte-identical output.
+ *
+ * This mimics service-mode reuse — the v2 plugin's `kplusplusSync` drives krapper_gen as
+ * a long-lived process and issues one generation per `IndexedServiceImpl` instance, so the
+ * process-global state (the WrappedType intern cache + rootPackage in GenerationContext,
+ * the DropLedger, and the libclang cursor->element memo in ModelFactories) outlives any
+ * single run. Each `IndexedServiceImpl.init` resets all three; if any leaked, run #2 would
+ * build on run #1's already-resolved/mutated elements and the generated bindings would
+ * diverge. Asserting identical output is the determinism gate the self-hosted stage-0 flip
+ * depends on.
+ */
+class DeterminismTest {
+
+    private fun config() = KrapperConfig(
+        pkg = "krapper.slice",
+        compiler = "clang++",
+        moduleName = "slice",
+        errorPolicy = ErrorPolicy.LOG,
+        referencePolicy = ReferencePolicy.INCLUDE_MISSING,
+        debug = false
+    )
+
+    // One full generation run (parse + force std::vector<int> + write) into a fresh dir,
+    // returning every generated file as relativePath -> content.
+    private suspend fun generateOnce(): Map<String, String> {
+        val outDir = File.createTempDir("krapper_determinism")
+        try {
+            val service = IndexedServiceImpl(config(), IndexRequest(emptyList(), emptyList()))
+            service.requestInstantiation(InstantiationRequest("std::vector", listOf("int")))
+            service.writeTo(outDir.path)
+            val files = mutableMapOf<String, String>()
+            collect(outDir, outDir, files)
+            return files
+        } finally {
+            outDir.rmR()
+        }
+    }
+
+    private fun collect(dir: File, base: File, into: MutableMap<String, String>) {
+        for (file in dir.listFiles().sortedBy { it.name }) {
+            if (file.isDir()) {
+                collect(file, base, into)
+            } else {
+                into[file.path.substring(base.path.length)] = file.readText()
+            }
+        }
+    }
+
+    @Test
+    fun twoInProcessRunsAreByteIdentical(): Unit = runBlocking {
+        val first = generateOnce()
+        val second = generateOnce()
+
+        assertTrue(
+            first.isNotEmpty(),
+            "the generation must produce at least one output file to compare"
+        )
+        // Same set of generated files.
+        assertEquals(
+            first.keys.sorted(),
+            second.keys.sorted(),
+            "the second in-process run produced a different set of files — a process-global " +
+                "leaked across runs"
+        )
+        // Identical content for every file.
+        for ((path, content) in first) {
+            assertEquals(
+                content,
+                second[path],
+                "generated file $path differs between two in-process runs — a process-global " +
+                    "leaked across runs (issue #11 hermeticity)"
+            )
+        }
+    }
+}

--- a/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
@@ -15,9 +15,9 @@
  */
 package com.monkopedia.krapper.generator
 
+import com.monkopedia.krapper.AllowListFilter
 import com.monkopedia.krapper.ErrorPolicy
 import com.monkopedia.krapper.IndexRequest
-import com.monkopedia.krapper.InstantiationRequest
 import com.monkopedia.krapper.KrapperConfig
 import com.monkopedia.krapper.ReferencePolicy
 import com.monkopedia.krapper.generator.codegen.File
@@ -50,13 +50,43 @@ class DeterminismTest {
         debug = false
     )
 
-    // One full generation run (parse + force std::vector<int> + write) into a fresh dir,
-    // returning every generated file as relativePath -> content.
+    // A header written to a STABLE path (not a per-run random name) so both runs parse the
+    // identical file: libclang assigns location-independent USRs to its declarations, so the
+    // two runs collide on the same keys in ModelFactories' cursor->element memo — the
+    // condition under which a non-reset memo would hand run #2 run #1's already-resolved
+    // instances. The class is shaped to MUTATE during resolution (the `value()` const-overload
+    // pair is de-duped; the `const Dep&` accessor pulls Dep in under INCLUDE_MISSING), so any
+    // non-idempotent reuse of a carried-over instance has the best chance to surface here.
+    private val headerPath = "/tmp/krapper_determinism_input.h"
+
+    private fun writeHeader() = File(headerPath).writeText(
+        """
+        |namespace fixture {
+        |class Dep {
+        |public:
+        |    int depValue() const;
+        |};
+        |class Widget {
+        |public:
+        |    Widget();
+        |    int value() const;
+        |    int value(int scale) const;
+        |    const Dep& dep() const;
+        |};
+        |}
+        """.trimMargin()
+    )
+
+    // One full generation run (parse the fixed header + resolve Widget + write) into a fresh
+    // output dir, returning every generated file as relativePath -> content.
     private suspend fun generateOnce(): Map<String, String> {
         val outDir = File.createTempDir("krapper_determinism")
         try {
-            val service = IndexedServiceImpl(config(), IndexRequest(emptyList(), emptyList()))
-            service.requestInstantiation(InstantiationRequest("std::vector", listOf("int")))
+            val service = IndexedServiceImpl(
+                config(),
+                IndexRequest(listOf(headerPath), emptyList())
+            )
+            service.filterAndResolve(AllowListFilter(listOf("fixture::Widget")))
             service.writeTo(outDir.path)
             val files = mutableMapOf<String, String>()
             collect(outDir, outDir, files)
@@ -71,13 +101,19 @@ class DeterminismTest {
             if (file.isDir()) {
                 collect(file, base, into)
             } else {
-                into[file.path.substring(base.path.length)] = file.readText()
+                // The .def file legitimately embeds the run's output directory (libraryPaths /
+                // compilerOpts -I) — a per-invocation INPUT, not leaked global state. Normalize
+                // it to a token so the comparison catches real cross-run leaks (stale element
+                // content, ordering, counters) without flagging the expected path difference.
+                into[file.path.substring(base.path.length)] =
+                    file.readText().replace(base.path, "<OUTDIR>")
             }
         }
     }
 
     @Test
     fun twoInProcessRunsAreByteIdentical(): Unit = runBlocking {
+        writeHeader()
         val first = generateOnce()
         val second = generateOnce()
 


### PR DESCRIPTION
Part **a** of #11 (self-bootstrap hermeticity): the residual **process-global state audit** for flip-gating determinism. A self-hosted stage-0 must generate identical output every run, and in service mode (`:slice`, the v2 plugin's `kplusplusSync`) one krapper_gen process is reused across runs — so any process-global that carries data across runs or makes output depend on run history is a determinism leak.

Scope is **#11a only** (globals). `#11b` (llvm-config) and `#11c` (runbook) remain.

## Audit — every mutable process-global in `krapper_gen` + `krapper_model` nativeMain

| Global | Where | Across-run carrier? | Reset/scoped? | Disposition |
|---|---|---|---|---|
| `GenerationContext` (`internedTypes` map, `rootPackage`) | krapper_model | yes | `reset()` in `IndexedServiceImpl.init` (PR #34) | already correct |
| `DropLedger` (`records`) | krapper_gen | yes | `reset()` in `IndexedServiceImpl.init` | already correct |
| `elementLookup` (cursor→element memo) | `ModelFactories.kt` | **yes — never cleared** | **NO** | **LEAK → fixed** |
| `droppedUsrs` | `ModelFactories.kt` | overwritten before each `mapAll` via `setDroppedUsrs` | set-before-use | not a leak (also reset defensively) |
| `Log.loggerImpl` | `Logging.kt` | logger sink, set at startup | config, not per-run data | not a leak |
| `dumpParsedModelPath`, `cppParsedModelPath`, `cppForcingModelPaths`, `dumpModelsDir`, `dumpModelCounter`, `cppBaseModelTu` | `Parsing.kt` | CLI/`--frontend=cpp`-only | null/default in service mode; service never reads them; ksrpc schema untouched | not a leak (debug/handoff path; one process = one CLI invocation) |
| `roundTripParsedModel` | `Parsing.kt` | env-derived (`KRAPPER_ROUNDTRIP_MODEL`) | deterministic constant, identical every run | not a leak (it's an input) |
| `Utils`, `FixupApplier`, `ForcingHeader` objects | both | — | stateless (no `var`/mutable fields) | not a leak |
| `WrappedTemplate.templateArgCounter` etc. | krapper_model | per-instance field, not global | — | not a leak |
| Service-impl fields (`forcingHeaders`, `requested`, `forcedContainerKeys`, `tempDir`, …) | `IndexedServiceImpl` | per-`IndexedServiceImpl` instance = per run | new instance each run | not a leak |

## The leak — `elementLookup`

`ModelFactories.kt` interns parsed `WrappedElement`s by USR-tag so a declaration re-encountered across the base parse and every forcing re-parse **within one run** collapses onto one instance (resolution then mutates that instance in place — metadata, synthetic children, dedup). The map was **process-global and never cleared**: in service mode a later run re-parsing the same header finds the prior run's already-resolved, mutated instances and the map grows unboundedly. The intended scope is one run's parses, not the process.

**Fix:** new `WrappedElement.resetElementMemo()` (clears `elementLookup`, and resets `droppedUsrs` defensively), wired into `IndexedServiceImpl.init` right next to the existing `DropLedger.reset()` / `GenerationContext.reset()`.

Transparency note: I could not exhibit an *output* divergence from this leak — resolution is idempotent over a reused element in every scenario I constructed (std::vector<int> instantiation; a fixed-path header with const-overload dedup + INCLUDE_MISSING synthetic pull-in). So this is a hermeticity hardening (removes cross-run element identity + unbounded growth in the reused service process), not a fix for an observed mis-generation.

## Determinism test

`DeterminismTest.twoInProcessRunsAreByteIdentical` runs two **full** generations (`filterAndResolve` + `writeTo`) in one process over a fixed-path header (USRs collide across runs, so the memo is genuinely re-hit) and asserts byte-identical output across every generated file. The per-invocation output dir is normalized out of the `.def` comparison (libraryPaths / `-I` are an input, not leaked state). This is the determinism regression guard the stage-0 flip depends on; any future global that leaks **and** affects output is caught here.

## Verify (JDK 17, foreground)

`:krapper_gen:nativeTest` **314/0** (+the new test), `:krapper_model:build`, `:featuregen:kplusplusSync` **zero `krapped/` drift**, `:featuregen:nativeTest` **188/0**, `:krapper_gen:ktlintCheck` green. Plugin IPC schema (KrapperConfig / IndexRequest / service interfaces) untouched, so no plugin recompile needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
