### PR TITLE
plugin+tools: thread headerDirectory(...) as -I into the cpp front-end pipeline (#99)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -72,10 +72,13 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             // -PenableClang); the default path never references it. This replaces the old
             // per-module manual `dependsOn(":cppfrontend:featuregenCppBindings")` wiring —
             // ANY module flipped to cpp now self-wires the front-end build generically.
-            if (target.findProperty("kpp.frontend.${target.name}") == "cpp" &&
-                target.rootProject.findProject(":cppfrontend") != null
-            ) {
-                it.dependsOn(":cppfrontend:linkReleaseExecutableKlinker")
+            // resolveCppFrontend covers BOTH the sibling layout (featuregen/cppfixture) and
+            // the included-build layout (the standalone v8 example, where cppfrontend lives in
+            // the kplusplus build pulled in via includeBuild) — its link task is null when
+            // clang isn't enabled, in which case the doLast fails fast with the -PenableClang
+            // guidance.
+            if (target.findProperty("kpp.frontend.${target.name}") == "cpp") {
+                resolveCppFrontend(target).first?.let { ct -> it.dependsOn(ct) }
             }
             val krappedDir = krappedDirFor(target)
             val manifestFile = File(krappedDir, "requested.txt")
@@ -272,18 +275,17 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         krappedDir: File,
         kexe: File
     ) {
-        val cppfrontendProject = target.rootProject.findProject(":cppfrontend")
-            ?: throw GradleException(
-                "kplusplusSync[$moduleName]: -Pkpp.frontend.$moduleName=cpp but :cppfrontend " +
-                    "is not in this build. The cpp front-end needs the LLVM-gated modules — " +
-                    "build with -PenableClang (or -PllvmConfig=<path-to-llvm-config>)."
-            )
-        val cppBinary = cppfrontendProject.layout.buildDirectory
-            .file("bin/klinker/cppfrontendRelease/cppfrontend").get().asFile
+        // Resolve the cppfrontend binary across BOTH layouts (sibling project / included
+        // build) — see resolveCppFrontend. A non-existent binary means clang isn't enabled
+        // (cppfrontend is LLVM-gated and then in neither build), so guide to -PenableClang.
+        val cppBinary = resolveCppFrontend(target).second
         if (!cppBinary.exists()) {
             throw GradleException(
-                "kplusplusSync[$moduleName]: cppfrontend binary not found at $cppBinary — the " +
-                    "sync should depend on :cppfrontend:linkReleaseExecutableKlinker."
+                "kplusplusSync[$moduleName]: -Pkpp.frontend.$moduleName=cpp but the cppfrontend " +
+                    "binary was not found at $cppBinary. The cpp front-end needs the LLVM-gated " +
+                    "modules — build with -PenableClang (or -PllvmConfig=<path-to-llvm-config>); " +
+                    "in a standalone consumer that pulls kplusplus in via includeBuild, the flag " +
+                    "must reach that included build too."
             )
         }
         val headers = ext?.headers.orEmpty()
@@ -300,6 +302,11 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // single-header, so the primary header is the parse root.
         val headerPath = target.file(headers.first()).absolutePath
         val std = ext?.cppStandard ?: DEFAULT_CPP_STANDARD
+        // The module's `kplusplus { headerDirectory(...) }` roots, resolved to absolute paths.
+        // These must reach BOTH the cpp parse (so the front-end's clang sees them) AND the
+        // krapper_gen wrapper compile (so its quote-includes resolve) — a header dropped on
+        // either side aborts the wrapper compile (exit 134) on cross-directory includes.
+        val includeDirs = ext?.headerDirectories.orEmpty().map { target.file(it).absolutePath }
 
         // The worklist is the SAME union kplusplusSync's libclang path uses: the
         // compiler-written manifest (ALWAYS at <projectDir>/krapped/requested.txt — the FIR
@@ -314,10 +321,13 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val requested = (manifestSpecs + ext?.instantiations.orEmpty()).distinct().sorted()
 
         val modelsDir = File(krappedDir, "cpp-models").apply { mkdirs() }
+        // The include dirs ride the trailing args as -I tokens; cppfrontend partitions them
+        // from the type specs (which never start with -I) — see --parity-emit / parityEmit.
+        val includeFlags = includeDirs.map { "-I$it" }
         fun emit(specs: List<String>): String {
             val proc = ProcessBuilder(
                 listOf(cppBinary.absolutePath, "--parity-emit", modelsDir.absolutePath, headerPath, std) +
-                    specs
+                    includeFlags + specs
             ).redirectErrorStream(true).start()
             val out = proc.inputStream.readBytes().toString(Charsets.UTF_8)
             val exit = proc.waitFor()
@@ -387,6 +397,11 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             for (h in ext.headers) {
                 args += "--header"
                 args += target.file(h).absolutePath
+            }
+            // headerDirectory(...) roots -> krapper_gen's wrapper-compile -I set.
+            for (dir in includeDirs) {
+                args += "--include-dir"
+                args += dir
             }
             for (lib in ext.libraries) {
                 args += "-l"
@@ -511,6 +526,40 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         return null to target.rootProject.file(
             "krapper_gen/build/bin/native/debugExecutable/krapper_gen.kexe"
         )
+    }
+
+    /**
+     * Find the :cppfrontend release binary and its link task — the SAME two layouts
+     * resolveKrapperGen handles, because a cpp-front-end module can equally be a sibling
+     * project (featuregen/cppfixture in the kplusplus build) or a consumer that pulls
+     * kplusplus in via `includeBuild("../../")` (the standalone v8 example). In the included
+     * case `rootProject.findProject(":cppfrontend")` is null — cppfrontend lives in the OTHER
+     * build — so we resolve its task + binary through `gradle.includedBuilds`.
+     *
+     * cppfrontend is LLVM-gated (`-PenableClang`); when the flag is absent it is in NEITHER
+     * build, so a null binary here means "not enabled". Returns the link task (or null) plus
+     * the binary File; the caller fails fast at execution time if the binary doesn't exist.
+     */
+    private fun resolveCppFrontend(target: Project): Pair<Any?, File> {
+        val relBinary = "cppfrontend/build/bin/klinker/cppfrontendRelease/cppfrontend"
+        val direct = target.rootProject.findProject(":cppfrontend")
+        if (direct != null) {
+            return direct.tasks.findByName("linkReleaseExecutableKlinker") to
+                direct.layout.buildDirectory
+                    .file("bin/klinker/cppfrontendRelease/cppfrontend").get().asFile
+        }
+        for (included in target.gradle.includedBuilds) {
+            val taskRef = try {
+                included.task(":cppfrontend:linkReleaseExecutableKlinker")
+            } catch (_: Throwable) {
+                null
+            }
+            val binary = File(included.projectDir, relBinary)
+            if (taskRef != null || binary.exists()) {
+                return taskRef to binary
+            }
+        }
+        return null to target.rootProject.file(relBinary)
     }
 
     /**

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -332,8 +332,12 @@ fun main(args: Array<String>): Unit = memScoped {
         return@memScoped
     }
     if (args.firstOrNull() == "--parity-emit") {
-        // --parity-emit <dir> <header> <std> [spec...] — Phase D (#46), see parityEmit.
-        val usage = "--parity-emit <dir> <header> <std> [spec...]"
+        // --parity-emit <dir> <header> <std> [-I<dir>...] [spec...] — Phase D (#46), see
+        // parityEmit. The trailing args mix the module's extra include dirs (each a `-I<dir>`
+        // token, threaded by the gradle plugin from `kplusplus { headerDirectory(...) }`) with
+        // the instantiation specs (C++ type strings, which never start with `-I`); parityEmit
+        // partitions them.
+        val usage = "--parity-emit <dir> <header> <std> [-I<dir>...] [spec...]"
         parityEmit(
             args.getOrNull(1) ?: fail(usage),
             args.getOrNull(2) ?: fail(usage),
@@ -1172,14 +1176,24 @@ private fun MemScope.handoffEmit(dir: String) {
  *    parse it, emit <forceName>.json, print `PARITY_MODEL <spec>=<path>` — the line the
  *    gradle task turns into krapper_gen's --forcingModel argument.
  * [std] pins the SAME standard featuregen's sync parses under (krapper_gen's default).
+ *
+ * [trailing] mixes the module's extra include dirs (each a `-I<dir>` token, threaded by the
+ * gradle plugin from `kplusplus { headerDirectory(...) }`) with the instantiation specs; we
+ * partition on the `-I` prefix (C++ type specs never start with `-I`) and fold the include
+ * flags into the driver args so cross-directory quote-includes resolve in BOTH the base and
+ * per-spec forcing parses — exactly as krapper_gen's wrapper compile sees them.
  */
 private fun MemScope.parityEmit(
     dir: String,
     headerPath: String,
     std: String,
-    specs: List<String>
+    trailing: List<String>
 ) {
-    val parseArgs = "-std=$std\n-resource-dir=" + commandOutput("clang++ -print-resource-dir")
+    val (includeFlags, specs) = trailing.partition { it.startsWith("-I") }
+    val parseArgs = (
+        listOf("-std=$std", "-resource-dir=" + commandOutput("clang++ -print-resource-dir")) +
+            includeFlags
+        ).joinToString("\n")
     if (specs.isEmpty()) {
         val baseTu = parseToWrappedTU(readFile(headerPath), "parity_base.cc", parseArgs)
         val path = "$dir/base_model.json"

--- a/example/kotlin_project/build.gradle.kts
+++ b/example/kotlin_project/build.gradle.kts
@@ -83,6 +83,10 @@ kplusplus {
     header("../include/v8-combined.h")
     headerDirectory("../include/")
     library("../libv8_monolith.a")
+    // v8 needs C++17 (the default is c++14); the cpp front-end parses AND the wrapper
+    // compiles under this standard. The frontend flip itself is in gradle.properties
+    // (kpp.frontend.kotlin_project=cpp), built with -PenableClang.
+    cppStandard = "c++17"
 
     fixup {
         // v8::ScriptOrigin::options returns a stale `const ScriptOriginOptions*`
@@ -100,13 +104,29 @@ kplusplus {
         stripConstFromReturnType("v8::ScriptOrigin<")
         stripConstFromReturnType("v8::Location<")
 
-        // Three v8 methods generate uncompilable C++ wrappers for this
-        // particular instantiation; drop them by their uniqueCName.
-        removeMethod("_v8_Persistent_v8_Value_new")
+        // v8 methods that generate uncompilable C++ wrappers; drop them by uniqueCName.
+        // v8::Persistent<v8::Value> is NonCopyable (NonCopyablePersistentTraits::Copy is a
+        // `static_assert(sizeof(S) < 0)`), so neither its copy ctor nor its copy-assignment
+        // may be instantiated. The cpp front-end (brick-1 flip to
+        // -Pkpp.frontend.kotlin_project=cpp) materializes these IMPLICIT special members
+        // parse-dependently — one run surfaces the copy ctor
+        // (`..._new__const_v8_Persistent_and`), another the copy-assignment (`..._op_assign`,
+        // the libclang-era name, still valid) — so drop BOTH to stay robust across parses.
+        removeMethod("v8_Persistent_v8_Value_new__const_v8_Persistent_and")
         removeMethod("v8_Persistent_v8_Value_op_assign")
         removeMethod(
             "v8_platform_tracing_TraceWriter_create_system_instrumentation_trace_writer"
         )
+
+        // v8::Maybe<void> is an explicit specialization carrying only IsJust/IsNothing/==/!=,
+        // but the front-end projects the primary Maybe<T> member set onto it, so these five
+        // reference members that don't exist on the void specialization (ToChecked/Check/To/
+        // FromJust/FromMaybe — the last also takes a `void` value). Drop them.
+        removeMethod("v8_Maybe_void_to_checked")
+        removeMethod("v8_Maybe_void_check")
+        removeMethod("v8_Maybe_void_to")
+        removeMethod("v8_Maybe_void_from_just")
+        removeMethod("v8_Maybe_void_from_maybe")
 
         // std::unique_ptr<>'s auto-generated `get()` doesn't model ownership
         // properly; this fixup emits a custom one per instantiation.

--- a/example/kotlin_project/gradle.properties
+++ b/example/kotlin_project/gradle.properties
@@ -1,2 +1,5 @@
 kotlin.native.cacheKind.linuxX64=none
 org.gradle.jvmargs=-Xmx4096m
+# Self-host the v8 bindings through the cpp front-end (built on generated libclang-cpp
+# bindings). Requires -PenableClang on the command line (the front-end is LLVM-gated).
+kpp.frontend.kotlin_project=cpp

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -127,6 +127,13 @@ class KrapperGen : CliktCommand() {
             "(borrowed/opaque) rather than being recursively bound. May be combined with " +
             "--only-file. When neither is set, DefaultFilter binds every non-std class."
     ).multiple()
+    val includeDir by option(
+        "--include-dir",
+        help = "Extra include directory (-I) for the generated C++ wrapper compile, from the " +
+            "module's `kplusplus { headerDirectory(...) }`. Repeatable. Folded in alongside the " +
+            "header files' own parent dirs so cross-directory quote-includes in the wrapper " +
+            "compile resolve the same way the cpp front-end's parse did."
+    ).multiple()
     val onlyFile by option(
         "--only-file",
         help = "Like --only, but reads the allowlist from a file (one fully-qualified " +
@@ -216,7 +223,15 @@ class KrapperGen : CliktCommand() {
                     strictDiagnostics = strictDiagnostics
                 )
             )
-            val indexService = service.index(IndexRequest(header, library))
+            // Augment the request's include dirs (default = header parents) with the module's
+            // explicit `headerDirectory(...)` roots passed via --include-dir; these reach the
+            // wrapper compile through CompileFlags so its quote-includes resolve.
+            val baseRequest = IndexRequest(header, library)
+            val indexService = service.index(
+                baseRequest.copy(
+                    headerDirectories = (baseRequest.headerDirectories + includeDir).distinct()
+                )
+            )
             try {
                 // v2 flow: when both --header and --instantiate are present, parse
                 // the headers first (filterAndResolve) then layer the requested

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -299,7 +299,10 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
                 "$pkg.internal",
                 config.moduleName!!,
                 headers,
-                request.libraries
+                request.libraries,
+                // The module's headerDirectory(...) roots, so the cinterop .def's
+                // compilerOpts carry the same -I set the wrapper compile needs.
+                request.headerDirectories
             )
         )
         Log.i("Compiling native wrapper library")
@@ -310,7 +313,10 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         ).compile(
             cppFile,
             headers,
-            request.libraries
+            request.libraries,
+            // Cross-directory quote-includes (e.g. v8's cppgc/*.h reaching v8config.h)
+            // resolve only if the module's headerDirectory(...) roots are on -I.
+            request.headerDirectories
         )
         Log.i("Generating Kotlin bindings")
         val srcDir = File(outputBase, "src")

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CompileFlags.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CompileFlags.kt
@@ -18,7 +18,12 @@ package com.monkopedia.krapper.generator.codegen
 class CompileFlags(
     private val headers: List<String>,
     libraries: List<String>,
-    linkStatics: Boolean = false
+    linkStatics: Boolean = false,
+    // Extra include dirs from the module's `kplusplus { headerDirectory(...) }` (threaded by
+    // the gradle plugin via krapper_gen's --include-dir). The header files' own parents are
+    // always on -I; these add cross-directory roots so quote-includes in the wrapper compile
+    // resolve the same way the cpp front-end's parse did.
+    private val extraIncludeDirs: List<String> = emptyList()
 ) {
 
     init {
@@ -71,7 +76,8 @@ class CompileFlags(
     val includeDirs: String?
         get() {
             if (headerFiles.isEmpty()) return null
-            return headerFiles.map { it.parent }.toSet().joinToString(" ") { "-I${it.path}" } +
+            val headerParents = headerFiles.map { it.parent.path }
+            return (headerParents + extraIncludeDirs).toSet().joinToString(" ") { "-I$it" } +
                 " -DV8_COMPRESS_POINTERS"
         }
 }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CppCompiler.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CppCompiler.kt
@@ -24,8 +24,19 @@ class CppCompiler(
     private val cppStandard: String = "c++14"
 ) {
 
-    fun compile(cppFile: File, header: List<String>, library: List<String>) {
-        val flags = CompileFlags(header, library, linkStatics = true)
+    fun compile(
+        cppFile: File,
+        header: List<String>,
+        library: List<String>,
+        // Extra -I roots from the module's headerDirectory(...); see CompileFlags.
+        extraIncludeDirs: List<String> = emptyList()
+    ) {
+        val flags = CompileFlags(
+            header,
+            library,
+            linkStatics = true,
+            extraIncludeDirs = extraIncludeDirs
+        )
         // The wrapper compile must use the same standard as the libclang parse,
         // or C++17/20 types (std::string_view, char8_t) parse but fail to compile.
         val command = "$compiler -std=$cppStandard -c -fPIE -o ${outputFile.path} " +

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/DefWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/DefWriter.kt
@@ -28,11 +28,14 @@ class DefWriter(private val namer: NameHandler) {
         pkg: String,
         moduleName: String,
         headers: List<String>,
-        libraries: List<String>
+        libraries: List<String>,
+        // Extra -I roots from the module's headerDirectory(...); see CompileFlags.
+        extraIncludeDirs: List<String> = emptyList()
     ): String = buildString {
         val flags = CompileFlags(
             listOf(File(outputBase, "$moduleName.h").path),
-            libraries + File(outputBase, "lib$moduleName.a").path
+            libraries + File(outputBase, "lib$moduleName.a").path,
+            extraIncludeDirs = extraIncludeDirs
         )
         appendLine("headers = ${flags.headerFiles.joinToString(" ") { it.name }}")
         flags.includeDirs?.let {


### PR DESCRIPTION
## The gap

A module's `kplusplus { headerDirectory("../include/") }` include dirs were **dropped** on the cpp front-end path. Today only `-I<krappedDir>` reaches the cpp parse and the wrapper compile, so cross-directory quote-includes (e.g. v8's `cppgc/*.h` reaching `v8config.h`) failed and the wrapper compile aborted with **exit 134**.

## The generic fix — two `-I` seams

Mirrored across the parse and the compile so a model parsed against a header set and a wrapper compiled against it agree:

- **`cppfrontend --parity-emit`**: the trailing args now mix `-I<dir>` tokens with the instantiation specs. `parityEmit` partitions on the `-I` prefix (C++ type specs never start with `-I`) and folds the include flags into the `\n`-joined driver args, so cross-directory includes resolve in BOTH the base and the per-spec forcing parses.
- **`krapper_gen --include-dir`** (repeatable): carried on `IndexRequest.headerDirectories` into `CompileFlags.extraIncludeDirs`, so the generated C++ wrapper compile (`CppCompiler`) AND the cinterop `.def` `compilerOpts` (`DefWriter`) get the same `-I` set the front-end parsed under.

The kplusplus gradle plugin resolves `ext.headerDirectories` to absolute paths and threads them into both seams. `resolveCppFrontend()` now locates the `:cppfrontend` binary across **both** layouts — sibling project (featuregen/cppfixture) and **included build** (a standalone consumer pulling kplusplus in via `includeBuild`) — the same way `resolveKrapperGen()` already does; without it the standalone v8 example could not find cppfrontend (it lives in the included build).

This is a generic plugin/tool capability, not a v8 special-case.

## Example wiring

The standalone v8 example (`example/kotlin_project/`) is flipped to the cpp front-end: `gradle.properties` pins `kpp.frontend.kotlin_project=cpp`, `cppStandard = "c++17"`, and its v8 `fixup { }` is updated to the cpp front-end's `uniqueCName` spellings (the `Persistent<v8::Value>` copy ctor/assign — NonCopyable; and `Maybe<void>`'s phantom primary-template methods). Build with `-PenableClang`.

## Verification

- `:featuregen:nativeTest -PenableClang` → **188/0** (the self-hosted parity gate; the generic change does not regress the existing cpp modules).
- example `kplusplusSync -PenableClang` → cpp front-end generates **509 Kotlin binding files** AND the **C++ wrapper COMPILES (no exit 134)**. The full Kotlin/Native link against the 62 MB v8 monolith is **brick 3** and out of scope here.

### Note for reviewers

The `Persistent<v8::Value>` NonCopyable special members surface **parse-dependently** under the cpp front-end — one parse materializes the implicit copy ctor (`..._new__const_v8_Persistent_and`), another the copy-assignment (`..._op_assign`) — so the example drops **both** to stay robust across parses. Flagging this implicit-special-member non-determinism as a follow-up observation; it does not affect this brick's result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
