### PR TITLE
krapper_gen: dedup namespace free functions across forcing passes (#62)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -59,7 +59,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedType
 // re-parse was ALREADY main-bound (keep) or is incidental (drop). Two distinct functions
 // that happen to mangle to the same uniqueCName get different identities here, so a
 // collision can't false-keep an incidental function (which would emit non-compiling Kotlin).
-private val ResolvedMethod.forcingIdentity: String
+internal val ResolvedMethod.forcingIdentity: String
     get() = "$qualified::$name(${args.joinToString(",") { it.type.toString() }})#$uniqueCName"
 
 class IndexedServiceImpl(private val config: KrapperConfig, private val request: IndexRequest) :
@@ -221,10 +221,12 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
             // walk omits. See ResolveContext.forcingTargetKeys.
             forcingTargets = setOf(target)
         )
-        // One entry per class type-key, last copy wins (#60): without this, every
-        // writer received a fresh full copy of each bound class per instantiation
-        // request and the C++ writers emitted a complete wrapper section per copy
-        // (18 sections per class in featuregen). See dedupClassesLastWins.
+        // One entry per class type-key AND per free-function identity, last copy wins
+        // (#60 classes, #62 free functions): without this, every writer received a fresh
+        // full copy of each bound class and each bound namespace free function per
+        // instantiation request and emitted a complete wrapper section per copy (18
+        // sections each in featuregen). Overloads stay distinct (keyed on the full
+        // argument-type signature). See dedupClassesLastWins.
         classes = (
             classes + newClasses.filter {
                 it !is ResolvedMethod || it.forcingIdentity in boundMethodIds

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -42,6 +42,7 @@ import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referen
 import com.monkopedia.krapper.generator.model.type.WrappedTypeReference
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
 import com.monkopedia.krapper.generator.resolvedmodel.type.CastMethod.CAST
 import com.monkopedia.krapper.generator.resolvedmodel.type.CastMethod.NATIVE
 import com.monkopedia.krapper.generator.resolvedmodel.type.CastMethod.POINTED_STRING_CAST
@@ -382,30 +383,41 @@ suspend fun List<WrappedElement>.resolveForcing(
 }
 
 /**
- * Collapse the per-instantiation class copies to ONE entry per class type-key (#60).
+ * Collapse the per-instantiation copies of each accumulating top-level element to ONE entry
+ * (#60 classes, #62 namespace free functions).
  *
- * Each `requestInstantiation` appends a re-resolved copy of every already-bound class
- * (that's how pass-3 recovery upgrades them), so after featuregen's header parse + 17
- * instantiation requests the element list carries 18 copies of each main-bound class.
- * KotlinWriter already collapses these via `associateBy { it.type.toString() }` —
- * last copy wins — but HeaderWriter/CppWriter iterated the raw list, emitting a full
- * wrapper section per copy: 18 identical declarations per symbol in the .h (legal
- * redeclarations) and 18 definitions in the .cc that only compiled because the
- * builder's `Scope.allocateName` `_`-uniquified the colliding names into dead
- * `_timespec_new`/`__timespec_new`/... variants.
+ * Each `requestInstantiation` appends a re-resolved copy of every already-bound class AND
+ * every already-bound namespace free function (that's how pass-3 recovery upgrades them), so
+ * after featuregen's header parse + 17 instantiation requests the element list carries 18
+ * copies of each main-bound class and each main-bound free function. KotlinWriter already
+ * collapses CLASSES via `associateBy { it.type.toString() }` — last copy wins — but
+ * HeaderWriter/CppWriter iterated the raw list, emitting a full wrapper section per copy: 18
+ * identical declarations per symbol in the .h (legal redeclarations) and 18 definitions in
+ * the .cc that only compiled because the builder's `Scope.allocateName` `_`-uniquified the
+ * colliding names into dead `_timespec_new`/`__timespec_new`/... variants. Free functions
+ * escaped #60's class-only dedup entirely: the KotlinWriter's free-function path (one
+ * `<ns>_Functions.kt` per namespace) emits EVERY copy too, so a single `hh::default_handler`
+ * surfaced as `default_handler`, `_default_handler`, `__default_handler`, ... 18 deep.
  *
- * Mirror the KotlinWriter semantics exactly: LAST copy wins (the most recent pass-3
- * re-resolution is the most completely resolved one — cumulative forcing guarantees the
- * final copy carries every recovered range accessor regardless of request order), kept
- * at the key's FIRST position (matching `associateBy`'s LinkedHashMap order, so the
- * Kotlin output is unchanged). Non-class elements pass through untouched.
+ * Mirror the KotlinWriter class semantics exactly: LAST copy wins (the most recent pass-3
+ * re-resolution is the most completely resolved one — cumulative forcing guarantees the final
+ * copy carries every recovered range accessor regardless of request order), kept at the key's
+ * FIRST position (matching `associateBy`'s LinkedHashMap order, so the class Kotlin output is
+ * unchanged). Classes are keyed by type-string; free functions by their full
+ * [forcingIdentity] (qualified name + simple name + C++ argument-type signature + uniqueCName)
+ * so genuine OVERLOADS — same name, different parameters — stay distinct and survive as
+ * separate sections. Any other top-level element passes through untouched.
  */
 fun List<ResolvedElement>.dedupClassesLastWins(): List<ResolvedElement> {
-    val lastByKey = filterIsInstance<ResolvedClass>().associateBy { it.type.toString() }
+    fun ResolvedElement.dedupKey(): String? = when (this) {
+        is ResolvedClass -> "class:$type"
+        is ResolvedMethod -> "fn:$forcingIdentity"
+        else -> null
+    }
+    val lastByKey = mapNotNull { e -> e.dedupKey()?.let { it to e } }.toMap()
     val seen = mutableSetOf<String>()
     return mapNotNull { element ->
-        if (element !is ResolvedClass) return@mapNotNull element
-        val key = element.type.toString()
+        val key = element.dedupKey() ?: return@mapNotNull element
         if (seen.add(key)) lastByKey.getValue(key) else null
     }
 }

--- a/krapper_gen/src/nativeTest/kotlin/FreeFunctionDedupTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/FreeFunctionDedupTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.ReferencePolicy
+import com.monkopedia.krapper.generator.model.MethodType
+import com.monkopedia.krapper.generator.model.WrappedArgument
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedElement
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Free-function dedup invariant (issue #62, the namespace sibling of #60's class dedup).
+ *
+ * Every `requestInstantiation` re-appends a re-resolved copy of each already-bound
+ * top-level element — both classes (#60) and namespace FREE FUNCTIONS (#62). #60's
+ * [dedupClassesLastWins] collapsed only the class copies and passed free functions through
+ * untouched, so featuregen's 17 instantiation requests left 18 copies of every namespace
+ * free function in the element list. Each writer then emitted a full wrapper section per
+ * copy: 18 `.h` declarations + 18 `.cc` definitions (`_`-uniquified into dead variants) and
+ * 18 Kotlin facades (`default_handler`, `_default_handler`, `__default_handler`, ...).
+ *
+ * These tests lock the extended invariant directly on [dedupClassesLastWins]: N forcing
+ * passes of a namespace free function collapse to ONE section, while genuine OVERLOADS
+ * (same name, different parameters) stay distinct.
+ */
+class FreeFunctionDedupTest {
+
+    /** A namespaced free function — a STATIC [WrappedMethod] parented to a [WrappedNamespace]. */
+    private fun freeFn(
+        ns: WrappedNamespace,
+        name: String,
+        argTypes: List<WrappedType> = emptyList()
+    ) = WrappedMethod(name, WrappedType("int"), MethodType.STATIC).also { fn ->
+        argTypes.forEachIndexed { i, type ->
+            fn.addChild(WrappedArgument("a$i", type))
+        }
+        ns.addChild(fn)
+        fn.parent = ns
+    }
+
+    /**
+     * Resolve a TU whose `Ns` namespace holds [build] free functions, returning the
+     * top-level resolved element list (free functions surface as top-level [ResolvedMethod]s,
+     * exactly as the writers consume them). Resets the process-scoped state as
+     * `IndexedServiceImpl.init` does.
+     */
+    private fun resolveFreeFns(build: (WrappedNamespace) -> Unit): List<ResolvedElement> =
+        runBlocking {
+            DropLedger.reset()
+            GenerationContext.reset(null)
+            val tu = WrappedTU()
+            val ns = WrappedNamespace("Ns").also {
+                tu.addChild(it)
+                it.parent = tu
+            }
+            build(ns)
+            val resolver = ParsedResolver(tu)
+            resolver.findClasses { defaultFilter() }
+                .resolveAll(resolver, ReferencePolicy.INCLUDE_MISSING)
+        }
+
+    private val ResolvedMethod.identity: String
+        get() = "$qualified::$name(${args.joinToString(",") { it.type.toString() }})"
+
+    // N forcing passes of the SAME free function collapse to a single section. We simulate
+    // the cumulative `requestInstantiation` append by concatenating the resolved list 18×
+    // (featuregen's header parse + 17 instantiation requests) and running the real dedup.
+    @Test
+    fun repeated_forcing_passes_collapse_a_free_function_to_one_section() {
+        val resolved = resolveFreeFns { ns -> freeFn(ns, "handler") }
+        val handler = resolved.filterIsInstance<ResolvedMethod>().single { it.name == "handler" }
+
+        val forced: List<ResolvedElement> = (1..18).flatMap { resolved }
+        assertEquals(
+            18,
+            forced.filterIsInstance<ResolvedMethod>().count { it.name == "handler" },
+            "sanity: the simulated forcing passes must produce 18 copies before dedup"
+        )
+
+        val deduped = forced.dedupClassesLastWins()
+        val handlersAfter = deduped.filterIsInstance<ResolvedMethod>().filter {
+            it.name == "handler"
+        }
+        assertEquals(
+            1,
+            handlersAfter.size,
+            "18 forcing copies of Ns::handler must dedup to a single section, got " +
+                handlersAfter.map { it.identity }
+        )
+        assertEquals(handler.identity, handlersAfter.single().identity)
+    }
+
+    // Genuine overloads — same name, different parameter types — must NOT collapse into each
+    // other: each distinct C++ signature survives as its own section after dedup.
+    @Test
+    fun overloaded_free_functions_stay_distinct_through_dedup() {
+        val resolved = resolveFreeFns { ns ->
+            freeFn(ns, "combine", listOf(WrappedType("int")))
+            freeFn(ns, "combine", listOf(WrappedType("double")))
+            freeFn(ns, "combine", listOf(WrappedType("int"), WrappedType("int")))
+        }
+        val combinesBefore = resolved.filterIsInstance<ResolvedMethod>()
+            .filter { it.name == "combine" }
+        assertEquals(
+            3,
+            combinesBefore.size,
+            "the three overloads must all resolve: ${combinesBefore.map { it.identity }}"
+        )
+
+        // 18 forcing passes over all three overloads, then dedup.
+        val deduped = ((1..18).flatMap { resolved }).dedupClassesLastWins()
+        val combinesAfter = deduped.filterIsInstance<ResolvedMethod>().filter {
+            it.name == "combine"
+        }
+        assertEquals(
+            3,
+            combinesAfter.size,
+            "each distinct overload signature must survive dedup as its own section, got " +
+                combinesAfter.map { it.identity }
+        )
+        assertEquals(
+            combinesBefore.map { it.identity }.toSet(),
+            combinesAfter.map { it.identity }.toSet(),
+            "dedup must preserve exactly the distinct overload signatures"
+        )
+    }
+
+    // Dedup is order-independent: shuffling the forcing copies yields the same surviving
+    // identities (the bootstrap reproducibility property #60/#62 depend on).
+    @Test
+    fun dedup_is_order_independent() {
+        val resolved = resolveFreeFns { ns ->
+            freeFn(ns, "handler")
+            freeFn(ns, "combine", listOf(WrappedType("int")))
+            freeFn(ns, "combine", listOf(WrappedType("double")))
+        }
+        fun survivors(list: List<ResolvedElement>) =
+            list.dedupClassesLastWins().filterIsInstance<ResolvedMethod>()
+                .map { it.identity }.toSet()
+
+        val forward = (1..18).flatMap { resolved }
+        val reversed = forward.reversed()
+        assertEquals(survivors(forward), survivors(reversed))
+        assertTrue(survivors(forward).isNotEmpty(), "the model must resolve at least one free fn")
+    }
+}


### PR DESCRIPTION
Fixes #62.

## Problem (still reproduces post-flip)

Namespace FREE FUNCTIONS still emitted one wrapper section per instantiation pass (18×) on the post-flip cpp front-end. #60 (PR #61)'s `dedupClassesLastWins` collapsed only `ResolvedClass` copies and let `ResolvedMethod` (namespace free functions) pass through untouched, so every `requestInstantiation` re-appended a re-resolved copy of each bound free function. The forcing + dedup machinery survived the flip, so the duplication reproduces via the cpp path (`featuregen:kplusplusSync -PenableClang`):

- `featuregen.h`: **18** `hh_default_handler` declarations
- `featuregen.cc`: **18** `default_handler` definitions (`_`-uniquified into dead `_default_handler`/`__default_handler`/... variants)
- `src/hh_Functions.kt`: **18** Kotlin facades — `default_handler`, `_default_handler`, `__default_handler`, ... 18 deep

## Fix

Extend `dedupClassesLastWins` to also collapse top-level `ResolvedMethod`s (namespace free functions), last-wins, mirroring the class semantics. Classes are keyed by type-string; free functions by their full `forcingIdentity` — `qualified::name(arg-type signature)#uniqueCName` — so genuine **OVERLOADS** (same name, different parameters) stay distinct and survive as separate sections. Any other top-level element still passes through untouched. (`forcingIdentity` was made `internal` so the resolver can reuse the exact identity `IndexedServiceImpl` already uses to decide keep-vs-drop.)

## Diff characterization (output shrinks, nothing else)

Regenerated via the cpp front-end and diffed against a parent-commit regen. Only the 6 free-function-related artifacts differ; **zero added lines**, all deletions:

| | baseline | fixed |
|---|---|---|
| `featuregen.h` `hh_default_handler` decls | 18 | **1** |
| `featuregen.cc` `default_handler` defs | 18 | **1** |
| `hh_Functions.kt` facades | 18 | **1** (clean `default_handler`) |
| `std_Functions.kt` `abs` sections | 90 (5 overloads × 18) | **5** (overloads preserved) |
| `std_Functions.kt` total funcs | 241 | 37 |

Overloads are NOT collapsed into each other (`abs` keeps its 5 distinct C++ signatures; the two that share a Kotlin spelling stay `_`-disambiguated by the writer as before). No class `.kt`, and no non-free-function section, changed.

## Stability

Two sequential `kplusplusSync -PenableClang` runs produce byte-identical generated sources.

## Tests

New `FreeFunctionDedupTest` (krapper_gen nativeTest) locks the invariant directly on `dedupClassesLastWins`:
- N (=18) forcing passes of a namespace free function collapse to ONE section
- genuine overloads (same name, distinct parameter types) survive as separate sections
- dedup is order-independent (forward vs reversed copy order → same survivors)

## Verify

- `:krapper_gen:nativeTest` → **280/0** (was 277; +3 new), `:krapper_gen:ktlintCheck` clean
- `:featuregen:nativeTest -PenableClang` → **188/0** on the new (smaller) baseline
- `:cppfrontend:handoffGenerate -PenableClang` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
