### PR TITLE
krapper_gen: keep pointer indirection for value-reduced out-pointer params (#103 Family 1)

### DIFF
--- a/example/kotlin_project/build.gradle.kts
+++ b/example/kotlin_project/build.gradle.kts
@@ -193,22 +193,18 @@ kplusplus {
         removeMethod("v8_Maybe_void_from_just")
         removeMethod("v8_Maybe_void_from_maybe")
 
-        // v8 brick 3 (#99): these methods generate Kotlin bindings that DON'T COMPILE
+        // v8 brick 3 (#99): these methods generated Kotlin bindings that DON'T COMPILE
         // (brick 1 only proved the C++ WRAPPER compiles; brick 3 is the first to compile +
         // link the Kotlin). They fall into two latent codegen-bug families the v8 surface
-        // exposes; none are on the hello-world path, so drop them by uniqueCName (the same
-        // mechanism used above for the genuinely-uncompilable v8 wrappers). The bug families
-        // are filed as follow-ups for krapper_gen to fix at the source:
+        // exposed (#103); none are on the hello-world path.
         //
         // Family 1 — OUT-POINTER PARAM modeled as a value: a `T* out` / `T& out` parameter
-        // (enum*, size_t&, uint64_t*) is bound as a by-value param, so the call passes a
-        // scalar where the extern's `CValuesRef<...>` pointer is expected.
-        removeMethod("v8_Maybe_v8_PropertyAttribute_to")              // Maybe::To(PropertyAttribute* out)
-        removeMethod("v8_String_get_external_string_resource_base")   // String::GetExternalStringResourceBase(Encoding* out)
-        removeMethod("v8_Isolate_get_code_range")                     // Isolate::GetCodeRange(void**, size_t*)
-        removeMethod("v8_Isolate_get_embedded_code_range")            // Isolate::GetEmbeddedCodeRange(void**, size_t*)
-        removeMethod("v8_platform_tracing_TraceBufferChunk_add_trace_event") // TraceBufferChunk::AddTraceEvent(size_t& index)
-        removeMethod("v8_ValueSerializer_Delegate_reallocate_buffer_memory") // Delegate::ReallocateBufferMemory(..., size_t* actual)
+        // (enum*, size_t&, size_t*) was bound as a by-value param, so the call passed a
+        // scalar where the extern's `CValuesRef<...>` pointer is expected. FIXED at source
+        // in krapper_gen (#103, `typeToKotlinType`: `size_t*`/`size_t&` -> `CValuesRef<
+        // ULongVar>?`, `enum*` -> the `void*`-backed `COpaquePointer`), so the six
+        // Maybe::To / GetExternalStringResourceBase / GetCodeRange / GetEmbeddedCodeRange /
+        // TraceBufferChunk::AddTraceEvent / ReallocateBufferMemory workarounds are dropped.
         //
         // Family 2 — REFERENCE-RETURN of a value-reduced type: an `operator|=` / `operator&=`
         // / `operator^=` returning `T&` (where T reduces to a Kotlin enum or UByte) is bound

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedKotlinType.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedKotlinType.kt
@@ -111,7 +111,17 @@ private val pointerTypeMap = mapOf(
     "wchar_t" to "kotlinx.cinterop.IntVar",
     "ptrdiff_t" to "kotlinx.cinterop.LongVar",
     "ssize_t" to "kotlinx.cinterop.LongVar",
-    "intptr_t" to "kotlinx.cinterop.LongVar"
+    "intptr_t" to "kotlinx.cinterop.LongVar",
+    // size_t is native (so its wrapper C signature is `size_t*`/`size_t&`), but it had no
+    // *Var entry, so a `size_t*`/`size_t&` out-param collapsed through the `?:` fallback
+    // below to a BARE `size_t` scalar — the Kotlin facade then passed a value where the
+    // extern's `CValuesRef<...>` pointer is expected and did NOT compile (issue #103,
+    // Family 1: v8 Isolate::GetCodeRange(..., size_t*), TraceBufferChunk::AddTraceEvent(
+    // size_t&), ValueSerializer::Delegate::ReallocateBufferMemory(..., size_t*)). size_t
+    // is unsigned long on LP64 (its by-value form is `platform.posix.size_t` = ULong), so
+    // its pointer rides ULongVar — identical to `uint64_t*` and to cinterop's own
+    // `CValuesRef<size_tVar>` (size_tVar aliases ULongVar), matching the `size_t*` extern.
+    "size_t" to "kotlinx.cinterop.ULongVar"
 )
 
 // The Kotlin-facing spelling of a model type. An extension (not a member) because the
@@ -204,6 +214,19 @@ fun WrappedKotlinType(type: WrappedType): WrappedKotlinType {
                     listOf(fullyQualifiedType(pointerType))
                 )
             )
+        }
+        // A POINTER to a value-reduced enum (issue #103, Family 1: v8 Maybe::To(
+        // PropertyAttribute*), String::GetExternalStringResourceBase(Encoding*)). The
+        // enum collapses to its underlying integer at the boundary and is NOT a
+        // `.ptr`-backed wrapper, so the wrapper's cType is `void*` (see
+        // WrappedModifiedType.cType: a non-native pointee yields `void*`). Surfacing the
+        // generated `enum class` here would make KotlinWriter.reference() emit `arg.value`
+        // (an Int) where the extern expects a pointer — uncompilable. Expose it as the
+        // opaque `void*` the caller fills/reads, exactly as a by-value `void*` arg above.
+        // Guarded on `isPointer`: an enum REFERENCE (`&`) is deliberately a by-value enum
+        // at the boundary (WrappedModifiedType.isEnum), so it must keep the enum class.
+        if (type.isPointer && baseType.isEnum) {
+            return fullyQualifiedType(C_OPAQUE_POINTER)
         }
         return nullable(WrappedKotlinType(baseType))
     }

--- a/krapper_gen/src/nativeTest/kotlin/OutPointerTypeTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/OutPointerTypeTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.model.kotlinType
+import com.monkopedia.krapper.generator.model.type.WrappedEnumConstant
+import com.monkopedia.krapper.generator.model.type.WrappedEnumType
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.pointerTo
+import com.monkopedia.krapper.generator.model.type.WrappedType.Companion.referenceTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #103, Family 1 — an OUT-POINTER (`T*` / `T& out`) whose pointee `T` reduces to a
+ * Kotlin scalar/enum must keep the POINTER indirection at the Kotlin/C boundary, NOT
+ * collapse to the by-value pointee.
+ *
+ * The C wrapper signature for such a param is a real pointer (`size_t*`, `void*` for an
+ * enum, ...), so cinterop types the extern as a `CValuesRef<...>?` / `COpaquePointer`.
+ * Before the fix the Kotlin facade collapsed the pointer to a bare `size_t` scalar or to
+ * the generated `enum class`, then `KotlinWriter.reference()` passed that value (or
+ * `arg.value`, an Int) where the extern wanted a pointer → the generated Kotlin did not
+ * compile. These shapes surfaced on the v8 surface (brick 3, #102) and were worked around
+ * at the example config level; this locks the source fix in `typeToKotlinType`.
+ */
+class OutPointerTypeTest {
+
+    private val sizeT = WrappedType("size_t")
+
+    // A value-reduced enum: at the boundary it is its underlying integer, and it is NOT a
+    // `.ptr`-backed wrapper — so a pointer to one cannot be the `enum class`.
+    private val enumType = WrappedEnumType(
+        cppName = "PropertyAttribute",
+        underlying = WrappedType("int"),
+        constants = listOf(WrappedEnumConstant("None", 0), WrappedEnumConstant("ReadOnly", 1))
+    )
+
+    @Test
+    fun sizeTPointerIsACValuesRefPointer() {
+        // `size_t*` (v8 Isolate::GetCodeRange(..., size_t*)) — was the bare `size_t` scalar.
+        assertEquals("CValuesRef<ULongVar>?", pointerTo(sizeT).kotlinType.name)
+    }
+
+    @Test
+    fun sizeTReferenceIsACValuesRefPointer() {
+        // `size_t&` (v8 TraceBufferChunk::AddTraceEvent(size_t& index)) — a reference to a
+        // native scalar marshals through the same pointer slot as `size_t*`.
+        assertEquals("CValuesRef<ULongVar>?", referenceTo(sizeT).kotlinType.name)
+    }
+
+    @Test
+    fun enumPointerIsAnOpaquePointer() {
+        // `enum*` (v8 Maybe::To(PropertyAttribute*)) — the wrapper's cType is `void*`, so
+        // the out-param is an opaque pointer, NOT the `enum class` (which would emit
+        // `arg.value` into a pointer slot).
+        assertEquals("void*", pointerTo(enumType).cType.toString())
+        assertEquals("COpaquePointer", pointerTo(enumType).kotlinType.name)
+    }
+
+    @Test
+    fun voidPointerPointerIsACValuesRefOfOpaquePointers() {
+        // `void**` (v8 Isolate::GetCodeRange(void**, ...)) — already correct; regression-lock.
+        assertEquals(
+            "CValuesRef<COpaquePointerVar>?",
+            pointerTo(pointerTo(WrappedType.VOID)).kotlinType.name
+        )
+    }
+
+    @Test
+    fun byValueEnumStillSurfacesAsTheEnumClass() {
+        // The fix is scoped to a POINTER pointee: a by-value enum keeps the generated
+        // `enum class` (and its `.value`/`fromValue` boundary conversions).
+        assertEquals("PropertyAttribute", enumType.kotlinType.name)
+    }
+
+    @Test
+    fun enumReferenceStillSurfacesAsTheEnumClass() {
+        // An enum REFERENCE is deliberately a by-value enum at the boundary
+        // (WrappedModifiedType.isEnum); only a `*` pointer becomes opaque.
+        assertEquals("PropertyAttribute?", referenceTo(enumType).kotlinType.name)
+    }
+}


### PR DESCRIPTION
## What

Fixes **#103 Family 1** — an out-pointer param `T*` / `T& out`, whose pointee `T` reduces to a Kotlin scalar/enum, was bound BY VALUE, so the generated Kotlin facade passed a scalar where the C extern's `CValuesRef<...>` / `COpaquePointer` pointer is expected → **did not compile**. Surfaced by the v8 brick-3 surface (#102) and worked around at the example config level.

## Root cause

Two mis-collapsing shapes in `WrappedKotlinType.typeToKotlinType`'s pointer/reference branch:

- **`size_t*` / `size_t&`** — `size_t` is native (its wrapper C signature is a real `size_t*`), but it had **no `pointerTypeMap` entry**, so it fell through the `?:` fallback to a **bare `size_t` scalar**. Added `size_t -> kotlinx.cinterop.ULongVar` (size_t is `ULong` on LP64 — identical to `uint64_t*`, and to cinterop's own `CValuesRef<size_tVar>` since `size_tVar` aliases `ULongVar`).
- **`enum*`** — a pointer to a value-reduced enum surfaced as the generated `enum class`, so `KotlinWriter.reference()` emitted `arg.value` (an `Int`) into the wrapper's `void*` slot. The enum is **not** a `.ptr`-backed wrapper and its pointer cType is `void*`, so it now surfaces as the opaque `COpaquePointer` the caller fills/reads — exactly as a by-value `void*` arg. **Guarded on `isPointer`**, so an enum *reference* stays a by-value enum (`WrappedModifiedType.isEnum`), unchanged.

`void**` already mapped correctly to `CValuesRef<COpaquePointerVar>?` — locked as a regression test.

## Family 2 deferred

Family 2 (reference-RETURN of a value-reduced type — the `std::byte` / `_Ios_*` bitmask compound-assignment operators, whose C wrapper is **itself UB**: it returns a pointer to a by-value local) is a distinct return-path + `CppWriter` concern, meaningfully more involved/riskier. Deferred to **#105**; its example `removeMethod` workarounds are **kept**.

## New test

`OutPointerTypeTest` (6 cases) pins all four pointer shapes (`size_t*`, `size_t&`, `enum*`, `void**`) **and** the two unchanged shapes (by-value enum, enum reference) so the fix stays scoped.

## Example workarounds dropped (verified compiling)

Dropped the **six** Family-1 `removeMethod` workarounds in `example/kotlin_project/build.gradle.kts`. `kplusplusSync compileKotlinNative -PenableClang` now **compiles the generated v8 bindings clean** — confirmed signatures:

- `Maybe::To(out: COpaquePointer?)` — enum*
- `String::GetExternalStringResourceBase(encoding_out: COpaquePointer?)` — enum*
- `Isolate::GetCodeRange(start: CValuesRef<COpaquePointerVar>?, length_in_bytes: CValuesRef<ULongVar>?)` (+ GetEmbeddedCodeRange) — void**, size_t*
- `TraceBufferChunk::AddTraceEvent(event_index: CValuesRef<ULongVar>?)` — size_t&
- `ValueSerializer::Delegate::ReallocateBufferMemory(old_buffer: COpaquePointer?, size: size_t, actual_size: CValuesRef<ULongVar>?)` — void*, size_t*

## Verification

- `:krapper_gen:nativeTest` → **287/0** (incl. the 6 new cases).
- **Mandatory generator regression gate** `:featuregen:nativeTest -PenableClang` → **188/0**.
- v8 example `kplusplusSync compileKotlinNative -PenableClang` → **BUILD SUCCESSFUL** with the 6 workarounds removed (the load-bearing compile-check).
- ktlintFormat clean; no `size_t*`/`enum*` shapes in the featuregen fixtures, so the cppfrontend parity ledger is unaffected (these are v8-specific shapes; featuregen cpp path is green).

refs #103 (Family 1 done; Family 2 -> #105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)