### PR TITLE
krapper_gen: constructor-factory call uses canonical plainDeclaredName (Fixes #81)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -2552,9 +2552,18 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         memScope: Symbol
     ): Symbol = Call(constructorMethod(type), ptr, memScope)
 
+    // CALL the generated `MemScope.<Type>(...)` CONSTRUCTOR factory by its canonical
+    // DECLARED name (`plainDeclaredName`, ignoring the per-file import-alias `remap`),
+    // matching the factory's declaration. The factory is a generated SIBLING function,
+    // not an imported type reference: a remote calling file that aliased `type` via an
+    // import collision would, through `plainName`, emit `<Alias>(...)` — an undeclared
+    // symbol, since the factory is declared under the canonical name regardless of the
+    // caller's alias. Declaration-name == call-name; neither follows the alias. This is
+    // the constructor-factory sibling of the `_Holder` call fix (#75) and the enum/class
+    // declaration fixes (#73), completing the #73/#75/#81 remap-hazard family.
     private fun constructorMethod(type: ResolvedKotlinType) = extensionMethod(
         type.pkg,
-        type.plainName
+        type.plainDeclaredName
     )
 
     private fun KotlinCodeBuilder.generateStringReturn(call: Symbol, free: Boolean = true) {

--- a/krapper_gen/src/nativeTest/kotlin/ConstructorCallRemapTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ConstructorCallRemapTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.builders.buildCode
+import com.monkopedia.krapper.generator.builders.extensionMethod
+import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainDeclaredName
+import com.monkopedia.krapper.generator.resolvedmodel.type.plainName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #81 — the CONSTRUCTOR-factory sibling of #73 (declaration side) and #75 (the
+ * `_Holder` factory call).
+ *
+ * A wrapper class is constructed via a generated `MemScope.<Type>(...)` factory. That
+ * factory is DECLARED once (in the class's own file) under the canonical name. `KotlinWriter`
+ * builds the CALL to it in `constructorMethod` via `extensionMethod(type.pkg, <name>)`. If the
+ * file emitting the call had a same-file import collision and aliased the constructed type
+ * (`clang.attr.Kind` -> `AttrKind`), reading `plainName` there yields the alias, so the call
+ * became `AttrKind(...)` — an undeclared symbol, because the factory is declared as `Kind`.
+ *
+ * The fix mirrors #75: the constructor-factory call uses the canonical `plainDeclaredName`,
+ * which ignores the per-file `remap`. The invariant locked here: a generated SIBLING factory's
+ * name is canonical at BOTH ends. Declaration-name == call-name; neither follows the alias.
+ */
+class ConstructorCallRemapTest {
+
+    /**
+     * Builds the `MemScope.<Type>(...)` constructor-factory call symbol exactly as
+     * `KotlinWriter.constructorMethod` does, then renders it. [factoryName] selects the name
+     * accessor so the test can contrast the fixed (`plainDeclaredName`) path with the pre-fix
+     * (`plainName`) path.
+     */
+    private fun renderConstructorCall(
+        type: ResolvedKotlinType,
+        factoryName: ResolvedKotlinType.() -> String
+    ): String {
+        val symbol = extensionMethod(type.pkg, type.factoryName())
+        return buildCode { symbol.build(this) }
+    }
+
+    @Test
+    fun constructorCallStaysCanonicalUnderAReferenceFileAlias() {
+        val kind = ResolvedKotlinType("clang.attr.Kind", isWrapper = true)
+
+        // No collision yet: both accessors agree, the constructor-factory call is canonical.
+        assertEquals("Kind", renderConstructorCall(kind) { plainDeclaredName })
+
+        // A remote calling file has a same-file import collision and aliases this import;
+        // ImportBlock stamps the alias onto the SHARED instance the constructor call reads.
+        kind.setNameRemap(mapOf("clang.attr.Kind" to "AttrKind"))
+
+        // The fix: the constructor call uses the canonical declared name, so it still names
+        // the factory that was declared canonically — regardless of the calling file's alias.
+        assertEquals("Kind", renderConstructorCall(kind) { plainDeclaredName })
+
+        // Pre-fix the call read `plainName`, which follows the alias — `AttrKind`, an
+        // undeclared symbol. This asserts the exact regression the fix removes.
+        assertEquals("AttrKind", renderConstructorCall(kind) { plainName })
+    }
+}


### PR DESCRIPTION
Fixes #81 — the latent CONSTRUCTOR-factory-call sibling of #73 (declaration side) and #75 (the `_Holder` factory call). This closes the #73/#75/#81 declaration-name-vs-per-file-alias family.

## The bug
`KotlinWriter.constructorMethod` (~line 2555) builds the CALL to a class's generated `MemScope.<Type>(...)` CONSTRUCTOR factory via `extensionMethod(type.pkg, type.plainName)`. `plainName` routes through `mappedName`, which applies the per-file import-alias `remap` (shared mutable state stamped onto the `ResolvedKotlinType` by `ImportBlock.build`). The constructor factory is a generated SIBLING function, not an imported type reference — it is declared under the canonical class name. So a remote calling file that aliased the constructed type via an import collision (`clang.attr.Kind` -> `AttrKind`) would emit `AttrKind(...)`, an undeclared symbol, since the factory is declared as `Kind(...)`. Same bug class as #73/#75, latent today (no featuregen import collision triggers it).

## The fix
The single call-site change, mirroring #75's `_Holder` fix exactly:

```
-    private fun constructorMethod(type: ResolvedKotlinType) = extensionMethod(
-        type.pkg,
-        type.plainName
-    )
+    private fun constructorMethod(type: ResolvedKotlinType) = extensionMethod(
+        type.pkg,
+        type.plainDeclaredName
+    )
```

`plainDeclaredName` (= `qualifyList.last()`, ignoring `remap`) is the canonical declared name. Declaration-name == call-name; neither follows the per-file alias. A comment cites the invariant, consistent with #73/#75. Only the factory-call symbol changed — type references in the args/cast legitimately keep the alias (the #73 distinction).

## Test
`ConstructorCallRemapTest` mirrors `HolderCallRemapTest`: it builds the constructor-factory call symbol exactly as `constructorMethod` does, sets a `remap` aliasing the type, and asserts the call name. Under the alias, the fixed accessor (`plainDeclaredName`) stays canonical `Kind`, while the pre-fix accessor (`plainName`) follows the alias to `AttrKind` — locking the exact regression the fix removes (the accessor-contrast approach the issue accepts when a faithful e2e repro is impractical at unit level).

## Verify (JDK 17)
- `:krapper_gen:nativeTest` → 277/0 (276 + the new test)
- `:krapper_gen:ktlintCheck` → green
- `:featuregen:nativeTest -PenableClang` → 188/0 (no collision, so unchanged — confirms no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
