### PR TITLE
build: harden the llvm-config / -PenableClang clang-gate probe (#11b)

### DIFF
--- a/clangwalk/build.gradle.kts
+++ b/clangwalk/build.gradle.kts
@@ -44,10 +44,14 @@ kotlin {
                 // The generated wrapper calls into Clang's C++ AST API, so the final
                 // executable links libclang-cpp (the monolithic LLVM/Clang shared lib)
                 // + LLVM core. -lstdc++ for the C++ wrapper runtime.
+                // libdir + LLVM major are DISCOVERED by settings.gradle.kts's #11(b) probe
+                // (llvm-config --libdir / --version) and threaded via rootProject extras,
+                // so an LLVM bump or non-/usr/lib install needs no edit here; the literal
+                // fallbacks match this host and only apply if the probe didn't run.
                 compilerOpts(
-                    "-L/usr/lib",
+                    "-L${rootProject.extra.properties["llvmLibDir"] ?: "/usr/lib"}",
                     "-lclang-cpp",
-                    "-lLLVM-22",
+                    "-lLLVM-${rootProject.extra.properties["llvmMajor"] ?: "22"}",
                     "-lstdc++",
                     "-lm",
                     "-lpthread"

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -36,10 +36,14 @@ kotlin {
                 // versions, --gc-sections so DEBUG dead-strips the stale platform.linux
                 // cinterop cache, and libclang-cpp + LLVM for the Clang C++ AST API.
                 linkerOpts("--gc-sections")
+                // libdir + LLVM major are DISCOVERED by settings.gradle.kts's #11(b) probe
+                // (llvm-config --libdir / --version) and threaded via rootProject extras;
+                // the literal fallbacks match this host and only apply if the probe didn't
+                // run. (See :clangwalk's build.gradle.kts for the full link rationale.)
                 compilerOpts(
-                    "-L/usr/lib",
+                    "-L${rootProject.extra.properties["llvmLibDir"] ?: "/usr/lib"}",
                     "-lclang-cpp",
-                    "-lLLVM-22",
+                    "-lLLVM-${rootProject.extra.properties["llvmMajor"] ?: "22"}",
                     "-lstdc++",
                     "-lm",
                     "-lpthread"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,17 +21,96 @@ include(":featuregen")
 
 // :clangwalk is the stage1 self-bootstrap harness — it binds Clang's own C++ AST
 // (libclang-cpp) and walks a real AST on the generated bindings. It REQUIRES an LLVM
-// toolchain on the box (system clang++, libclang-cpp, LLVM-22) that an ordinary build
+// toolchain on the box (system clang++, libclang-cpp, libLLVM) that an ordinary build
 // host won't have, so it is OFF by default and never configured on an LLVM-absent box.
-// Opt in with `-PenableClang` (or set `enableClang=true`); the probe also auto-includes
-// it when an explicit LLVM is requested via the `llvmConfig` property pointing at a real
-// llvm-config. Default OFF keeps `./gradlew` green everywhere.
+// Opt in with `-PenableClang` (or set `enableClang=true`); the modules also auto-enable
+// when an explicit toolchain is pointed at via `-PllvmConfig=<path-to-llvm-config>`.
+// Default OFF keeps `./gradlew` green everywhere.
+//
+// #11(b) — toolchain probe hardening: when the modules ARE enabled, the LLVM toolchain
+// is PROBED ONCE here and the discovered values (major version + libdir) are threaded to
+// both clang modules via rootProject extras. So an LLVM major bump (22 -> 23) or a
+// non-/usr/lib install needs NO per-module edits, and an absent/mis-pointed toolchain
+// fails right here with an ACTIONABLE message instead of a cryptic `cannot find -lLLVM-22`
+// linker error ~8 minutes into a release link.
+
+// Look up an executable: an absolute/relative path is taken verbatim; a bare name is
+// searched on PATH. Returns null when nothing executable is found.
+fun resolveExecutable(name: String): File? {
+    val direct = File(name)
+    if (direct.path.contains(File.separatorChar)) {
+        return direct.takeIf { it.canExecute() }
+    }
+    return System.getenv("PATH").orEmpty().split(File.pathSeparator)
+        .map { File(it, name) }.firstOrNull { it.canExecute() }
+}
+
+// First line of `<exec> <arg>` stdout, trimmed (e.g. `llvm-config --version`/`--libdir`).
+fun probe(exec: File, arg: String): String {
+    val proc = ProcessBuilder(exec.absolutePath, arg).redirectErrorStream(true).start()
+    val out = proc.inputStream.readBytes().toString(Charsets.UTF_8).trim()
+    proc.waitFor()
+    return out
+}
+
 val enableClang = settings.providers.gradleProperty("enableClang").orNull
-val clangEnabled = (enableClang != null && enableClang != "false") ||
-    settings.providers.gradleProperty("llvmConfig").orNull?.let { File(it).canExecute() } == true
+// `-PllvmConfig=<exec>` is BOTH an opt-in (its presence enables the modules) AND the
+// override that points the probe at a specific llvm-config (e.g. a side-by-side install
+// or a versioned `llvm-config-22`); without it the probe uses `llvm-config` on PATH.
+val llvmConfigProp = settings.providers.gradleProperty("llvmConfig").orNull
+val clangEnabled = (enableClang != null && enableClang != "false") || llvmConfigProp != null
 if (clangEnabled) {
+    val llvmConfig = resolveExecutable(llvmConfigProp ?: "llvm-config")
+    val clangxx = resolveExecutable("clang++")
+    if (llvmConfig == null || clangxx == null) {
+        throw GradleException(
+            """
+            |The clang modules (:clangwalk, :cppfrontend) are enabled${
+                if (llvmConfigProp != null) " (-PllvmConfig=$llvmConfigProp)" else " (-PenableClang)"
+            } but the
+            |LLVM/Clang toolchain they link against was not found:
+            |  - llvm-config: ${
+                llvmConfig?.absolutePath
+                    ?: (llvmConfigProp?.let { "'$it' is not an executable file" }
+                        ?: "not found on PATH")
+            }
+            |  - clang++:     ${clangxx?.absolutePath ?: "not found on PATH"}
+            |
+            |Fix one of:
+            |  * install LLVM/Clang so `llvm-config` and `clang++` are on PATH; or
+            |  * point the build at a specific install:
+            |        ./gradlew <task> -PllvmConfig=/path/to/llvm-config
+            |  * to build WITHOUT the clang modules, just drop -PenableClang/-PllvmConfig
+            |    (the default build excludes them and needs no LLVM).
+            """.trimMargin()
+        )
+    }
+    // Discover the toolchain shape ONCE (was hardcoded `LLVM-22` + `/usr/lib` in each
+    // module): `--version` -> the major (`-lLLVM-<major>`), `--libdir` -> the `-L<dir>`.
+    val llvmMajor = probe(llvmConfig, "--version").substringBefore('.').ifEmpty { "22" }
+    val llvmLibDir = probe(llvmConfig, "--libdir").ifEmpty { "/usr/lib" }
+    // Soft check: surface the exact missing `-l` target now (a clearer hint than the
+    // linker's), but don't hard-fail — distros name the monolithic lib differently and
+    // the linker is the real authority on what it can resolve.
+    if (!File(llvmLibDir, "libLLVM-$llvmMajor.so").exists() &&
+        !File(llvmLibDir, "libclang-cpp.so").exists()
+    ) {
+        println(
+            "WARNING: clang modules expect libLLVM-$llvmMajor.so + libclang-cpp.so under " +
+                "$llvmLibDir (from ${llvmConfig.absolutePath} --libdir), but neither was " +
+                "found there; the gated link may fail. Override with -PllvmConfig."
+        )
+    }
+
     include(":clangwalk")
     // :cppfrontend is the stage1 front-end scaffold (#44 brick 2): it constructs
     // :krapper_model's parse-output model from the same gated libclang-cpp bindings.
     include(":cppfrontend")
+
+    // Thread the discovered toolchain shape to both clang modules (read in their
+    // build.gradle.kts as rootProject.extra, with /usr/lib + 22 fallbacks).
+    gradle.rootProject {
+        extra["llvmMajor"] = llvmMajor
+        extra["llvmLibDir"] = llvmLibDir
+    }
 }


### PR DESCRIPTION
Part **b** of #11 (self-bootstrap build-infra): harden the `llvm-config` / `-PenableClang` probe that gates the clang modules (`:clangwalk`, `:cppfrontend`). Small, gate/probe-only scope. (#11a globals done; #11c runbook is a sibling's.)

## Probe audit — what was hardcoded/fragile
- `llvm-config` was **never invoked**. Everything was hardcoded: `-lLLVM-22` and `-L/usr/lib` literally, in **two** build files each (`clangwalk/build.gradle.kts`, `cppfrontend/build.gradle.kts`). An LLVM major bump (22→23) or a non-`/usr/lib` install meant editing 2 files in 2 places.
- `-PllvmConfig` was only used in a `canExecute()` **gate check** — its value was never threaded anywhere, so the documented "point at a specific install" override didn't actually point the link at anything.
- **No actionable guard:** `-PenableClang` with an absent/mis-pointed toolchain failed ~8 min into a release link with a cryptic `cannot find -lLLVM-22`. (The box even carries a stale `libLLVM-15.so` next to 22 — the wrong-version hazard is real.)

## What I hardened (settings.gradle.kts)
- **Probe once, thread discovered values:** when the modules are enabled, resolve `llvm-config` (`-PllvmConfig` override, else PATH) + `clang++`, then discover the LLVM major (`--version`) and libdir (`--libdir`) and thread them to both modules via `rootProject` extras. Both modules now emit `-L${llvmLibDir}` / `-lLLVM-${llvmMajor}` with `/usr/lib` + `22` fallbacks. An LLVM bump or relocated install needs **no per-module edit**.
- **Actionable failure at the gate:** enabled but no `llvm-config`/`clang++` → fail at **configure time** (not a late linker error) naming exactly what's missing and how to set `-PllvmConfig` (or drop the flag for the default build).
- **`-PllvmConfig` is now genuinely used** (threaded), the documented override — and is its own opt-in.
- **Soft WARNING** if the expected libs aren't under the discovered libdir (the "LLVM present but wrong version" hint, before the linker).

## Deliberately left
- Did **not** parse `llvm-config --libs` / emulate its full link line — the explicit `-lclang-cpp -lLLVM-<major>` shape is kept (minimal, matches the modules). Lib-existence is a soft warning, not a hard fail, to avoid false negatives across distros that name the monolithic lib differently (the linker stays the authority).
- Did **not** touch the default build, #11a globals, or the #11c runbook.

## Failure-message demo (`-PllvmConfig=/nonexistent`)
```
The clang modules (:clangwalk, :cppfrontend) are enabled (-PllvmConfig=/nonexistent) but the
LLVM/Clang toolchain they link against was not found:
  - llvm-config: '/nonexistent' is not an executable file
  - clang++:     /usr/bin/clang++

Fix one of:
  * install LLVM/Clang so `llvm-config` and `clang++` are on PATH; or
  * point the build at a specific install:
        ./gradlew <task> -PllvmConfig=/path/to/llvm-config
  * to build WITHOUT the clang modules, just drop -PenableClang/-PllvmConfig
    (the default build excludes them and needs no LLVM).
```
Fires in ~350 ms at configure time, not ~8 min into a link.

## Verify (JDK 17)
- **Default unaffected:** `./gradlew projects` → clang modules ABSENT; `:krapper_gen:nativeTest :krapper_gen:ktlintCheck` GREEN.
- **Gate works:** `-PenableClang` → both modules PRESENT (probe finds 22.1.6 / `/usr/lib`, no warning); valid `-PllvmConfig=/usr/bin/llvm-config` → PRESENT; `:clangwalk:tasks -PenableClang` configures cleanly with the threaded extras.
- **Failure path:** `-PllvmConfig=/nonexistent` → actionable error above (configure-time).
- **Link line unchanged on this host:** discovered values (major=22, libdir=/usr/lib) are byte-identical to the prior literals, so the emitted `-l`/`-L` flags are textually unchanged.
- Note: a full gated `:clangwalk:linkReleaseExecutableKlinker` currently fails **upstream of linking**, at `compileKotlinNative`, on regenerated bindings importing `clang.attr.Kind`/`.value` (a krapper_gen codegen gap vs the box's LLVM-22.1.6 headers). That is independent of this change (the Kotlin compile step never reads `compilerOpts`) and out of scope for the gate/probe brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
