### PR TITLE
test(krapper_gen): relocate skip-not-crash + determinism coverage to the self-hosted boundary (#89)

### DIFF
--- a/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/DeterminismTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.ReferencePolicy
+import com.monkopedia.krapper.generator.builders.CppCodeBuilder
+import com.monkopedia.krapper.generator.codegen.CppWriter
+import com.monkopedia.krapper.generator.codegen.File
+import com.monkopedia.krapper.generator.codegen.HeaderWriter
+import com.monkopedia.krapper.generator.codegen.KotlinWriter
+import com.monkopedia.krapper.generator.model.MethodType
+import com.monkopedia.krapper.generator.model.ModelIo
+import com.monkopedia.krapper.generator.model.WrappedArgument
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.const
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referenceTo
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Hermeticity lock at the SELF-HOSTED boundary (issue #89, the #11a determinism guard
+ * relocated).
+ *
+ * The deleted [DeterminismTest] proved that two sequential generations IN ONE PROCESS over
+ * the same input were byte-identical — its load-bearing job was catching a process-global
+ * that leaked across runs (the `WrappedType` intern cache + `rootPackage` in
+ * [GenerationContext], the [DropLedger], and the now-removed libclang cursor->element memo).
+ * It drove that through the in-process libclang parse the self-hosting flip (B5, #88)
+ * deleted, so it can't be ported as-is. Two of its three guarded process-globals survive
+ * the flip (GenerationContext + DropLedger), and determinism of the self-hosted output is
+ * exactly the property the stage-0 bootstrap depends on.
+ *
+ * This test relocates the guard onto the surviving boundary: it runs the real
+ * deserialize -> resolve -> codegen pipeline (the path the self-hosted CLI takes from a
+ * cppfrontend-produced ModelIo, minus the clang COMPILE) TWICE in one process and asserts
+ * byte-identical output. Each run DESERIALIZES A FRESH model from the same ModelIo JSON and
+ * resets the process-scoped state (as `IndexedServiceImpl.init` does) before resolving, so
+ * the only thing carried between runs is leaked global state — if the intern cache,
+ * rootPackage, or DropLedger leaked run #1 into run #2, the output would diverge and this
+ * fails. The model is shaped to MUTATE during resolution (the `value()` overload pair, the
+ * `const Dep&` accessor that pulls `Dep` in under INCLUDE_MISSING) so a non-idempotent reuse
+ * of carried-over state has the best chance to surface.
+ */
+class DeterminismTest {
+
+    private fun method(name: String, returnType: WrappedType, isConst: Boolean = false) =
+        WrappedMethod(name, returnType, MethodType.METHOD).also { it.isConst = isConst }
+
+    // Build the input model (the moral equivalent of the deleted test's parsed header):
+    //   namespace fixture { class Dep { int depValue() const; };
+    //                       class Widget { Widget(); int value() const;
+    //                                      int value(int scale) const; const Dep& dep() const; }; }
+    private fun buildModel(): WrappedTU {
+        val tu = WrappedTU()
+        val ns = WrappedNamespace("fixture").also {
+            tu.addChild(it)
+            it.parent = tu
+        }
+        val depType = WrappedType("fixture::Dep")
+        WrappedClass("Dep").also { dep ->
+            ns.addChild(dep)
+            dep.parent = ns
+            dep.addChild(method("depValue", WrappedType("int"), isConst = true))
+        }
+        WrappedClass("Widget").also { widget ->
+            ns.addChild(widget)
+            widget.parent = ns
+            widget.addChild(
+                WrappedConstructor("Widget", WrappedType("fixture::Widget"), false, true)
+            )
+            widget.addChild(method("value", WrappedType("int"), isConst = true))
+            widget.addChild(
+                method("value", WrappedType("int"), isConst = true).also {
+                    it.addChild(WrappedArgument("scale", WrappedType("int")))
+                }
+            )
+            widget.addChild(method("dep", referenceTo(const(depType)), isConst = true))
+        }
+        return tu
+    }
+
+    // One full deserialize -> resolve -> emit pass into a fresh output dir, returning every
+    // generated file as relativePath -> content. Mirrors `IndexedServiceImpl.writeTo`'s
+    // header/cpp/kotlin emission (the three real writers) but omits the clang COMPILE + .def
+    // (which need the original headers on disk); determinism of the emitted SOURCE is what
+    // the bootstrap reproducibility depends on. Resets the process-scoped state up front,
+    // exactly as `IndexedServiceImpl.init` does before any resolution.
+    private suspend fun generateOnce(modelJson: String): Map<String, String> {
+        DropLedger.reset()
+        GenerationContext.reset(null)
+        val tu = ModelIo.decodeFromString(modelJson)
+        val resolver = ParsedResolver(tu)
+        val classes: List<ResolvedElement> = resolver.findClasses { defaultFilter() }
+            .resolveAll(resolver, ReferencePolicy.INCLUDE_MISSING)
+
+        val outDir = File.createTempDir("krapper_determinism")
+        try {
+            val module = "fixture"
+            val headers = listOf("fixture.h")
+            File(outDir, "$module.h").writeText(
+                CppCodeBuilder().also {
+                    HeaderWriter(it).generate(module, headers, classes)
+                }.toString()
+            )
+            File(outDir, "$module.cc").writeText(
+                CppCodeBuilder(qualifyFunctionPointers = true).also {
+                    CppWriter(File(outDir, "$module.cc"), it).generate(module, headers, classes)
+                }.toString()
+            )
+            val srcDir = File(outDir, "src")
+            KotlinWriter("fixture.internal").generate(srcDir, classes)
+
+            val files = mutableMapOf<String, String>()
+            collect(outDir, outDir, files)
+            return files
+        } finally {
+            outDir.rmR()
+        }
+    }
+
+    private fun collect(dir: File, base: File, into: MutableMap<String, String>) {
+        for (file in dir.listFiles().sortedBy { it.name }) {
+            if (file.isDir()) {
+                collect(file, base, into)
+            } else {
+                // Normalize the per-run output dir (a legitimate per-invocation INPUT) so the
+                // comparison catches real cross-run leaks (stale element content, ordering,
+                // counters) without flagging the expected temp-path difference.
+                into[file.path.substring(base.path.length)] =
+                    file.readText().replace(base.path, "<OUTDIR>")
+            }
+        }
+    }
+
+    @Test
+    fun twoInProcessGenerationsAreByteIdentical(): Unit = runBlocking {
+        val modelJson = ModelIo.encodeToString(buildModel())
+        val first = generateOnce(modelJson)
+        val second = generateOnce(modelJson)
+
+        assertTrue(
+            first.isNotEmpty(),
+            "the generation must produce at least one output file to compare"
+        )
+        assertEquals(
+            first.keys.sorted(),
+            second.keys.sorted(),
+            "the second in-process run produced a different set of files — a process-global " +
+                "leaked across runs (issue #11 hermeticity)"
+        )
+        for ((path, content) in first) {
+            assertEquals(
+                content,
+                second[path],
+                "generated file $path differs between two in-process runs — a process-global " +
+                    "leaked across runs (issue #11 hermeticity)"
+            )
+        }
+    }
+}

--- a/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
@@ -57,7 +57,10 @@ class SkipNotCrashResolveTest {
     private fun intType() = WrappedType("int")
 
     /** A namespaced class wired into a fresh [WrappedTU], ready for resolve. */
-    private fun classInTu(name: String, build: WrappedClass.() -> Unit): Pair<WrappedTU, WrappedClass> {
+    private fun classInTu(
+        name: String,
+        build: WrappedClass.() -> Unit
+    ): Pair<WrappedTU, WrappedClass> {
         val tu = WrappedTU()
         val ns = WrappedNamespace("Skip").also {
             tu.addChild(it)
@@ -139,9 +142,11 @@ class SkipNotCrashResolveTest {
     fun fully_bindable_class_records_no_drops() {
         val (tu, _) = classInTu("Clean") {
             addChild(method("value", intType(), isConst = true))
-            addChild(method("scaled", intType()).also {
-                it.addChild(WrappedArgument("scale", intType()))
-            })
+            addChild(
+                method("scaled", intType()).also {
+                    it.addChild(WrappedArgument("scale", intType()))
+                }
+            )
         }
         val resolved = resolve(tu)
 

--- a/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
@@ -126,6 +126,12 @@ class SkipNotCrashResolveTest {
             drop.reason.isNotBlank(),
             "every drop must carry a reason: $drop"
         )
+        // hasDrops() is exactly the predicate the opt-in --fail-on-drop gate reads
+        // (IndexedServiceImpl.reportDrops): a dropped symbol makes it true.
+        assertTrue(
+            DropLedger.hasDrops(),
+            "a dropped symbol must make --fail-on-drop's hasDrops() gate fire"
+        )
     }
 
     // The ledger does not false-positive: a fully-bindable class drops nothing.
@@ -147,6 +153,10 @@ class SkipNotCrashResolveTest {
             emptyList(),
             DropLedger.drops,
             "a fully-bindable class must drop nothing: ${DropLedger.drops}"
+        )
+        assertFalse(
+            DropLedger.hasDrops(),
+            "a clean run must leave --fail-on-drop's hasDrops() gate false"
         )
     }
 

--- a/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/SkipNotCrashResolveTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.ReferencePolicy
+import com.monkopedia.krapper.generator.model.MethodType
+import com.monkopedia.krapper.generator.model.WrappedArgument
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
+import com.monkopedia.krapper.generator.model.WrappedElement
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Skip-not-crash at the SURVIVING boundary (issue #89).
+ *
+ * The original [SkipNotCrashTest] drove the core invariant — "an unmodelable shape is
+ * DROPPED + logged, it does not crash the run" — by parsing an inline C++ header through
+ * the in-process libclang reducer that the self-hosting flip (B5, #88) deleted. That parse
+ * path is gone, so the test can't be ported as-is. The invariant itself is unchanged and
+ * now lives on the self-hosted pipeline: a [WrappedElement] model (whatever produced it —
+ * the cppfrontend binary in production, a hand-built model here) flows through
+ * resolve+codegen, and any element it can't model must be dropped through the central
+ * [ResolveContext.notifyFailed] choke point into the [DropLedger] rather than throwing.
+ *
+ * These tests build the model directly (no parse) and exercise exactly that resolve-phase
+ * skip-not-crash contract:
+ *   - an unresolvable return type drops the offending method while its bindable siblings
+ *     still resolve, and the drop is ledgered WITH A REASON (RESOLVE phase),
+ *   - a fully-bindable class drops nothing (the ledger does not false-positive), and
+ *   - a const/non-const accessor pair de-dups to the const half (DEDUP phase), ledgered.
+ */
+class SkipNotCrashResolveTest {
+
+    private fun intType() = WrappedType("int")
+
+    /** A namespaced class wired into a fresh [WrappedTU], ready for resolve. */
+    private fun classInTu(name: String, build: WrappedClass.() -> Unit): Pair<WrappedTU, WrappedClass> {
+        val tu = WrappedTU()
+        val ns = WrappedNamespace("Skip").also {
+            tu.addChild(it)
+            it.parent = tu
+        }
+        val cls = WrappedClass(name).also {
+            ns.addChild(it)
+            it.parent = ns
+            it.build()
+        }
+        return tu to cls
+    }
+
+    private fun method(name: String, returnType: WrappedType, isConst: Boolean = false) =
+        WrappedMethod(name, returnType, MethodType.METHOD).also { it.isConst = isConst }
+
+    /**
+     * Reset the process-scoped generation state (as `IndexedServiceImpl.init` does), then
+     * run the real `findClasses { defaultFilter() }.resolveAll(...)` path over [tu] under
+     * [policy] — the exact resolve the self-hosted CLI runs, minus the parse front-end.
+     */
+    private fun resolve(
+        tu: WrappedTU,
+        policy: ReferencePolicy = ReferencePolicy.IGNORE_MISSING
+    ): List<ResolvedClass> = runBlocking {
+        DropLedger.reset()
+        GenerationContext.reset(null)
+        val resolver = ParsedResolver(tu)
+        resolver.findClasses { defaultFilter() }
+            .resolveAll(resolver, policy)
+            .filterIsInstance<ResolvedClass>()
+    }
+
+    private fun ResolvedClass.methodNames() =
+        children.filterIsInstance<ResolvedMethod>().map { it.name }
+
+    // The core invariant: a method whose return type cannot be resolved (under
+    // IGNORE_MISSING) is DROPPED, not fatal. The class still binds with its resolvable
+    // members; the unmodelable method is gone; and the central notifyFailed choke point
+    // ledgers it as a RESOLVE-phase drop with a non-blank reason — so a consumer can tell
+    // "the generator dropped bad()" from "the model never had it".
+    @Test
+    fun unresolvable_return_type_drops_the_method_not_the_run() {
+        val (tu, _) = classInTu("Widget") {
+            addChild(method("value", intType(), isConst = true))
+            // Skip::Missing is declared nowhere — its return type can't resolve.
+            addChild(method("bad", WrappedType("Skip::Missing")))
+        }
+        val resolved = resolve(tu)
+
+        val widget = resolved.single { it.name == "Widget" }
+        assertTrue(
+            "value" in widget.methodNames(),
+            "the bindable method must still resolve: ${widget.methodNames()}"
+        )
+        assertFalse(
+            "bad" in widget.methodNames(),
+            "the unmodelable method must be dropped: ${widget.methodNames()}"
+        )
+        val drop = DropLedger.drops.firstOrNull { "bad" in it.symbol }
+        assertTrue(
+            drop != null && drop.phase == DropPhase.RESOLVE,
+            "the dropped method must be ledgered as a RESOLVE drop: ${DropLedger.drops}"
+        )
+        assertTrue(
+            drop.reason.isNotBlank(),
+            "every drop must carry a reason: $drop"
+        )
+    }
+
+    // The ledger does not false-positive: a fully-bindable class drops nothing.
+    @Test
+    fun fully_bindable_class_records_no_drops() {
+        val (tu, _) = classInTu("Clean") {
+            addChild(method("value", intType(), isConst = true))
+            addChild(method("scaled", intType()).also {
+                it.addChild(WrappedArgument("scale", intType()))
+            })
+        }
+        val resolved = resolve(tu)
+
+        assertTrue(
+            "value" in resolved.single { it.name == "Clean" }.methodNames(),
+            "the bindable class must resolve its members"
+        )
+        assertEquals(
+            emptyList(),
+            DropLedger.drops,
+            "a fully-bindable class must drop nothing: ${DropLedger.drops}"
+        )
+    }
+
+    // The DEDUP skip path: a class declaring both a `const` and a non-`const` overload of
+    // the same accessor (same name + params) is the read-only/mutable halves of ONE logical
+    // accessor. The dedup keeps the const half and drops the non-const one, ledgering the
+    // drop as a DEDUP-phase record — another skip-not-crash decision that must be visible.
+    @Test
+    fun const_overload_duplicate_is_deduped_and_ledgered() {
+        val (tu, _) = classInTu("Accessor") {
+            addChild(method("get", intType(), isConst = false))
+            addChild(method("get", intType(), isConst = true))
+        }
+        val resolved = resolve(tu)
+
+        val accessor = resolved.single { it.name == "Accessor" }
+        assertEquals(
+            listOf("get"),
+            accessor.methodNames().filter { it == "get" || it == "_get" },
+            "the const/non-const pair must collapse to ONE `get`: ${accessor.methodNames()}"
+        )
+        val dedup = DropLedger.drops.firstOrNull { it.phase == DropPhase.DEDUP }
+        assertTrue(
+            dedup != null && "get" in dedup.symbol,
+            "the deduped non-const overload must be ledgered as a DEDUP drop: ${DropLedger.drops}"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #89.

The self-hosting flip (B5, #88) deleted 5 krapper_gen nativeTests because they drove their invariants through the in-process libclang parse it removed. This audits each against current coverage and re-establishes the two CORE invariants that had no explicit assertion left, on the surviving deserialize → resolve → codegen boundary (no parse front-end), built from hand-constructed / `ModelIo`-serialized models.

## Coverage audit

| Deleted test | Invariant | Status |
| --- | --- | --- |
| **ParseTest** (17) | parse-shape decode of C++ constructs | **Confirmed covered** — parse-shape decode is now cppfrontend's `TypeBuilder`/`ModelBuilder` job (its ~100+ construction self-checks + `:cppfrontend:goldenCompare`), and the resulting model→resolve→codegen shapes are asserted by the surviving krapper_gen tests (`CppCodeTests` 83, `CppHeaderTests` 80, `FullKotlinTests` 80, `KotlinCodeTests`) + `:featuregen:nativeTest` 188. Parse-dependent, not re-created. |
| **ReturnShapeTest** (15) | return-style determination (by-value/ptr/ref/STRING/range) | **Confirmed covered** — `ReturnStyle` is computed during resolve; the surviving model→resolve→codegen tests assert the emitted C++/Kotlin that encodes each style, and featuregen exercises by-value/ptr/ref/STRING/range end-to-end across 188 behavioral tests. |
| **ForcingCharacterizationTest** (4) | multi-instantiation forcing | **Confirmed covered** — featuregen forces 17 instantiations (incl. cumulative range-accessor recovery, the path #40 added) through the same `ForcingHeader` the cppfrontend binary synthesizes; 188/0 on the self-hosted front-end. |
| **SkipNotCrashTest** (9) | unmodelable shape DROPS + logs, doesn't crash (core invariant) | **NEW test** — `SkipNotCrashResolveTest` (below). cppfrontend also skips unmodelable shapes at construction and featuregen has dropped members, but there was no explicit *drop-not-crash* assertion on the krapper_gen side after the flip. |
| **DeterminismTest** (1) | two in-process generations byte-identical (#11a hermeticity) | **NEW test** — `DeterminismTest` re-added at the self-hosted boundary (below). The original guarded the (now-deleted) cursor→element memo plus two process-globals that survive the flip. |

## New tests

**`SkipNotCrashResolveTest`** (3) — drives the core skip-not-crash contract through the real `findClasses { defaultFilter() }.resolveAll(...)` path over hand-built models (resets `DropLedger` + `GenerationContext` first, as `IndexedServiceImpl.init` does):
- an unresolvable return type (under `IGNORE_MISSING`) **drops the offending method while its bindable siblings still resolve**, and the drop is ledgered through the central `ResolveContext.notifyFailed` choke point as a `RESOLVE`-phase record **with a reason** — it does not throw;
- a fully-bindable class drops nothing (the ledger does not false-positive);
- a const/non-const accessor pair de-dups to the const half (`DEDUP` phase), ledgered;
- `DropLedger.hasDrops()` — the exact predicate the opt-in `--fail-on-drop` gate reads (`IndexedServiceImpl.reportDrops`) — is asserted true on a drop and false on a clean run (closes the deleted L3 case).

**`DeterminismTest`** (1, the #11a guard relocated) — runs the real `ModelIo.decodeFromString → resolve → emit (HeaderWriter + CppWriter + KotlinWriter)` pipeline TWICE in one process over the same `ModelIo` JSON and asserts byte-identical output. Each run deserializes a FRESH model and resets the process-scoped state, so the only thing carried between runs is leaked global state. This guards the two process-globals the original protected that survive the flip — the `GenerationContext` `WrappedType` intern cache + `rootPackage`, and the `DropLedger` — i.e. reproducibility of the self-hosted output, which the stage-0 bootstrap depends on. (Omits the clang COMPILE + `.def`, which need the original headers on disk; determinism of the emitted SOURCE is the bootstrap property.) **Sanity-checked: temporarily leaking a process-global counter into one emitted file made it go RED, confirming it guards cross-run divergence.**

## Genuine gaps

None left open. The three confirmed-covered invariants are parse-shape/return-style/forcing decode that genuinely moved into cppfrontend + the surviving resolve/codegen + featuregen layers; the two that had no explicit post-flip assertion (skip-not-crash drop, determinism) now do.

## Verify (JDK 17)

- `:krapper_gen:nativeTest` → **276/0** (272 surviving + 4 new: `SkipNotCrashResolveTest` 3, `DeterminismTest` 1).
- `:featuregen:nativeTest -PenableClang` → **188/0** (self-hosted via cppfrontend, no libclang).
- `:krapper_gen:ktlintCheck` → green.
- Determinism test verified to FAIL on an injected cross-run leak, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
