### PR TITLE
krapper_gen: emit forcing-header consumer #include relative to the krapped dir (#86)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -67,9 +67,12 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     private var classes: List<ResolvedElement> = emptyList()
     private val mappings = mutableListOf<MappingService>()
 
-    // Forcing headers recorded by requestInstantiation for the specializations the cpp
-    // front-end forced. Keyed forceName -> file contents. They are re-materialized into the
-    // output dir by writeTo, so the generated wrapper #includes them by a stable, relative,
+    // Forcing specializations recorded by requestInstantiation for the targets the cpp
+    // front-end forced. Keyed forceName -> the instantiation target spec. The header CONTENT
+    // is synthesized later, in writeTo: only then is the output dir known, and the consumer
+    // `#include` in the forcing header must be RELATIVE to that dir (so a regen from any
+    // checkout location produces byte-identical headers — #86). Materialized into the output
+    // dir by writeTo, so the generated wrapper #includes them by a stable, relative,
     // self-contained path (deterministic across runs).
     private val forcingHeaders = linkedMapOf<String, String>()
 
@@ -136,8 +139,9 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         // bytes for its forcing parse, so both paths force the same specialization from
         // the same translation unit.
         val forceName = ForcingHeader.forceName(target)
-        val forcingContent = ForcingHeader.contentFor(target, request.headers)
-        forcingHeaders[forceName] = forcingContent
+        // Record only the target spec; writeTo synthesizes the bytes once it knows the output
+        // dir (the consumer #include must be relative to where the header lands — #86).
+        forcingHeaders[forceName] = target
         // The forcing-parse tree is produced by the cppfrontend binary (which synthesizes
         // the SAME forcing header and parses it with the Clang C++ AST); load it. The
         // forcing header content above is still recorded: writeTo re-materializes it so the
@@ -244,13 +248,21 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         }
         val outputBase = File(output)
         outputBase.mkdirs()
-        // Re-materialize the forcing headers into the output dir so the generated wrapper
-        // #includes them by a stable relative path (no /tmp), and the emitted .cc is
+        // Synthesize + materialize the forcing headers into the output dir so the generated
+        // wrapper #includes them by a stable relative path (no /tmp), and the emitted .cc is
         // self-contained / re-compilable. Deterministic name -> deterministic output.
+        //
+        // The forcing header's OWN consumer `#include` is emitted RELATIVE to the forcing
+        // file's location (the output dir), mirroring how the main .cc relativizes its
+        // consumer includes against cppFile (CppWriter.onGenerate -> File(h).relativeTo).
+        // The forcing header lands in <krapped>/ and is compiled with -I<krapped> (see the
+        // .def compilerOpts), so a path relative to that dir resolves; and because it carries
+        // no absolute host path, a regen from any checkout location is byte-identical (#86).
         syntheticHeaders.clear()
-        for ((forceName, content) in forcingHeaders) {
+        for ((forceName, target) in forcingHeaders) {
             val forcingFile = File(outputBase, "$forceName.h")
-            forcingFile.writeText(content)
+            val relHeaders = request.headers.map { File(it).relativeTo(forcingFile) }
+            forcingFile.writeText(ForcingHeader.contentFor(target, relHeaders))
             syntheticHeaders.add(forcingFile.path)
         }
         val headers = request.headers + syntheticHeaders


### PR DESCRIPTION
## Fixes #86 — forcing-header consumer `#include` was an absolute path

`ForcingHeader` (`:krapper_model`) synthesizes a `KrapperForce_*.h` per template
instantiation: a `KrapperForce_*` struct whose `value` member IS the requested
specialization, `#include`-ing the consumer's own header so the element type
resolves. That consumer `#include` was emitted as the **absolute** path of the
consumer header (`request.headers`, which the gradle plugin passes as
`target.file(h).absolutePath`). So generated forcing headers were **not
byte-reproducible across checkout locations** — a determinism hole (cf. #11/#25).
It surfaced when flip B1 committed cppfrontend's seed and the absolute path broke
portability (hand-relativized in #85).

### The fix — per-module relative include
Defer the forcing-header *content* synthesis from `requestInstantiation` (where
the output dir is unknown) to `writeTo` (where it is), and relativize each
consumer `#include` against the forcing file's own location:

```kotlin
for ((forceName, target) in forcingHeaders) {
    val forcingFile = File(outputBase, "$forceName.h")
    val relHeaders = request.headers.map { File(it).relativeTo(forcingFile) }
    forcingFile.writeText(ForcingHeader.contentFor(target, relHeaders))
    syntheticHeaders.add(forcingFile.path)
}
```

This **mirrors the mechanism the main `.cc` already uses** for its consumer
includes (`CppWriter.onGenerate` → `File(header).relativeTo(cppFile)`). The
forcing header lands in `<krapped>/` and is compiled with `-I<krapped>` (the
`.def` `compilerOpts`), so a path relative to that dir resolves; and because it
carries no absolute host path, the relative form is computed *per module* from
the real `<module>/krapped/` → consumer-header offset:
- cppfrontend: `../include/clang_slice.h`
- featuregen: `../../src/cppMain/include/strings_feature.h`

`forcingHeaders` now stores `forceName → target spec` (not pre-baked content),
since the bytes can only be synthesized once the output dir is known.

### Portability proof
- **featuregen regen:** all 17 `KrapperForce_*.h` now carry the relative
  `../../src/cppMain/include/strings_feature.h`; `grep -rn /home/jmonk` over
  every regenerated `KrapperForce_*.h` is **empty**.
- **cppfrontend seed re-cut:** a fresh regen of cppfrontend's bindings via the
  cpp front-end path produces both committed forcing headers
  (`KrapperForce_std_vector_clang_DeclPtr.h`,
  `KrapperForce_std_vector_clang_CXXBaseSpecifierPtr.h`) **byte-identical** to the
  committed seed (`../include/clang_slice.h`). The generator now natively emits
  what #85 hand-relativized — **no seed update needed**.

### Verification (JDK 17)
- `:featuregen:nativeTest -PenableClang` → **188 / 0** (forcing headers now have
  relative includes and still compile).
- cppfrontend seed forcing headers regen byte-identically (diff = identical).
- `:cppfrontend:featuregenParity` is independently broken by flip B5 (#47): its
  libclang-baseline arm invokes krapper_gen with no `--parsedModel` and aborts
  (`krapper_gen requires --parsedModel`) because the libclang reducer was deleted.
  Pre-existing, unrelated to this change (which touches no libclang/parsedModel
  path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
