### PR TITLE
krapper_gen: a forced instantiation target may drop an unresolvable primary base — fixes std::pair<int,int> on the cpp front-end (#77)

### DIFF
--- a/featuregen/build.gradle.kts
+++ b/featuregen/build.gradle.kts
@@ -68,15 +68,9 @@ if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
     tasks.named("kplusplusSync") {
         dependsOn(":cppfrontend:featuregenCppBindings")
     }
-    // FLIP-WORKLIST item (#47): CpPairTest references std::pair<int,int>'s binding, which
-    // the cpp front-end DROPS under the full multi-instantiation sync — even though it
-    // generates fine per-spec (featuregenParity: std::pair<int,int>=diff:83). So this is a
-    // multi-instantiation forcing cross-contamination drop (binding-side, not a spelling
-    // rename, not test-side), the ONE thing blocking a clean flip today. Exclude just this
-    // unit from the cpp-harness test compile so the remaining 186 behavioral tests can be
-    // measured against the cpp bindings. This filter applies ONLY under
-    // -Pkpp.frontend.featuregen=cpp; the default test path compiles ALL tests unchanged.
-    tasks.named("compileTestKotlinNative") {
-        (this as org.gradle.api.tasks.util.PatternFilterable).exclude("**/CpPairTest.kt")
-    }
+    // #77 RESOLVED: std::pair<int,int> now binds under the full multi-instantiation cpp
+    // sync (a forced instantiation target may drop an unresolvable primary base — pair's
+    // private __pair_base<_T1,_T2> the libclang walk omits — instead of hard-failing; see
+    // ResolveContext.forcingTargetKeys). So CpPairTest is no longer excluded: all 188
+    // behavioral tests compile against the cpp bindings.
 }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -262,7 +262,13 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             resolver,
             config.referencePolicy,
             alreadyBoundKeys,
-            forcedContainerKeys
+            forcedContainerKeys,
+            // The explicitly-requested specialization (this request's target) is a listed
+            // binding, so its INCLUDE_MISSING materialization may drop an unresolvable
+            // PRIMARY base instead of hard-failing — e.g. std::pair<int, int>, whose
+            // faithful cpp model carries the private __pair_base<_T1, _T2> the libclang
+            // walk omits. See ResolveContext.forcingTargetKeys.
+            forcingTargets = setOf(target)
         )
         // One entry per class type-key, last copy wins (#60): without this, every
         // writer received a fresh full copy of each bound class per instantiation

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -205,7 +205,8 @@ suspend fun List<WrappedElement>.resolveForcing(
     resolver: Resolver,
     policy: ReferencePolicy,
     alreadyBoundKeys: Set<String>,
-    forcedContainerKeys: MutableSet<String> = mutableSetOf()
+    forcedContainerKeys: MutableSet<String> = mutableSetOf(),
+    forcingTargets: Set<String> = emptySet()
 ): List<ResolvedElement> {
     val classes = filterIsInstance<WrappedClass>()
     // The `KrapperForce_*` struct's `value` member type IS the forced container
@@ -234,7 +235,8 @@ suspend fun List<WrappedElement>.resolveForcing(
             resolver = resolver,
             debugFilter = { _, _, _ ->
                 platform.posix.getenv("KRAPPER_DEBUG_RESOLVE") != null
-            }
+            },
+            forcingTargetKeys = forcingTargets
         )
         .withClasses(classes)
 
@@ -430,7 +432,19 @@ data class ResolveContext(
     // bases/members (e.g. `std::ctype<char>` → `std::ctype_base`), emitting broken
     // C++. False only while expanding an INCLUDE_MISSING reference. See
     // `WrappedClass.resolve`.
-    val dropUnresolvablePrimaryBase: Boolean = true
+    val dropUnresolvablePrimaryBase: Boolean = true,
+    // The type-string keys of the instantiation targets being FORCED this resolve (the
+    // `--instantiate`/forcing-struct specializations). An INCLUDE_MISSING expansion of a
+    // class whose key is in this set is an EXPLICITLY REQUESTED binding, not an incidental
+    // transitive reference, so it gets the listed/found-class treatment — drop an
+    // unresolvable PRIMARY base rather than hard-failing the whole class. This is what lets
+    // `std::pair<int, int>` bind on the cpp front-end: its faithful model carries the
+    // private `__pair_base<_T1, _T2>` base (libclang's lossy walk omits it) with
+    // unsubstituted dependent params that can't resolve; dropping that empty constraint
+    // base keeps pair's own `first`/`second`/`swap`, matching the libclang binding. Empty
+    // off the forcing path, so the main resolve is unaffected. See `typeMapper`'s
+    // INCLUDE_MISSING branch and `resolveForcing`.
+    val forcingTargetKeys: Set<String> = emptySet()
 ) {
 
     suspend fun map(type: WrappedType): WrappedType? {
@@ -648,11 +662,14 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
                             // pulled class's primary base can't resolve (don't
                             // resurrect transitively-referenced subclasses + their
                             // incomplete-at-emit bases). Listed/found classes still
-                            // drop-to-borrowed via their own resolve context.
+                            // drop-to-borrowed via their own resolve context — as does an
+                            // EXPLICITLY-FORCED instantiation target (in forcingTargetKeys),
+                            // which is a requested binding, not an incidental reference.
+                            val dropBase = it.toString() in context.forcingTargetKeys
                             val (resolved, wrapper) =
                                 context.resolver.resolve(
                                     it,
-                                    context.copy(dropUnresolvablePrimaryBase = false)
+                                    context.copy(dropUnresolvablePrimaryBase = dropBase)
                                 ) ?: error("Couldn't include $it, resolve failed")
                             if (!resolved.isNotEmpty()) {
                                 return@operateOn RemoveElement


### PR DESCRIPTION
## Fixes #77 — `std::pair<int,int>` dropped under `--frontend=cpp`

### Root cause (binding-side, NOT the merge / NOT multi-instantiation)
The cpp front-end models `std::pair` faithfully: newer libstdc++ declares
`struct pair : private __pair_base<_T1, _T2>`, and that private base is in the model
with **unsubstituted dependent params** (`__pair_base<_T1, _T2>`), so it can't resolve.
libclang's lossy AST walk omits `__pair_base` entirely, so its `pair` has no base.

When a forcing struct's `value` field (the requested specialization) is materialized
on-demand under `INCLUDE_MISSING`, the expansion uses `dropUnresolvablePrimaryBase = false`
(the legacy hard-fail that protects against resurrecting incidental transitively-referenced
subclasses). So pair's unresolvable `__pair_base` **hard-failed the whole pair class** and it
was dropped — `Warning: can't resolve forcing struct KrapperForce_std_pair_int_int`.

This is **not** a multi-instantiation cross-contamination: pair drops even when forced
ALONE on the cpp path. (The per-spec `featuregenParity` ledger reads `std::pair<int, int>=diff:83`
because the dropped-pair file-set gap was hidden as a `file sets differ` note inside that
unit's diff verdict, not a separate failure.)

### Fix
A forced instantiation target is an **explicitly requested binding**, so it deserves the
same listed/found-class treatment as a top-level allowlisted class: drop an unresolvable
PRIMARY base instead of hard-failing. Added `ResolveContext.forcingTargetKeys` (the request's
target type-strings); `requestInstantiation` seeds it with `setOf(target)`, and the
`INCLUDE_MISSING` typeMapper relaxes `dropUnresolvablePrimaryBase` to true **only** when the
class being expanded is exactly a forcing target. Everything else keeps the hard-fail.
`__pair_base` is an empty constraint base — dropping it loses nothing; pair keeps
`first`/`second`/`swap`, matching the libclang binding byte-for-byte.

No-op off the forcing path (the set is empty), and a no-op on the libclang forcing path
(its pair has no base), so `krapped/` is byte-identical.

### Before / after
- **Before:** `featuregen/build/krapped-cpp` had 116 files, **no `std_Pair__Int__Int.kt`**; CpPairTest excluded from the cpp harness.
- **After:** 117 files, `std_Pair__Int__Int.kt` present and **byte-identical** to the committed libclang `featuregen/krapped/src/std_Pair__Int__Int.kt`. CpPairTest re-included; `:featuregen:compileTestKotlinNative -PenableClang -Pkpp.frontend.featuregen=cpp` compiles all **188** tests (was 186/188). (The behavioral RUN is still blocked by the separate #78 toolchain skew — that gates the LINK, not the compile.)

### Verify
- `:krapper_gen:nativeTest :featuregen:kplusplusSync :featuregen:nativeTest :krapper_gen:ktlintCheck` (no flag) — GREEN, **zero `krapped/` drift**.
- `:cppfrontend:goldenCompare :cppfrontend:featuregenParity -PenableClang` — GREEN, **18/18, 0 regressions** (the `std::pair<int, int>` unit's only-libclang file-set gap is now closed; the cpp surplus `root___locale_struct.kt` is the pre-existing D2b accepted residue).
- `:cppfrontend:featuregenCppBindings :featuregen:compileTestKotlinNative -PenableClang -Pkpp.frontend.featuregen=cpp` — GREEN (pair present, 188/188 compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
