### PR TITLE
example(v8): richer demo — read a numeric JS result via Value::Int32Value (#99 brick 2)

### DIFF
--- a/example/kotlin_project/build.gradle.kts
+++ b/example/kotlin_project/build.gradle.kts
@@ -142,6 +142,14 @@ kplusplus {
     // (kpp.frontend.kotlin_project=cpp), built with -PenableClang.
     cppStandard = "c++17"
 
+    // v8 brick 2 (#99): force the v8::Maybe<int> model so Value::Int32Value(context) — whose
+    // return is v8::Maybe<int32_t> (int32_t == int) — survives codegen instead of being
+    // dropped (IGNORE_MISSING) for want of a forcing model. Unblocks the richer number→int
+    // demo in Main.kt (`numResult.Int32Value(context).FromJust()`). The Maybe<int> member
+    // set (FromJust/ToChecked/IsJust/…) is the primary Maybe<T> projection — no void-spec
+    // workarounds apply here.
+    instantiate("v8::Maybe<int>")
+
     // v8 brick 3 (#99): the v8 monolith is built `-fno-rtti`, so it exports no `typeinfo`
     // symbols. Without this, the generated generic `dynamic_cast<D*>` down-cast helpers
     // (e.g. TracingController.asTracingController(), ExternalStringResourceBase.as*()) emit

--- a/example/kotlin_project/src/nativeMain/kotlin/Main.kt
+++ b/example/kotlin_project/src/nativeMain/kotlin/Main.kt
@@ -11,6 +11,7 @@ import v8.MaybeLocal__ObjectTemplate.Companion.MaybeLocal__ObjectTemplate
 import v8.MaybeLocal__Value.Companion.MaybeLocal__Value
 import v8.NewStringType
 import v8.Script.Companion.Compile
+import v8.Value
 import v8.String.Companion.NewFromUtf8
 import v8.V8.Companion.Dispose
 import v8.V8.Companion.DisposePlatform
@@ -116,6 +117,32 @@ fun main(args: Array<String>) {
                     // Generated accessor for operator* is `reference()` (was `_reference()`
                     // under the libclang front-end).
                     println("Got: ${utf8.reference()}")
+                }
+                memScoped {
+                    // v8 brick 2 (#99): a RICHER operation beyond string concat — evaluate an
+                    // ARITHMETIC script and read the numeric result back as a 32-bit int via
+                    // Value::Int32Value(context), which returns v8::Maybe<int32_t>. This
+                    // exercises the Maybe<int>/Int32Value path: the FIR manifest discovers the
+                    // method's templated return, and the `instantiate("v8::Maybe<int>")` spec in
+                    // build.gradle.kts forces the Maybe<int> model so the method survives the
+                    // IGNORE_MISSING drop and FromJust() (which yields the unwrapped Int) binds.
+                    val numSource = NewFromUtf8(
+                        isolate,
+                        "40 + 2",
+                        NewStringType.kNormal
+                    ).ToLocalChecked()
+                    val numScript = Compile(context, numSource, null).ToLocalChecked()
+                    val numResult = numScript.reference()?.Run(context)?.ToLocalChecked()
+                    // Local<Value>.reference() returns the EMPTY marker interface ValueApi (a
+                    // polymorphic base gets only `val ptr`, with the real methods on the concrete
+                    // Value class), so the `as? Value` downcast recovers them — reference() does
+                    // construct a real Value under the hood, so the cast always succeeds. See the
+                    // tracked generator gap (#107): a Local<PolymorphicBase>.reference() should
+                    // expose the base's instance methods directly. Int32Value -> Maybe<int>;
+                    // FromJust() unwraps the present value (the script always produces a number).
+                    val numValue = numResult?.reference() as? Value
+                    val computed = numValue?.Int32Value(context)?.FromJust()
+                    println("Computed: $computed")
                 }
             }
         }


### PR DESCRIPTION
## v8 brick 2 (#99) — grow the proven v8 surface

The brick-3 hello-world proved the self-hosted v8 bindings compile+link+run a string concat. This brick extends the demo to a **richer operation**: evaluate `"40 + 2"` and read the result back as a native 32-bit `Int`.

```
Got: Hello, Worldy!
Computed: 42
```

### What changed (small, bounded)
- **`build.gradle.kts`:** `instantiate("v8::Maybe<int>")` — forces the `Maybe<int>` model so `v8::Value::Int32Value(context)` (returns `v8::Maybe<int32_t>`, `int32_t == int`) survives the `IGNORE_MISSING` drop. This is the only generation delta. Verified the method now binds: `v8_Value.kt: Int32Value(context): Maybe__Int`.
- **`Main.kt`:** the richer block. `Int32Value(context).FromJust()` yields the unwrapped `Int`.

### The `as? Value` downcast + a filed gap (#107)
`Local<Value>.reference()` returns the **empty marker interface** `ValueApi` (`val ptr` only) — a polymorphic base's real methods (`Int32Value`, `IsString`, `ToString`, …) live on the concrete `Value` class. So a consumer-side `as? Value` downcast is needed to reach them. It always succeeds (reference() builds a real `Value` under the hood). The underlying usability gap is filed as **#107** for a scoped generator fix; this brick routes around it rather than tacking on a non-trivial generator change.

### Verification
End-to-end green under `-PenableClang`: `kplusplusSync` + `compileKotlinNative` + link vs the 62MB `libv8_monolith.a` + `runDebugExecutableKlinker` — program prints both lines. No krapper_gen change (only one forcing spec + example consumer code), so featuregen parity is unaffected.

refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)