### PR TITLE
fix(krapper_gen): holder-factory CALL must use canonical name, not per-file import alias (#75)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -747,7 +747,14 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                 cls.children.filterIsInstance<ResolvedDestructor>().firstOrNull()
             extensionFunction {
                 receiver = fqType(MEM_SCOPE)
-                name = cls.type.kotlinType.plainName + "_Holder"
+                // The `<Type>_Holder` factory is a generated SIBLING function, not an
+                // imported type reference: it is DECLARED here under the canonical name
+                // (`plainDeclaredName`, ignoring `remap`) and every CALL to it (see
+                // generateMethodBody's ARG_CAST path) must use that SAME canonical name.
+                // `plainName` would route through the per-file import alias (issue #75) —
+                // a remote calling file that aliased this type would then emit
+                // `<Alias>_Holder`, an undeclared symbol. Declaration-name == call-name.
+                name = cls.type.kotlinType.plainDeclaredName + "_Holder"
                 retType = type(cls.type)
                 body {
                     if (defaultConstructor != null) {
@@ -2081,7 +2088,13 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                 initializer = memScope dot Call(
                     extensionMethod(
                         kotlinType.fullyQualified + ".Companion",
-                        kotlinType.plainName + "_Holder"
+                        // CALL the `<Type>_Holder` factory by its canonical DECLARED name
+                        // (`plainDeclaredName`), matching the declaration site above. This
+                        // body is emitted in the file of the method's owning class, which
+                        // may have aliased `kotlinType` via an import collision; `plainName`
+                        // would yield `<Alias>_Holder` (undeclared), since the factory is
+                        // declared canonical regardless of the calling file's alias (#75).
+                        kotlinType.plainDeclaredName + "_Holder"
                     )
                 )
             ).also {

--- a/krapper_gen/src/nativeTest/kotlin/HolderCallRemapTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/HolderCallRemapTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.builders.buildCode
+import com.monkopedia.krapper.generator.builders.extensionMethod
+import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainDeclaredName
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #75 — the REFERENCE-side sibling of #73.
+ *
+ * A class with an ARG_CAST return is constructed via a generated `<Type>_Holder` factory.
+ * That factory is DECLARED once (in the class's own file) under the canonical name —
+ * `KotlinWriter` builds the declaration token from `plainDeclaredName`, which ignores the
+ * per-file import-alias `remap`. The factory is CALLED from `generateMethodBody`'s ARG_CAST
+ * path, which is emitted in the file of the METHOD's owning class. If that remote file had a
+ * same-file import collision and aliased the returned type (`clang.attr.Kind` -> `AttrKind`),
+ * reading `plainName` there yields the alias, so the call became `AttrKind_Holder` — an
+ * undeclared symbol, because the factory is declared as `Kind_Holder`. K/N compile failed.
+ *
+ * The invariant locked here: a generated SIBLING factory's name is canonical at BOTH ends.
+ * Declaration-name == call-name; neither follows the per-file alias.
+ */
+class HolderCallRemapTest {
+
+    /**
+     * Builds the `<Type>_Holder` call symbol exactly as `KotlinWriter.generateMethodBody`
+     * does for an ARG_CAST wrapper return, then renders it. [holderName] selects the name
+     * accessor so the test can contrast the fixed (`plainDeclaredName`) path with the
+     * pre-fix (`plainName`) path.
+     */
+    private fun renderHolderCall(
+        type: ResolvedKotlinType,
+        holderName: ResolvedKotlinType.() -> String
+    ): String {
+        val symbol = extensionMethod(
+            type.fullyQualified + ".Companion",
+            type.holderName() + "_Holder"
+        )
+        return buildCode { symbol.build(this) }
+    }
+
+    @Test
+    fun holderCallStaysCanonicalUnderAReferenceFileAlias() {
+        val kind = ResolvedKotlinType("clang.attr.Kind", isWrapper = true)
+
+        // No collision yet: both accessors agree, the holder call is canonical.
+        assertEquals("Kind_Holder", renderHolderCall(kind) { plainDeclaredName })
+
+        // A remote calling file has a same-file import collision and aliases this import;
+        // ImportBlock stamps the alias onto the SHARED instance the ARG_CAST return reads.
+        kind.setNameRemap(mapOf("clang.attr.Kind" to "AttrKind"))
+
+        // The fix: the holder CALL uses the canonical declared name, so it still names the
+        // factory that was declared canonically — regardless of the calling file's alias.
+        assertEquals("Kind_Holder", renderHolderCall(kind) { plainDeclaredName })
+
+        // Pre-fix the call read `plainName`, which follows the alias — `AttrKind_Holder`,
+        // an undeclared symbol. This asserts the exact regression the fix removes.
+        assertEquals("AttrKind_Holder", renderHolderCall(kind) { plainName })
+    }
+}


### PR DESCRIPTION
Fixes #75 — the REFERENCE-side sibling of #73 (declaration side, PR #74).

## Confirmed mechanism + trigger
A class with an `ARG_CAST` return is constructed via a generated `<Type>_Holder` factory.

- **Declaration** (`KotlinWriter.kt` ~750): the `fun MemScope.<Type>_Holder()` factory is declared once, in the class's *own* file. That file resets `remap` to its own import map and never aliases its own type, so the declared name is canonical (`Kind_Holder`).
- **Call** (`KotlinWriter.generateMethodBody` ~2084, the `returnStyle == ARG_CAST && kotlinType.isWrapper` path): the call is emitted in the file of the **method's owning class**, a *different* file. If that file has a same-file import collision and aliases the returned type (`clang.attr.Kind` -> `AttrKind`), reading `kotlinType.plainName` there returns the alias, so the emitted call became `AttrKind_Holder` — an **undeclared symbol** (the factory is `Kind_Holder`). K/N compile failed.

This is the inverse distinction from #73: there, declarations went canonical while imported *type* references legitimately kept the alias. Here the `_Holder` symbol is a generated **sibling factory name**, not an imported type reference — so the CALL must also be canonical, matching its canonical declaration.

## Fix
Both the `_Holder` **declaration** (~750) and its **call** (~2084) now use `plainDeclaredName + "_Holder"` (the canonical accessor added in #73, which ignores `remap`). Declaration-name == call-name by construction, independent of any calling file's alias. The receiver qualifier (`fullyQualified + ".Companion"`) was already canonical. Added comments stating the declaration-name-matches-call-name invariant at both sites.

The declaration change is byte-identical (it was already canonical in its own file); the call change is the actual fix.

## Test
`HolderCallRemapTest` builds the real holder-call symbol exactly as `generateMethodBody` does (via `extensionMethod` + `buildCode`), applies a reference-file remap (`clang.attr.Kind` -> `AttrKind`), and asserts the rendered call stays `Kind_Holder`. It also asserts the pre-fix `plainName` construction would have rendered `AttrKind_Holder`, pinning the exact regression. Mirrors #73's `DeclNameRemapTest`.

## Verify (JDK 17, foreground)
- `:krapper_gen:nativeTest` green — HolderCallRemapTest 1/0, suite green.
- `:krapper_model:build`, `:featuregen:kplusplusSync`, `:featuregen:nativeTest`, `:krapper_gen:ktlintCheck` all green.
- **Byte-identical**: zero `featuregen/krapped/` drift after sync (specs don't hit the collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)