### PR TITLE
example(v8): LINK + RUN the hello-world against the 62MB monolith (#99)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -109,6 +109,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 it.inputs.property("instantiations", e.instantiations.sorted())
                 it.inputs.property("referencePolicy", e.referencePolicy ?: "")
                 it.inputs.property("cppStandard", e.cppStandard ?: "")
+                it.inputs.property("noRtti", e.noRtti)
                 it.inputs.property("rootPackage", e.rootPackage ?: "")
                 it.inputs.property("only", e.only.sorted())
                 it.inputs.property("onlyFile", e.onlyFile ?: "")
@@ -380,6 +381,9 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         ext?.rootPackage?.let {
             args += "--root-package"
             args += it
+        }
+        if (ext?.noRtti == true) {
+            args += "--no-rtti"
         }
         for (spec in requested) {
             args += "--instantiate"

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
@@ -64,6 +64,16 @@ open class KPlusPlusExtension {
     var cppStandard: String? = null
 
     /**
+     * The target C++ library is built `-fno-rtti` (e.g. v8's monolith) and exports no
+     * `typeinfo` symbols. Forwarded to krapper_gen as `--no-rtti`: the generated generic
+     * `dynamic_cast<D*>` down-cast helpers (`Base.asDerived()`) would reference a missing
+     * `typeinfo for Derived` and fail to LINK, so they are skipped (only RTTI-free LLVM
+     * `classof` down-casts survive). Default false (RTTI-on library keeps the generic
+     * checked down-casts).
+     */
+    var noRtti: Boolean = false
+
+    /**
      * Root Kotlin package for the generated bindings (e.g. "com.acme.app").
      * Forwarded to krapper_gen as `--root-package`; every binding's package
      * becomes `<rootPackage>.<C++ namespace path>` (so `std::vector<int>` lands

--- a/example/kotlin_project/build.gradle.kts
+++ b/example/kotlin_project/build.gradle.kts
@@ -35,6 +35,32 @@ repositories {
     mavenCentral()
 }
 
+// ---- v8 brick 3 (#99): LINK the executable against the system libstdc++ ----
+// PORT of featuregen's #78 recipe (see featuregen/build.gradle.kts). The cpp front-end
+// (kpp.frontend.kotlin_project=cpp) parses v8 against the SYSTEM libstdc++ (gcc-16 here),
+// so the faithful generated wrapper references newer-libstdc++ internals that K/N's
+// BUNDLED gcc-8.3 sysroot (caps at GLIBCXX_3.4.25) cannot resolve. The system libstdc++
+// HAS those symbols and is backward-ABI-compatible, so point K/N's own linker at the REAL
+// system libstdc++.so by ABSOLUTE PATH (NOT -lstdc++ — konan's bundled-sysroot -L is
+// searched first, so `-lstdc++` would shadow to the OLD lib and the newer symbols would
+// stay undefined; an absolute path can't be shadowed by search order). The .so is
+// DISCOVERED at configure time from `clang++ -print-file-name=libstdc++.so` (a GNU-ld
+// linker script/symlink), canonicalized to the real shared object — host-portable, not
+// hardcoded. This is the SAME mechanism clangwalk/cppfrontend/featuregen already use for
+// their klinked binaries; here it is applied to the example's EXECUTABLE binary.
+val systemStdcxxSo: File = run {
+    val proc = ProcessBuilder("clang++", "-print-file-name=libstdc++.so")
+        .redirectErrorStream(true).start()
+    val out = proc.inputStream.readBytes().toString(Charsets.UTF_8).trim()
+    proc.waitFor()
+    File(out).canonicalFile.takeIf { it.isFile }
+        ?: error(
+            "#99: could not resolve the system libstdc++.so from " +
+                "`clang++ -print-file-name=libstdc++.so` (got: '$out')"
+        )
+}
+val systemStdcxxLibDir = systemStdcxxSo.parentFile.absolutePath
+
 kotlin {
     // Determine host preset.
     val hostOs = System.getProperty("os.name")
@@ -56,7 +82,35 @@ kotlin {
     hostTarget.apply {
         binaries {
             klinkedExecutable {
-                compilerOpts("-lstdc++", "-lm", "-lpthread")
+                // The v8 monolith link itself comes from the kplusplus { library(...) }
+                // entry below. Here we add the system-libstdc++ link recipe (see the
+                // block above the `kotlin {` for the full WHY): the REAL libstdc++.so by
+                // ABSOLUTE PATH (replaces -lstdc++, which would shadow to konan's old
+                // bundled lib), plus dead-strip + shlib-undefined relaxation + rpath.
+                linkerOpts(
+                    systemStdcxxSo.absolutePath,
+                    // Dead-strip the stale platform.linux cinterop cache (K/N emits one
+                    // section per wrapper for exactly this) — the same trick the klinked
+                    // clang consumers use (see clangwalk/build.gradle.kts).
+                    "--gc-sections",
+                    // The system libstdc++.so.6 in turn references NEWER glibc symbols
+                    // (pthread_*@GLIBC_2.34, __isoc23_*@GLIBC_2.38, …) that konan's bundled
+                    // old-sysroot glibc stub doesn't define; they are resolved at RUNTIME by
+                    // the host glibc. This ONLY relaxes undefined refs coming from SHARED
+                    // LIBRARIES — the generated wrapper archive's own symbols (and the v8
+                    // monolith archive) stay fully checked, so a genuinely missing binding
+                    // symbol still fails the link.
+                    "--allow-shlib-undefined",
+                    // Load the system .so at runtime: its SONAME libstdc++.so.6 wins over
+                    // the bundled one via the rpath.
+                    "-rpath",
+                    systemStdcxxLibDir,
+                    "-rpath-link",
+                    systemStdcxxLibDir
+                )
+                // -lstdc++ REMOVED (it shadowed to the old bundled lib — the exact #78 bug);
+                // the absolute-path .so above replaces it. Keep -lm/-lpthread.
+                compilerOpts("-lm", "-lpthread")
                 runTask()
             }
         }
@@ -87,6 +141,14 @@ kplusplus {
     // compiles under this standard. The frontend flip itself is in gradle.properties
     // (kpp.frontend.kotlin_project=cpp), built with -PenableClang.
     cppStandard = "c++17"
+
+    // v8 brick 3 (#99): the v8 monolith is built `-fno-rtti`, so it exports no `typeinfo`
+    // symbols. Without this, the generated generic `dynamic_cast<D*>` down-cast helpers
+    // (e.g. TracingController.asTracingController(), ExternalStringResourceBase.as*()) emit
+    // `undefined reference to typeinfo for v8::...` at LINK time. noRtti skips those generic
+    // checked down-casts (none are on the hello-world path); RTTI-free LLVM `classof`
+    // down-casts, if any, are unaffected.
+    noRtti = true
 
     fixup {
         // v8::ScriptOrigin::options returns a stale `const ScriptOriginOptions*`
@@ -127,6 +189,42 @@ kplusplus {
         removeMethod("v8_Maybe_void_to")
         removeMethod("v8_Maybe_void_from_just")
         removeMethod("v8_Maybe_void_from_maybe")
+
+        // v8 brick 3 (#99): these methods generate Kotlin bindings that DON'T COMPILE
+        // (brick 1 only proved the C++ WRAPPER compiles; brick 3 is the first to compile +
+        // link the Kotlin). They fall into two latent codegen-bug families the v8 surface
+        // exposes; none are on the hello-world path, so drop them by uniqueCName (the same
+        // mechanism used above for the genuinely-uncompilable v8 wrappers). The bug families
+        // are filed as follow-ups for krapper_gen to fix at the source:
+        //
+        // Family 1 — OUT-POINTER PARAM modeled as a value: a `T* out` / `T& out` parameter
+        // (enum*, size_t&, uint64_t*) is bound as a by-value param, so the call passes a
+        // scalar where the extern's `CValuesRef<...>` pointer is expected.
+        removeMethod("v8_Maybe_v8_PropertyAttribute_to")              // Maybe::To(PropertyAttribute* out)
+        removeMethod("v8_String_get_external_string_resource_base")   // String::GetExternalStringResourceBase(Encoding* out)
+        removeMethod("v8_Isolate_get_code_range")                     // Isolate::GetCodeRange(void**, size_t*)
+        removeMethod("v8_Isolate_get_embedded_code_range")            // Isolate::GetEmbeddedCodeRange(void**, size_t*)
+        removeMethod("v8_platform_tracing_TraceBufferChunk_add_trace_event") // TraceBufferChunk::AddTraceEvent(size_t& index)
+        removeMethod("v8_ValueSerializer_Delegate_reallocate_buffer_memory") // Delegate::ReallocateBufferMemory(..., size_t* actual)
+        //
+        // Family 2 — REFERENCE-RETURN of a value-reduced type: an `operator|=` / `operator&=`
+        // / `operator^=` returning `T&` (where T reduces to a Kotlin enum or UByte) is bound
+        // as a by-value return, but the extern returns the reference as a pointer, so the
+        // generated body feeds a CPointer into `fromValue(Int)` / a UByte slot. These are the
+        // bitmask compound-assignment operators that leak in from libstdc++ <ios> (std::byte
+        // and the _Ios_* flag types) — pure transitive-include noise, unused by the example.
+        removeMethod("std_operator_oreq")   // std::byte& operator|=
+        removeMethod("std_operator_andeq")  // std::byte& operator&=
+        removeMethod("std_operator_xoreq")  // std::byte& operator^=
+        removeMethod("std_operator_oreq__std__Ios_Fmtflags_and_std__Ios_Fmtflags")
+        removeMethod("std_operator_andeq__std__Ios_Fmtflags_and_std__Ios_Fmtflags")
+        removeMethod("std_operator_xoreq__std__Ios_Fmtflags_and_std__Ios_Fmtflags")
+        removeMethod("std_operator_oreq__std__Ios_Openmode_and_std__Ios_Openmode")
+        removeMethod("std_operator_andeq__std__Ios_Openmode_and_std__Ios_Openmode")
+        removeMethod("std_operator_xoreq__std__Ios_Openmode_and_std__Ios_Openmode")
+        removeMethod("std_operator_oreq__std__Ios_Iostate_and_std__Ios_Iostate")
+        removeMethod("std_operator_andeq__std__Ios_Iostate_and_std__Ios_Iostate")
+        removeMethod("std_operator_xoreq__std__Ios_Iostate_and_std__Ios_Iostate")
 
         // std::unique_ptr<>'s auto-generated `get()` doesn't model ownership
         // properly; this fixup emits a custom one per instantiation.

--- a/example/kotlin_project/src/nativeMain/kotlin/Main.kt
+++ b/example/kotlin_project/src/nativeMain/kotlin/Main.kt
@@ -1,10 +1,15 @@
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
+import platform.posix.memset
 import v8.Context.Companion.New
-import v8.DeserializeInternalFieldsCallback.Companion.DeserializeInternalFieldsCallback
+import v8.DeserializeInternalFieldsCallback
+import v8.DeserializeInternalFieldsCallback.Companion.DeserializeInternalFieldsCallback_Holder
 import v8.HandleScope.Companion.HandleScope
 import v8.Isolate.Companion.New
 import v8.MaybeLocal__ObjectTemplate.Companion.MaybeLocal__ObjectTemplate
 import v8.MaybeLocal__Value.Companion.MaybeLocal__Value
+import v8.NewStringType
 import v8.Script.Companion.Compile
 import v8.String.Companion.NewFromUtf8
 import v8.V8.Companion.Dispose
@@ -17,8 +22,12 @@ import v8.arrayBuffer.Allocator.Companion.NewDefaultAllocator
 import v8.context.Scope.Companion.Scope
 import v8.isolate.CreateParams.Companion.CreateParams
 import v8.isolate.Scope.Companion.Scope
+import v8.platform.IdleTaskSupport
+import v8.platform.InProcessStackDumping
 import v8.platform.NewSingleThreadedDefaultPlatform
 import v8.string.Utf8Value.Companion.Utf8Value
+import std.Unique_ptr__TracingController
+import std.Unique_ptr__TracingController.Companion.Unique_ptr__TracingController_Holder
 
 /*
  * Copyright 2021 Jason Monk
@@ -36,6 +45,17 @@ import v8.string.Utf8Value.Companion.Utf8Value
  * limitations under the License.
  */
 
+// v8 brick 3 (#99): a `_Holder()` factory only allocates the struct's storage; it does NOT
+// run a C++ constructor. For the two by-value structs we pass to v8 below
+// (std::unique_ptr<TracingController> and DeserializeInternalFieldsCallback) the safe
+// default state is all-zero bits (an empty unique_ptr / a {nullptr, nullptr} callback), and
+// the v8 wrapper consumes them with `std::move(*ptr)` / by copy, so zero the freshly
+// allocated storage before handing it over.
+private fun COpaquePointer.zeroed(size: Int): COpaquePointer {
+    memset(this, 0, size.convert())
+    return this
+}
+
 fun main(args: Array<String>) {
     println("Got args: ${args.size}")
     for (arg in args) {
@@ -45,8 +65,22 @@ fun main(args: Array<String>) {
         println("Executing kotlin")
         InitializeICUDefaultLocation("", "")
         InitializeExternalStartupData("")
-        val platform = NewSingleThreadedDefaultPlatform()
-        InitializePlatform(platform.get())
+        // v8 brick 3 (#99): the cpp front-end does not materialize ENUM-/CLASS-typed default
+        // arguments (only literal ones like `length = -1` survive), so the generated
+        // NewSingleThreadedDefaultPlatform requires all three params that C++ defaults. Pass
+        // the C++ defaults explicitly: kDisabled / kDisabled / an empty TracingController
+        // unique_ptr (zeroed Holder storage — see COpaquePointer.zeroed above).
+        val tracingController = Unique_ptr__TracingController_Holder()
+        tracingController.ptr.zeroed(Unique_ptr__TracingController.size)
+        val platform = NewSingleThreadedDefaultPlatform(
+            IdleTaskSupport.kDisabled,
+            InProcessStackDumping.kDisabled,
+            tracingController
+        )
+        // The generated NewSingleThreadedDefaultPlatform already `.release()`s the
+        // std::unique_ptr<Platform> and returns the raw Platform?, so pass it straight to
+        // InitializePlatform(Platform?) — there is no unique_ptr `.get()` wrapper here.
+        InitializePlatform(platform)
         Initialize()
 
         val createParams = CreateParams()
@@ -55,22 +89,33 @@ fun main(args: Array<String>) {
         memScoped {
             Scope(isolate)
             HandleScope(isolate) { handleScope ->
+                // Empty (no-op) internal-fields deserializer — zeroed Holder storage, see above.
+                val deserializer = DeserializeInternalFieldsCallback_Holder()
+                deserializer.ptr.zeroed(DeserializeInternalFieldsCallback.size)
                 val context = New(
                     isolate,
                     null,
                     MaybeLocal__ObjectTemplate(),
                     MaybeLocal__Value(),
-                    DeserializeInternalFieldsCallback(),
+                    deserializer,
                     null
                 )
                 Scope(context)
                 memScoped {
-                    val source = NewFromUtf8(isolate, "'Hello' + ', Worldy!'").ToLocalChecked()
+                    // v8 brick 3 (#99): `type`'s enum default (NewStringType::kNormal) is not
+                    // materialized by the cpp front-end either — pass it explicitly.
+                    val source = NewFromUtf8(
+                        isolate,
+                        "'Hello' + ', Worldy!'",
+                        NewStringType.kNormal
+                    ).ToLocalChecked()
 
                     val script = Compile(context, source, null).ToLocalChecked()
                     val result = script.reference()?.Run(context)?.ToLocalChecked()
                     val utf8 = Utf8Value(isolate, result ?: error("No result"))
-                    println("Got: ${utf8._reference()}")
+                    // Generated accessor for operator* is `reference()` (was `_reference()`
+                    // under the libclang front-end).
+                    println("Got: ${utf8.reference()}")
                 }
             }
         }

--- a/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
+++ b/krapper_gen/src/commonMain/kotlin/KrapperConfig.kt
@@ -60,5 +60,12 @@ data class KrapperConfig(
     // takes the entire import down. Translation-unit-level / fatal diagnostics (a missing
     // include, "too many errors", an error with no attributable cursor) abort regardless,
     // since the recovered AST can't be trusted past them.
-    val strictDiagnostics: Boolean = false
+    val strictDiagnostics: Boolean = false,
+    // When true, the target C++ library is built `-fno-rtti` (e.g. v8's monolith), so it
+    // exports no `typeinfo` symbols. The generated generic `dynamic_cast<D*>` down-cast
+    // helpers would reference a `typeinfo for D` the library doesn't provide and fail to
+    // LINK; under this flag those generic down-casts are skipped (only the RTTI-free
+    // LLVM-style `classof` down-casts survive). Opt-in (default false): an RTTI-on library
+    // keeps emitting the generic checked down-casts.
+    val noRtti: Boolean = false
 )

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -155,6 +155,13 @@ class KrapperGen : CliktCommand() {
             "Fatal / translation-unit-level errors (missing include, unattributable) abort " +
             "regardless."
     ).flag()
+    val noRtti by option(
+        "--no-rtti",
+        help = "The target C++ library is built -fno-rtti (e.g. v8's monolith) and exports " +
+            "no typeinfo symbols. Skip the generic dynamic_cast<D*> down-cast helpers (they " +
+            "would reference a missing `typeinfo for D` and fail to LINK); only RTTI-free " +
+            "LLVM-style `classof` down-casts are emitted. Default: off (RTTI-on library)."
+    ).flag()
     val parsedModel by option(
         "--parsedModel",
         help = "REQUIRED. Path to the ModelIo JSON WrappedTU to load — the parse-output " +
@@ -220,7 +227,8 @@ class KrapperGen : CliktCommand() {
                     cppStandard = cppStandard,
                     rootPackage = rootPackage,
                     failOnDrop = failOnDrop,
-                    strictDiagnostics = strictDiagnostics
+                    strictDiagnostics = strictDiagnostics,
+                    noRtti = noRtti
                 )
             )
             // Augment the request's include dirs (default = header parents) with the module's

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -103,7 +103,7 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         // package is baked into its ResolvedKotlinType at resolve time, so rooting it later
         // (e.g. in writeTo) would be too late.
         DropLedger.reset()
-        GenerationContext.reset(config.rootPackage)
+        GenerationContext.reset(config.rootPackage, config.noRtti)
     }
 
     override suspend fun filterAndResolve(filter: FilterDefinition) {
@@ -432,7 +432,21 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
 
     private fun applyResult(result: MapResult, element: ResolvedElement) = when (result) {
         RemoveChild -> {
-            element.parent?.removeChild(element)
+            val parent = element.parent
+            if (parent != null) {
+                parent.removeChild(element)
+            } else {
+                // A TOP-LEVEL element (a namespace free function, or a top-level class) is not
+                // a child of any ResolvedElement — it lives directly in `classes`, so its
+                // `parent` is null and `removeChild` can't reach it. removeMethod's RemoveChild
+                // must therefore drop it from the top-level list; without this branch the
+                // fixup silently no-ops on free functions (e.g. the uncompilable std::byte /
+                // <ios> bitmask `operator|=`/`&=`/`^=` wrappers). `classes` is reassigned here,
+                // but executeMappings snapshots `allElements` before the loop, so the in-flight
+                // iteration is unaffected. Identity (`!==`) match: distinct overloads are
+                // distinct instances, and only the one the mapper selected is removed.
+                classes = classes.filter { it !== element }
+            }
         }
 
         RemoveParent -> {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
@@ -15,6 +15,7 @@
  */
 package com.monkopedia.krapper.generator.codegen
 
+import com.monkopedia.krapper.generator.GenerationContext
 import com.monkopedia.krapper.generator.resolvedmodel.MethodType
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
 import com.monkopedia.krapper.generator.resolvedmodel.ResolvedMethod
@@ -151,6 +152,12 @@ fun downCastTargetsFor(
         }
         if (!reachesBase) continue
         val useLlvmDynCast = hasLlvmClassof(derived)
+        // A `-fno-rtti` target library (config.noRtti) exports no `typeinfo` symbols, so the
+        // generic `dynamic_cast<D*>` path below would reference a `typeinfo for D` the library
+        // doesn't provide and fail to LINK (e.g. v8's TracingController / ExternalStringResource
+        // against the -fno-rtti monolith). The LLVM `classof` path needs no RTTI, so keep it;
+        // drop only the generic-dynamic_cast pairs.
+        if (GenerationContext.noRtti && !useLlvmDynCast) continue
         // The generic `dynamic_cast` path needs a POLYMORPHIC base (RTTI to check). A
         // non-polymorphic base with no LLVM `classof` on the derived has no safe checked
         // down-cast at all — skip it (drop, don't emit non-compiling C). The LLVM path

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -306,13 +306,17 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // Render an enum constant's integer literal (stored as a signed Long) in its
     // underlying Kotlin type. UInt/ULong have literal suffixes; UShort/UByte have
     // none (a `u` suffix would be a UInt, which won't match the property type), so
-    // build them via a cast.
+    // build them via a cast. Boolean is for a `bool`-underlying C++ enum (e.g. v8's
+    // `enum class MessageLoopBehavior : bool { kDoNotWait = false, kWaitForWork = true }`),
+    // which reduces to Kotlin Boolean at the boundary — emit `false`/`true` so the entry
+    // matches the `val value: Boolean` property (an Int `0`/`1` would not compile).
     private fun literalForUnderlying(value: Long, underlying: String): String = when (underlying) {
         "UInt" -> "${value.toUInt()}u"
         "ULong" -> "${value.toULong()}uL"
         "Long" -> "${value}L"
         "UShort" -> "${value.toInt() and 0xFFFF}.toUShort()"
         "UByte" -> "${value.toInt() and 0xFF}.toUByte()"
+        "Boolean" -> (value != 0L).toString()
         else -> value.toString()
     }
 

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/GenerationContext.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/GenerationContext.kt
@@ -53,9 +53,20 @@ object GenerationContext {
     var rootPackage: String? = null
         private set
 
-    /** Begin a fresh generation pass: clear the intern cache and root [rootPackage]. */
-    fun reset(rootPackage: String?) {
+    /**
+     * True when the target C++ library is compiled `-fno-rtti` (e.g. v8's monolith),
+     * so it exports no `typeinfo` symbols. Under this flag the down-cast helpers must NOT
+     * emit a generic `dynamic_cast<D*>` (it would reference a `typeinfo for D` the library
+     * doesn't provide and fail to LINK); only the LLVM-style `classof` down-cast — which
+     * needs no RTTI — is emitted. Set once per run by [reset] from `config.noRtti`.
+     */
+    var noRtti: Boolean = false
+        private set
+
+    /** Begin a fresh generation pass: clear the intern cache and root [rootPackage]/[noRtti]. */
+    fun reset(rootPackage: String?, noRtti: Boolean = false) {
         internedTypes.clear()
         this.rootPackage = rootPackage
+        this.noRtti = noRtti
     }
 }


### PR DESCRIPTION
## Goal

Brick 3 of the v8 self-host campaign (#99): prove the cpp-front-end-generated v8 bindings (brick 1, #100) actually **LINK** against `../libv8_monolith.a` (62MB) and **RUN** the JS hello-world in `example/kotlin_project/src/nativeMain/kotlin/Main.kt`.

## Result — STRETCH/flagship reached: it RUNS

```
Got args: 0
Executing kotlin
Got: Hello, Worldy!
```

`./gradlew runDebugExecutableKlinker -PenableClang` links against the monolith and V8 executes the JS `'Hello' + ', Worldy!'`, returning the string end-to-end.

## The link recipe (PORT of featuregen's #78)

The cpp front-end parses v8 against the SYSTEM libstdc++ (gcc-16), so the generated wrapper references newer-libstdc++ internals K/N's bundled gcc-8.3 sysroot can't resolve. The example's `klinkedExecutable` now links the REAL system `libstdc++.so` by ABSOLUTE PATH (replacing `-lstdc++`, which shadows to the bundled old lib via search order) + `--gc-sections` + `--allow-shlib-undefined` + `-rpath`/`-rpath-link`. The `.so` is discovered at configure time via `clang++ -print-file-name=libstdc++.so`. Same mechanism clangwalk/cppfrontend/featuregen already use, applied to the EXECUTABLE binary.

## Main.kt adapted to the cpp-generated surface

Main.kt was written against the old libclang surface; the cpp front-end produces a slightly different shape. **No `instantiate()` specs were needed** — the methods were all present, only the surface shape differed:

- `NewSingleThreadedDefaultPlatform` / `NewFromUtf8`: the cpp front-end does not materialize ENUM-/CLASS-typed default arguments (only literal ones like `length = -1`), so the enum (`IdleTaskSupport.kDisabled`, `NewStringType.kNormal`) and `unique_ptr` defaults are now passed explicitly.
- `DeserializeInternalFieldsCallback()` → `DeserializeInternalFieldsCallback_Holder()` (and the `unique_ptr<TracingController>` Holder): a `_Holder()` only allocates storage (no ctor), and the wrapper consumes these by-value with `std::move`, so the storage is zeroed (empty `unique_ptr` / `{nullptr,nullptr}` callback) before use.
- `_reference()` → `reference()`; `InitializePlatform(platform.get())` → `InitializePlatform(platform)` (the generated factory already `.release()`s the `unique_ptr<Platform>`).

## Generator/codegen fixes the v8 surface exposed

Brick 1 only proved the C++ **wrapper** compiles; brick 3 is the first to compile + LINK the Kotlin bindings, surfacing four latent issues (all default-off / additive):

1. **bool-underlying enum** (`KotlinWriter.literalForUnderlying`): a C++ `enum class : bool` (v8's `MessageLoopBehavior`) reduces to Kotlin `Boolean`, but entry values were emitted as Int `0`/`1`. Now emits `false`/`true`.
2. **`removeMethod` now reaches TOP-LEVEL free functions** (`IndexedServiceImpl.applyResult`): a parentless element lives directly in `classes`, so `element.parent?.removeChild` silently no-op'd — `removeMethod` could not drop namespace free functions at all. Now drops from the top-level list when `parent == null`. This lets the example drop the uncompilable libstdc++ `<ios>`/`std::byte` bitmask `operator|=`/`&=`/`^=` wrappers (reference-return collapsed to value; the C wrapper is itself UB — returns a pointer to a by-value local).
3. **`noRtti` config knob** (`KrapperConfig`/`App --no-rtti`, `KPlusPlusExtension.noRtti`, threaded via `GenerationContext` to `CastTargets.downCastTargetsFor`): the v8 monolith is built `-fno-rtti` and exports no `typeinfo`, so generic `dynamic_cast<D*>` down-cast helpers fail to LINK (`undefined reference to typeinfo for v8::...`). Under `noRtti` those generic down-casts are skipped (RTTI-free LLVM `classof` down-casts unaffected). The example sets `noRtti = true`.

## `removeMethod` fixups added to the example (18, grouped + commented)

Methods that emit uncompilable Kotlin and are NOT on the hello-world path — two latent codegen-bug families filed as krapper_gen follow-ups:
- **Out-pointer param modeled as a value** (`Maybe::To`, `String::GetExternalStringResourceBase`, `Isolate::GetCodeRange`/`GetEmbeddedCodeRange`, `TraceBufferChunk::AddTraceEvent`, `Delegate::ReallocateBufferMemory`).
- **Reference-return of a value-reduced type** (the `std::byte` / `<ios>` `_Ios_*` bitmask `*=` operators — pure transitive-include noise).

## Verification

- `:krapper_gen:nativeTest` green (41s, no failures).
- `:krapper_gen:ktlintCheck` + `:krapper_model:ktlintCheck` green.
- `runDebugExecutableKlinker -PenableClang` links against the 62MB monolith and prints `Got: Hello, Worldy!`.
- All generator changes are default-off/additive, so the default build and other consumers (featuregen committed bindings) are unaffected.

## Files changed

- `example/kotlin_project/build.gradle.kts` (link recipe + `noRtti=true` + 18 removeMethod fixups)
- `example/kotlin_project/src/nativeMain/kotlin/Main.kt` (surface adaptation)
- `krapper_gen/.../codegen/KotlinWriter.kt` (bool enum)
- `krapper_gen/.../IndexedServiceImpl.kt` (free-function removal)
- `krapper_gen/.../codegen/CastTargets.kt` (noRtti down-cast skip)
- `krapper_gen/.../KrapperConfig.kt`, `App.kt` (`--no-rtti`)
- `krapper_model/.../GenerationContext.kt` (`noRtti` carrier)
- `compiler/gradle/.../KPlusPlusExtension.kt`, `KPlusPlusCompilerGradlePlugin.kt` (DSL `noRtti` + `--no-rtti` arg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
