### PR TITLE
featuregen: link the gated cpp-front-end test variant against system libstdc++ (#78)

### DIFF
--- a/featuregen/build.gradle.kts
+++ b/featuregen/build.gradle.kts
@@ -73,4 +73,63 @@ if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
     // private __pair_base<_T1,_T2> the libclang walk omits — instead of hard-failing; see
     // ResolveContext.forcingTargetKeys). So CpPairTest is no longer excluded: all 188
     // behavioral tests compile against the cpp bindings.
+
+    // #78 (the last flip prerequisite): MAKE THE 188 TESTS LINK + RUN. The cpp front-end
+    // parses featuregen's surface against the SYSTEM libstdc++ (gcc-16 here), so the
+    // faithful generated wrapper references newer-libstdc++ internals
+    // (std::__throw_bad_array_new_length@GLIBCXX_3.4.29,
+    // std::__glibcxx_assert_fail@GLIBCXX_3.4.30, std::__size_to_integer). K/N's default
+    // test link resolves libstdc++ from its BUNDLED gcc-8.3 sysroot, which caps at
+    // GLIBCXX_3.4.25 → those symbols are undefined and linkDebugTestNative fails. The
+    // system libstdc++ HAS them and is backward-ABI-compatible (it provides every older
+    // GLIBCXX version too). Point K/N's own linker at it: link the REAL system
+    // libstdc++.so by ABSOLUTE PATH (not -L/-lstdc++ — konan's bundled gcc-8.3 sysroot
+    // -L is searched first, so `-lstdc++` would resolve to the OLD lib and the newer
+    // symbols would stay undefined; an absolute path can't be shadowed by search order),
+    // --gc-sections to dead-strip the stale platform.linux cinterop cache (the same trick
+    // the klinked clang consumers use — see clangwalk/build.gradle.kts), and
+    // -rpath/-rpath-link so the test binary loads that .so at runtime (its SONAME
+    // libstdc++.so.6 wins over the bundled one via the rpath). The .so is DISCOVERED at
+    // configure time from `clang++ -print-file-name=libstdc++.so` (a GNU-ld linker
+    // script/symlink), canonicalized to the real shared object — host-portable, not
+    // hardcoded. This is ENTIRELY under the property guard: the default
+    // `./gradlew :featuregen:nativeTest` never enters this block, so the standard test
+    // link path is untouched (it keeps using the bundled libstdc++ against the committed
+    // libclang krapped/ bindings). Post-flip the default consumer link will target the
+    // system libstdc++ wholesale — consistent with main becoming LLVM-mandatory once
+    // `--frontend=cpp` is the default.
+    val systemStdcxxSo: File = run {
+        val proc = ProcessBuilder("clang++", "-print-file-name=libstdc++.so")
+            .redirectErrorStream(true).start()
+        val out = proc.inputStream.readBytes().toString(Charsets.UTF_8).trim()
+        proc.waitFor()
+        File(out).canonicalFile.takeIf { it.isFile }
+            ?: error(
+                "#78: could not resolve the system libstdc++.so from " +
+                    "`clang++ -print-file-name=libstdc++.so` (got: '$out')"
+            )
+    }
+    val systemStdcxxLibDir = systemStdcxxSo.parentFile.absolutePath
+    kotlin {
+        linuxX64("native") {
+            binaries.getTest("DEBUG").linkerOpts(
+                systemStdcxxSo.absolutePath,
+                "--gc-sections",
+                // The system libstdc++.so.6 in turn references NEWER glibc symbols
+                // (pthread_*@GLIBC_2.34 — the libpthread→libc merge, strfromf128@GLIBC_2.26,
+                // __isoc23_*@GLIBC_2.38) that konan's bundled old-sysroot glibc stub doesn't
+                // define, which --no-allow-shlib-undefined (K/N's default) rejects. These
+                // are resolved at RUNTIME by the host glibc (the test runs on this box, the
+                // same toolchain that parsed the bindings), so relax the shlib check.
+                // Crucially this only relaxes undefined refs coming from SHARED LIBRARIES —
+                // the generated libfeaturegen.a archive's own symbols are still fully
+                // checked, so a genuinely missing binding symbol would still fail the link.
+                "--allow-shlib-undefined",
+                "-rpath",
+                systemStdcxxLibDir,
+                "-rpath-link",
+                systemStdcxxLibDir
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Fixes #78 — the last flip prerequisite

Completes the behavioral flip-safety proof: featuregen's **188 tests now RUN green** when built on cpp-front-end bindings.

### Diagnosis (confirmed)
PR #76's harness (`-Pkpp.frontend.featuregen=cpp`) regenerates featuregen's bindings via `--frontend=cpp`; they COMPILE (188/188 sources after #77/#79), but `:featuregen:nativeTest` failed at `linkDebugTestNative`. The cpp front-end parses against the **system libstdc++** (gcc-16), so the faithful generated wrapper references newer-libstdc++ internals — confirmed undefined at link:
- `std::__throw_bad_array_new_length()@GLIBCXX_3.4.29`
- `std::__glibcxx_assert_fail()@GLIBCXX_3.4.30`

K/N's default test link resolves libstdc++ from its bundled gcc-8.3 sysroot (caps at GLIBCXX_3.4.25) → undefined.

### The fix (Approach 1 — linker config, under the existing property guard)
On the cpp-variant test binary's link only:
- **Link the REAL system `libstdc++.so` by ABSOLUTE PATH**, discovered at configure time from `clang++ -print-file-name=libstdc++.so` (canonicalized to the real shared object; host-portable, not hardcoded). Absolute path is required because `-L/-lstdc++` is shadowed by konan's bundled-sysroot `-L` (searched first → old lib → symbols stay undefined).
- **`--gc-sections`** to dead-strip the stale `platform.linux` cinterop cache (the same trick the klinked clang consumers use — `clangwalk/build.gradle.kts`).
- **`--allow-shlib-undefined`** — the system `libstdc++.so.6` in turn references newer glibc symbols (`pthread_*@GLIBC_2.34` from the libpthread→libc merge, `strfromf128@2.26`, `__isoc23_*@2.38`) the old sysroot glibc stub lacks; these resolve at **runtime** against the host glibc. This relaxes only refs coming from **shared libraries** — the generated `libfeaturegen.a` archive's own symbols stay fully checked, so a genuinely missing binding symbol would still fail the link.
- **`-rpath`/`-rpath-link`** so the system `.so` (SONAME `libstdc++.so.6`) loads at runtime.

No parse-sysroot downgrade — the bindings stay maximally correct; this is purely the linker route.

### Result
`GRADLE_OPTS … :featuregen:nativeTest -PenableClang -Pkpp.frontend.featuregen=cpp` → **links + runs 188/188 green**. Behavioral flip-safety fully proven.

### Default path untouched (verified)
`./gradlew :featuregen:kplusplusSync :featuregen:nativeTest` (no flags) → **188/0, zero `krapped/` drift**. The default never enters the `if (kpp.frontend.featuregen == "cpp")` block, so the standard test link keeps using the bundled libstdc++ against the committed libclang bindings. The linkerOpts do NOT apply to the default build.

### Productionization note
This stays REVERSIBLE: no default change, no deletion of libclang/cinterop, `--frontend=cpp` is not the default. Post-flip the default consumer link will target the system libstdc++ wholesale — consistent with main becoming LLVM-mandatory once `--frontend=cpp` is the default (a separate, human-approved step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)