### PR TITLE
fix(krapper_gen): declaration name must ignore per-file import-alias remap (#73)

### DIFF
--- a/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedType.kt
+++ b/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedType.kt
@@ -168,6 +168,24 @@ data class ResolvedKotlinType(
         } else {
             "$mappedName${if (isNullable) "?" else ""}"
         }
+
+    // The CANONICAL declaration name — this type's own identity, INDEPENDENT of any
+    // per-file import alias (issue #73). `name`/`plainName` resolve through `mappedName`,
+    // which applies `remap`; `remap` is a per-FILE REFERENCE-site rename (how one file
+    // refers to a colliding import it had to alias, e.g. `clang.attr.Kind` -> `AttrKind`),
+    // set as SHARED MUTABLE STATE on this instance by `ImportBlock.build`. A DECLARATION
+    // (the `class X` / `enum class X` token, plus its file name and package) must NOT
+    // depend on that: `remap` set while emitting one file would otherwise leak into the
+    // declared name emitted for this same shared type in another file (a non-hermetic,
+    // order-dependent corruption). So declarations use this canonical name; only
+    // REFERENCES go through `name`/`plainName` and keep the alias.
+    val declaredName: String
+        get() = if (templates.isNotEmpty()) {
+            "${qualifyList.last()}<${templates.joinToString(", ") { it.name }}>" +
+                if (isNullable) "?" else ""
+        } else {
+            "${qualifyList.last()}${if (isNullable) "?" else ""}"
+        }
     val pkg: String
         get() = qualifyList.subList(0, qualifyList.size - 1).joinToString(".") {
             it.replaceFirstChar { it.lowercase() }
@@ -213,6 +231,12 @@ fun nullable(base: ResolvedKotlinType): ResolvedKotlinType = base.copy(isNullabl
 // a `<Name>Api`/`to<Name>` prefix needs the bare name without it.
 val ResolvedKotlinType.plainName: String
     get() = name.trimEnd('?')
+
+// [declaredName] with the use-position nullable `?` stripped — the bare declaration token
+// (`enum class X` / `class X` is illegal with a trailing `?`). Mirrors [plainName], but
+// canonical: a declaration name must never carry a per-file import alias (issue #73).
+val ResolvedKotlinType.plainDeclaredName: String
+    get() = declaredName.trimEnd('?')
 
 fun ResolvedKotlinType.typedWith(parseTypes: List<ResolvedKotlinType>): ResolvedKotlinType =
     copy(templates = parseTypes)

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/ImportBlock.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/ImportBlock.kt
@@ -48,10 +48,15 @@ class ImportBlock(pkg: String, private val target: CodeBuilder<KotlinFactory>) :
         }
         val mappings = fqNames.mapNotNull { item -> item.second?.let { item.first to it } }
             .toMap()
-        if (mappings.isNotEmpty()) {
-            fqSymbols.forEach {
-                it.setNameRemap(mappings)
-            }
+        // Apply this file's alias map to every symbol in the file UNCONDITIONALLY — even
+        // when empty. `remap` is shared mutable state on a `ResolvedKotlinType`, so a type
+        // referenced here may still carry an alias set while a PREVIOUS file (with a
+        // collision) was emitted. Re-applying this file's map (empty == no aliases) resets
+        // that stale alias, so a reference renders by the alias only in files that actually
+        // need it — making reference output independent of file render order (issue #73 /
+        // #11 hermeticity). Declarations are already canonical via `declaredName`.
+        fqSymbols.forEach {
+            it.setNameRemap(mappings)
         }
     }
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -102,6 +102,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedType
 import com.monkopedia.krapper.generator.resolvedmodel.type.fullyQualifiedType
 import com.monkopedia.krapper.generator.resolvedmodel.type.nullable
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainDeclaredName
 import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
 import com.monkopedia.krapper.generator.resolvedmodel.type.typedWith
 

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -264,9 +264,14 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // fixed boilerplate with no AST nodes to model.
     private fun renderEnum(enum: ResolvedKotlinType): String {
         val underlying = enum.enumUnderlying?.name ?: "Int"
-        // The enum's DECLARATION name must be the bare class name (`plainName`): an
-        // `enum class TranslationUnitKind?` is illegal. Type USAGES keep the `?`.
-        val name = enum.plainName
+        // The enum's DECLARATION name must be the bare CANONICAL class name
+        // (`plainDeclaredName`, not `plainName`): `plainName` routes through the shared,
+        // per-file import-alias `remap`, so another file aliasing this enum (e.g.
+        // `clang.attr.Kind` -> `AttrKind` to dodge a same-file `Kind` collision) would leak
+        // that alias into this declaration — `enum class AttrKind` while the file/package
+        // and every reference use `clang.attr.Kind` -> unresolved (issue #73). The canonical
+        // name also strips the use-position `?` (an `enum class X?` is illegal).
+        val name = enum.plainDeclaredName
         val entries = enum.enumEntries.joinToString(", ") { entry ->
             "${entry.name}(${literalForUnderlying(entry.value, underlying)})"
         }
@@ -787,7 +792,11 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
     }
 
-    private fun named(name: ResolvedKotlinType) = Raw(name.name)
+    // Sole use: the `class X` declaration token in onGenerate. Uses the CANONICAL
+    // [declaredName], not `name`: a declaration must not inherit a per-file import alias
+    // from the shared `remap` (issue #73 — same hazard as the enum declaration above).
+    // References to a class keep `name`/`plainName` so an aliased import still resolves.
+    private fun named(name: ResolvedKotlinType) = Raw(name.declaredName)
 
     /**
      * Describes the generic interface + scoped factory ("facade") generated for a

--- a/krapper_gen/src/nativeTest/kotlin/DeclNameRemapTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/DeclNameRemapTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainDeclaredName
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #73: a per-file import-alias `remap` must NOT corrupt a type's own DECLARATION name.
+ *
+ * `ImportBlock.build` disambiguates a same-file collision (two `Kind` imports) by aliasing
+ * one — `clang.attr.Kind` -> `AttrKind` — and stamping that alias onto the SHARED
+ * `ResolvedKotlinType.remap`. That instance is reused for the enum's own declaration file,
+ * so the declaration was emitted as `enum class AttrKind` while its file/package and every
+ * reference still used `clang.attr.Kind` -> unresolved reference, K/N compile failed.
+ *
+ * The invariant locked here: REFERENCES (`name`/`plainName`) honor the alias; the
+ * DECLARATION name (`declaredName`/`plainDeclaredName`) is canonical and ignores `remap`.
+ */
+class DeclNameRemapTest {
+
+    @Test
+    fun aliasRemapRenamesReferencesButNotTheDeclaration() {
+        val kind = ResolvedKotlinType("clang.attr.Kind", isWrapper = false)
+
+        // Before any collision: reference and declaration agree on the canonical name.
+        assertEquals("Kind", kind.plainName)
+        assertEquals("Kind", kind.plainDeclaredName)
+
+        // A colliding file aliases this import; ImportBlock stamps the alias onto the
+        // shared instance.
+        kind.setNameRemap(mapOf("clang.attr.Kind" to "AttrKind"))
+
+        // A REFERENCE to the aliased import must use the alias — that is the remap's job.
+        assertEquals("AttrKind", kind.name)
+        assertEquals("AttrKind", kind.plainName)
+
+        // The DECLARATION name must stay canonical, independent of the per-file alias —
+        // this is the #73 fix. (Pre-fix, `plainDeclaredName` did not exist and the
+        // declaration sites read `plainName`, yielding the corrupt `AttrKind`.)
+        assertEquals("Kind", kind.declaredName)
+        assertEquals("Kind", kind.plainDeclaredName)
+    }
+}


### PR DESCRIPTION
Fixes #73.

## Confirmed mechanism
`ImportBlock.build` disambiguates a same-file import collision (two `Kind` imports — `clang.attr.Kind` next to another `Kind`) by aliasing one to `AttrKind` and calling `setNameRemap(...)`, which stamps the alias onto `remap` — **mutable state on a SHARED `ResolvedKotlinType`**. `plainName -> name -> mappedName` returns `remap[fullyQualified] ?: qualifyList.last()`.

The enum's own declaration file is rendered by `KotlinWriter.renderEnum` (a plain string builder with no ImportBlock), yet it read `enum.plainName` off that **same shared instance** — which a *different* file's collision had already mutated. Result: `enum class AttrKind` while the file name, package, and every reference kept `clang.attr.Kind` → unresolved reference, K/N `compileKotlinNative` failed. The class-declaration token (`named(type)` → `type.name`) carries the identical hazard.

This is also a hermeticity bug (#11): because `remap` is shared mutable state, the corruption is render-order dependent.

## Fix — declaration uses canonical, references keep alias
- Added canonical `declaredName` / `plainDeclaredName` on `ResolvedKotlinType` that resolve to `qualifyList.last()` and **ignore `remap`**.
- Declaration sites now use them: the `enum class X` token (`renderEnum`) and the `class X` token (`named`).
- References still go through `name` / `plainName`, so an aliased import legitimately resolves under its alias.
- Determinism: `ImportBlock.build` now applies its per-file alias map **unconditionally** (even when empty) so a collision-free file resets any stale alias a previously-rendered file left on the shared instance — reference output is now independent of file render order. Byte-identical when there are no collisions.

## Verification (JDK 17)
- `:krapper_gen:nativeTest` **315/0** (314 + new `DeclNameRemapTest` locking the invariant: a `remap` renames references but not the declaration), `:featuregen:nativeTest` **188/0**, `:krapper_gen:ktlintCheck` green.
- **featuregen output byte-identical** — zero `krapped/` drift (clean `git status`; featuregen's specs hit no attr collision).
- **Flagship clangwalk now GREEN** — `:clangwalk:runReleaseExecutableKlinker -PenableClang` previously failed at `compileKotlinNative` on `clang.attr.Kind`; it now compiles, links, and runs the real libclang-cpp AST walk:
```
clangwalk: top-level declarations of the parsed TU
  [CXXRecord] Circle
      <base> Shape
      <method> radius : double
  [Function] freeFunction : void (int)
  [Var] globalVar : int
clangwalk: walked 10 top-level declarations via real libclang-cpp
```
- `:cppfrontend:goldenCompare :cppfrontend:featuregenParity -PenableClang` still green (the pre-characterized `[as expected]` diffs only; 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
