### PR TITLE
build: commit a sane Gradle daemon heap so K/N links stop OOMing (#83)

### DIFF
--- a/docs/clang-runbook.md
+++ b/docs/clang-runbook.md
@@ -106,12 +106,32 @@ normal build picks up the generated bindings.
 
 ## 6. Troubleshooting
 
-- **Out-of-memory during the release link.** The K/N release link is memory-hungry and can
-  OOM the Gradle daemon. Remedy that bit the campaign repeatedly:
+- **Out-of-memory during the release link.** The K/N release link is memory-hungry. Kotlin/
+  Native compiles **and links in-process inside the Gradle daemon**, so what governs OOM is
+  the *daemon* heap — `org.gradle.jvmargs` — and **not** `GRADLE_OPTS`, which does not reach
+  the in-process K/N compiler. That subtlety bit the campaign repeatedly: people exported
+  `GRADLE_OPTS="-Xmx…"` and still OOM'd.
+
+  The repo now commits a sane daemon heap in the root `gradle.properties`:
 
   ```
-  ./gradlew --stop
-  GRADLE_OPTS="-Xmx12g" ./gradlew :clangwalk:runReleaseExecutableKlinker -PenableClang
+  org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+  ```
+
+  6g reliably builds the default (LLVM-free) gate and the gated cpp front-end
+  (`-PenableClang`) — no manual per-build heap bump needed. If a *heavier* gated release
+  link (the cpp/clang modules under `-PenableClang`) still OOMs, raise the heap — edit that
+  line, or add the same key to `~/.gradle/gradle.properties` (a per-user override that keeps
+  the committed default sane for low-RAM contributors):
+
+  ```
+  org.gradle.jvmargs=-Xmx12g -XX:MaxMetaspaceSize=512m
+  ```
+
+  Then re-run, e.g.:
+
+  ```
+  ./gradlew :clangwalk:runReleaseExecutableKlinker -PenableClang
   ```
 
 - **Known issue — `:clangwalk` release generation against LLVM-22.1.6.** There is a current

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,15 @@ group=com.monkopedia.kplusplus
 signing.gnupg.keyName=5B83421E2338B907
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 
+# Gradle daemon heap (#83). Kotlin/Native compiles + LINKS in-process inside the Gradle
+# daemon, so the DAEMON heap below — NOT GRADLE_OPTS, which does not reach the in-process
+# K/N compiler — is what governs OOM on the link. Gradle's stock 512m default OOMs the K/N
+# release link, which previously forced a manual per-build heap workaround. 6g reliably
+# builds the default (LLVM-free) gate AND the gated cpp front-end (-PenableClang) here; the
+# heaviest gated release links (cpp/clang under -PenableClang) may want more — raise this
+# line, or ~/.gradle/gradle.properties, to -Xmx8g/12g. See docs/clang-runbook.md.
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+
 # Phase E step 3 (#47, flip brick B3) — PERSISTENT per-module front-end defaults.
 #
 # These make each binding-generating consumer build OFF the in-tree libclang front-end BY


### PR DESCRIPTION
Fixes #83

## Problem
The repo committed **no** `org.gradle.jvmargs`, so the Gradle daemon ran at its stock ~512m heap. Kotlin/Native compiles **and links in-process inside the Gradle daemon**, so that tiny heap OOMs the K/N release link — forcing a manual per-build heap workaround on every build.

The trap that bit the campaign repeatedly: people reached for `GRADLE_OPTS="-Xmx…"`, which does **not** reach the in-process K/N compiler. Only the **daemon** heap (`org.gradle.jvmargs`) governs the link.

## Fix
Commit a sane daemon heap to root `gradle.properties`:

```
org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
```

**Why 6g (measured, not guessed):** it's the smallest round value that reliably builds *both* gates on this box, while staying sane as a default for low-RAM contributors (this box has 62G; 6g is a contributor default, not the box max). Verified at the committed value with **no** local override (fresh 9.4.1 daemon confirmed up at `-Xmx6g`):

- `GRADLE_OPTS= JAVA_HOME=…java-17-openjdk ./gradlew :krapper_gen:nativeTest` → **272 / 0** (default LLVM-free gate)
- `GRADLE_OPTS= JAVA_HOME=…java-17-openjdk ./gradlew :featuregen:nativeTest -PenableClang` → **188 / 0** (the heavier gated cpp front-end — no manual heap bump needed)

## Runbook
`docs/clang-runbook.md` Troubleshooting now documents:
- the committed heap,
- that K/N links in-process in the daemon so the daemon heap — **not GRADLE_OPTS** — is what matters (the subtlety that bit the campaign),
- how to raise it for the heaviest gated cpp/clang release links: edit the line or add the key to `~/.gradle/gradle.properties` (a per-user override that keeps the committed default contributor-friendly), e.g. `-Xmx12g`.

## Scope
Purely additive: the per-module `kpp.frontend.*` front-end defaults from the flip are untouched — this only adds the `org.gradle.jvmargs` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
