### PR TITLE
cppfrontend: lock NonCopyable special-member parse determinism (#101)

### DIFF
--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -247,6 +247,17 @@ val goldenEmit = tasks.register<Exec>("goldenEmit") {
     commandLine(cppfrontendBinary.absolutePath, "--golden-emit", goldenDir.absolutePath)
 }
 
+// ---- #101: NONCOPYABLE special-member determinism guard ----
+// Runs the cppfrontend binary's `--noncopyable-determinism` mode, which parses a
+// self-contained reduction of v8::Persistent's NonCopyable shape N times (separate
+// ASTContexts) and asserts the special-member set is byte-identical and complete across
+// parses — the standing regression lock for the Persistent<v8::Value> parse-dependent
+// copy-member report (a non-zero exit fails the task). Gated with the module (-PenableClang).
+tasks.register<Exec>("noncopyableDeterminismCheck") {
+    dependsOn("linkReleaseExecutableKlinker")
+    commandLine(cppfrontendBinary.absolutePath, "--noncopyable-determinism")
+}
+
 // ---- #45 brick 2: THE HANDOFF (Phase C) ----
 // The first time generated-bindings-parsed C++ flows through krapper_gen's REAL pipeline:
 //   goldenEmit       — the cppfrontend binary parses the fixture with the Clang C++ AST

--- a/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
+++ b/cppfrontend/src/nativeMain/kotlin/CppFrontend.kt
@@ -24,6 +24,7 @@ import com.monkopedia.krapper.generator.model.WrappedElement
 import com.monkopedia.krapper.generator.model.WrappedField
 import com.monkopedia.krapper.generator.model.WrappedMethod
 import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTU
 import com.monkopedia.krapper.generator.model.WrappedTemplate
 import com.monkopedia.krapper.generator.model.WrappedTypedef
 import com.monkopedia.krapper.generator.model.serialized
@@ -307,6 +308,64 @@ private val FORCING_FIXTURE_HEADER = """
 // The fixture's instantiation requests — one per `--instantiate` the generate step makes.
 private val FORCING_TARGETS = listOf("std::vector<Item*>")
 
+// #101 — the NONCOPYABLE DETERMINISM fixture. A self-contained reduction of v8::Persistent's
+// exact shape: a NON-COPYABLE base (`= delete`d copy ctor + copy assignment), a traits class
+// whose `Copy` is a `static_assert(sizeof(T) < 0)` (un-instantiable on use), and the NC
+// template that USER-DECLARES a copy ctor + copy assignment whose bodies call the trap. The
+// `ForceNC` struct's `value` member implicitly INSTANTIATES `NC<Value>` — the same trigger
+// the synthesized forcing header (ForcingHeader) is for `v8::Persistent<v8::Value>`.
+//
+// THE INVARIANT THIS LOCKS (#101): the special-member set of a NonCopyable type must be
+// IDENTICAL across parses. The original report saw `Persistent<v8::Value>` surface its copy
+// ctor on one parse and its copy assignment on another. The root cause that COULD produce
+// that is lazy template-member instantiation: Clang instantiates a specialization's member
+// FUNCTIONS on first use, so an implicitly-instantiated specialization's `decls()` carries
+// only what THIS parse happened to trigger — a parse-dependent set. This front-end is immune
+// BY CONSTRUCTION because it never walks the specialization (ModelBuilder.addContextDecls
+// SKIPS ClassTemplateSpecialization, citing #101): NC's members ride the template PATTERN,
+// whose `decls()` are fixed source-order declarations, and the resolver materializes
+// `NC<Value>` by deterministic param substitution (Parsing.typedAs). This guard parses the
+// fixture repeatedly and asserts the pattern's special-member set never varies — so a future
+// change that started walking the lazily-instantiated specialization would fail here.
+private val NONCOPYABLE_FIXTURE = """
+    struct Value { int x; };
+
+    template <class T>
+    class NCBase {
+     public:
+        void reset();
+        bool isEmpty() const { return ptr_ == nullptr; }
+        NCBase(const NCBase&) = delete;
+        void operator=(const NCBase&) = delete;
+     protected:
+        explicit NCBase(T* p) : ptr_(p) {}
+        T* ptr_;
+    };
+
+    template <class T>
+    struct NonCopyableTraits {
+        template <class S>
+        static void Copy(const S* from, S* to) {
+            static_assert(sizeof(T) < 0, "NonCopyableTraits::Copy is not instantiable");
+        }
+    };
+
+    template <class T, class M = NonCopyableTraits<T> >
+    class NC : public NCBase<T> {
+     public:
+        NC() : NCBase<T>(nullptr) {}
+        NC(const NC& that) : NCBase<T>(nullptr) { M::Copy(that.ptr_, this->ptr_); }
+        NC& operator=(const NC& that) { M::Copy(that.ptr_, this->ptr_); return *this; }
+        ~NC() {}
+        int get() const;
+    };
+
+    struct ForceNC { NC<Value> value; };
+""".trimIndent()
+
+// Parse the NonCopyable fixture this many times; any cross-parse divergence fails the guard.
+private const val NONCOPYABLE_PARSE_COUNT = 8
+
 private var failures = 0
 
 private fun check(name: String, pass: Boolean, detail: String = "") {
@@ -329,6 +388,14 @@ fun main(args: Array<String>): Unit = memScoped {
     if (args.firstOrNull() == "--handoff-emit") {
         val dir = args.getOrNull(1) ?: fail("--handoff-emit <dir>")
         handoffEmit(dir)
+        return@memScoped
+    }
+    if (args.firstOrNull() == "--noncopyable-determinism") {
+        // #101 — parse the NonCopyable fixture NONCOPYABLE_PARSE_COUNT times and assert the
+        // special-member set never varies across parses (the cpp regression lock for the
+        // Persistent<v8::Value> parse-dependent copy-member report). Self-contained: no
+        // external header, so the only gradle wiring is `dependsOn(linkRelease…)`.
+        noncopyableDeterminismCheck()
         return@memScoped
     }
     if (args.firstOrNull() == "--parity-emit") {
@@ -1123,6 +1190,56 @@ fun main(args: Array<String>): Unit = memScoped {
 
     if (failures > 0) fail("$failures self-check(s) failed")
     println("cppfrontend: ALL SELF-CHECKS PASSED")
+}
+
+/**
+ * #101 — NONCOPYABLE SPECIAL-MEMBER DETERMINISM GUARD. Parse [NONCOPYABLE_FIXTURE]
+ * [NONCOPYABLE_PARSE_COUNT] times (each a SEPARATE buildASTWithArgs / ASTContext) and assert:
+ *  1. every parse's full serialized model is byte-identical — the front-end is deterministic
+ *     parse-to-parse for a NonCopyable type (the exact #101 acceptance);
+ *  2. the `NC` template PATTERN carries BOTH special members on EVERY parse — a copy
+ *     constructor AND a copy assignment — so the set is COMPLETE and never the report's
+ *     "one parse the ctor, another the assignment". This holds because the members ride the
+ *     template pattern's fixed source-order `decls()`, not a specialization's lazily-
+ *     instantiated `decls()` (ModelBuilder skips the specialization — see its #101 note).
+ *
+ * Note this guard is at the FRONT-END (model) boundary on purpose: the un-instantiable copy
+ * ops are a body-only `static_assert`, invisible to every copy-constructibility AST query
+ * (`isDeleted()` / `is_copy_constructible` are FALSE/true respectively — the trap only fires
+ * if the body is instantiated), so the front-end cannot faithfully SUPPRESS them; it can only
+ * emit them DETERMINISTICALLY (the consumer drops the un-compilable pair by uniqueCName).
+ */
+private fun MemScope.noncopyableDeterminismCheck() {
+    val parseArgs = "-std=c++17\n-resource-dir=" + commandOutput("clang++ -print-resource-dir")
+    val models = (1..NONCOPYABLE_PARSE_COUNT).map { i ->
+        parseToWrappedTU(NONCOPYABLE_FIXTURE, "noncopyable_$i.cc", parseArgs)
+    }
+    val jsons = models.map { ModelIo.encodeToString(it) }
+    val divergent = jsons.withIndex().filter { it.value != jsons.first() }.map { it.index + 1 }
+    check(
+        "$NONCOPYABLE_PARSE_COUNT parses of the NonCopyable fixture are byte-identical (#101)",
+        divergent.isEmpty(),
+        "parse(s) $divergent diverged from parse 1"
+    )
+    // The special-member set of the NC PATTERN, per parse: the copy-ctor + copy-assignment
+    // signal that survives substitution into NC<Value>. Both must be present on EVERY parse.
+    fun specialMembers(tu: WrappedTU): Pair<Boolean, Boolean> {
+        val members = tu.children.filterIsInstance<WrappedTemplate>()
+            .find { it.name == "NC" }?.children.orEmpty()
+        val hasCopyCtor = members.filterIsInstance<WrappedConstructor>()
+            .any { it.isCopyConstructor }
+        val hasCopyAssign = members.filterIsInstance<WrappedMethod>()
+            .any { it !is WrappedConstructor && it !is WrappedDestructor && it.name == "operator=" }
+        return hasCopyCtor to hasCopyAssign
+    }
+    val sets = models.map { specialMembers(it) }
+    check(
+        "NC pattern carries BOTH copy ctor and copy assignment on every parse (#101)",
+        sets.all { it == (true to true) },
+        "per-parse (copyCtor, copyAssign): $sets"
+    )
+    if (failures > 0) fail("$failures NonCopyable-determinism check(s) failed")
+    println("cppfrontend: NONCOPYABLE DETERMINISM CHECK PASSED ($NONCOPYABLE_PARSE_COUNT parses)")
 }
 
 /**

--- a/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/cppfrontend/src/nativeMain/kotlin/ModelBuilder.kt
@@ -164,6 +164,15 @@ private class ModelBuilder {
             // walk never surfaces IMPLICIT instantiations (they hang off the template's
             // specialization set, not the TU) — guard so one is never mistaken for a
             // plain record. Explicit specializations are brick-6+.
+            // #101 — this skip is also the NONCOPYABLE DETERMINISM guarantee. Clang
+            // instantiates a specialization's member FUNCTIONS LAZILY (on first odr-use), so
+            // an implicitly-instantiated spec's decls() carries only what THIS parse happened
+            // to trigger — a PARSE-DEPENDENT set (the report: Persistent<v8::Value> surfacing
+            // its copy ctor on one parse, its copy assignment on another). By never walking
+            // the specialization and instead materializing it from the template PATTERN's
+            // fixed source-order decls() (the resolver's deterministic param substitution,
+            // Parsing.typedAs), the special-member set is identical every parse. Locked by
+            // the cppfrontend `--noncopyable-determinism` guard.
             if (decl.getKind() == Kind.ClassTemplateSpecialization ||
                 decl.getKind() == Kind.ClassTemplatePartialSpecialization
             ) {

--- a/example/kotlin_project/build.gradle.kts
+++ b/example/kotlin_project/build.gradle.kts
@@ -169,11 +169,14 @@ kplusplus {
         // v8 methods that generate uncompilable C++ wrappers; drop them by uniqueCName.
         // v8::Persistent<v8::Value> is NonCopyable (NonCopyablePersistentTraits::Copy is a
         // `static_assert(sizeof(S) < 0)`), so neither its copy ctor nor its copy-assignment
-        // may be instantiated. The cpp front-end (brick-1 flip to
-        // -Pkpp.frontend.kotlin_project=cpp) materializes these IMPLICIT special members
-        // parse-dependently — one run surfaces the copy ctor
-        // (`..._new__const_v8_Persistent_and`), another the copy-assignment (`..._op_assign`,
-        // the libclang-era name, still valid) — so drop BOTH to stay robust across parses.
+        // may be instantiated — the generated wrapper that copy-constructs / assigns into the
+        // Holder buffer fails to compile. Both members are USER-DECLARED on the Persistent
+        // template (NOT implicit), so the cpp front-end emits them DETERMINISTICALLY (#101):
+        // it walks the template PATTERN — never the lazily-instantiated specialization — so
+        // BOTH always surface on every parse (proven by the cppfrontend
+        // `--noncopyable-determinism` guard). The un-instantiability is body-only, invisible
+        // to copy-constructibility AST queries, so the front-end can't auto-suppress them;
+        // drop both here by uniqueCName (`op_assign` is the libclang-era name, still valid).
         removeMethod("v8_Persistent_v8_Value_new__const_v8_Persistent_and")
         removeMethod("v8_Persistent_v8_Value_op_assign")
         removeMethod(


### PR DESCRIPTION
## Root cause
`#101` reported that under the cpp front-end a NonCopyable type's special members materialize **parse-dependently** — `v8::Persistent<v8::Value>` surfacing its copy ctor (`..._new__const_v8_Persistent_and`) on one parse and its copy assignment (`..._op_assign`) on another. The hypothesised mechanism is **lazy template-member instantiation**: Clang instantiates a specialization's member functions on first odr-use, so an implicitly-instantiated specialization's `decls()` carries only what *that* parse happened to trigger — a parse-dependent set.

## Finding (verified empirically)
The cpp front-end is **deterministic by construction** and is *not* affected by lazy instantiation, because it never walks the specialization:

- `ModelBuilder.addContextDecls` **SKIPS** `ClassTemplateSpecialization`. A NonCopyable type's members ride the template **PATTERN** (fixed source-order `decls()`); the resolver materializes `Persistent<v8::Value>` by deterministic param substitution (`Parsing.typedAs`).
- Proven with the actual binary: the full v8 base model is **byte-identical across 10 parses** (19346 named elements, 1.26 MB), and **two separate `krapper_gen` processes** emit byte-identical `v8.h`/`v8.cc` with **both** copy ops present — never "one or the other".

## Why suppression (option a) is not feasible
The un-instantiability is a **body-only `static_assert`**, invisible to every copy-constructibility AST query: the copy ctor/assignment are *user-declared* and not deleted (`isDeleted()` is false, `is_copy_constructible` is true — the trap only fires if the body is instantiated). The front-end therefore cannot faithfully detect/suppress them; it can only emit them **deterministically**, and the consumer drops the un-compilable pair by `uniqueCName` (the example's two `removeMethod` fixups, now provably both-needed every run).

## Changes
- **`cppfrontend --noncopyable-determinism`** mode + gated **`noncopyableDeterminismCheck`** task: parses a self-contained v8::Persistent-shaped fixture (deleted-copy base + `static_assert` traits + user-declared copy ctor/assign + a `ForceNC` instantiation) **8×** and asserts the model is byte-identical *and* the NC pattern carries **both** special members on every parse. The standing regression lock for `#101` (a future change that started walking the lazy specialization fails here).
- **`ModelBuilder`**: cite `#101` at the specialization-skip — the skip **is** the determinism guarantee.
- **example**: correct the now-inaccurate Persistent fixup comment (both members are user-declared, emitted deterministically, both always present — not implicit/parse-dependent). The `removeMethod` workaround is **kept** (the members are genuinely un-compilable; suppression isn't AST-detectable).

## Verification
- `noncopyableDeterminismCheck`: **PASSED** (8 parses byte-identical; `(copyCtor, copyAssign)` = `(true, true)` every parse)
- `:featuregen:nativeTest -PenableClang`: **188/0**
- `:krapper_gen:nativeTest`: **281/0**
- `:cppfrontend:runReleaseExecutableKlinker`: ALL SELF-CHECKS PASSED

No model-output change (additive mode + comments), so the cppfrontend parity ledger is unaffected.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)