### PR TITLE
cleanup: drop redundant v8 binary + fix stale v1-plugin comment (part 4)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
@@ -31,11 +31,10 @@ import org.gradle.api.Action
  *      forwarded to krapper_gen via --fixup-file.
  *   3. (future) Per-spec compiler options, package overrides, etc.
  *
- * This block intentionally does not re-introduce the v1 mapping DSL. If
- * you need arbitrary FIR introspection or per-method closures, that's a
- * signal to either (a) extend the [Fixup] sealed type with a new narrow
- * directive or (b) drop back to the legacy `com.monkopedia.kplusplus.plugin`
- * (which is still maintained for backwards compatibility).
+ * This block intentionally does not re-introduce the v1 mapping DSL (the v1
+ * `com.monkopedia.kplusplus.plugin` was removed). If you need a semantic
+ * correction the current fixups can't express, extend the [Fixup] sealed type
+ * with a new narrow directive rather than reaching for arbitrary closures.
  */
 open class KPlusPlusExtension {
 


### PR DESCRIPTION
## Repo cleanup — part 4: small leftovers

- **`samples/v8/include/libv8_monolith.a`** — a 55 MB **unreferenced** duplicate of the 62 MB `samples/v8/libv8_monolith.a` that the build actually links (`library("libv8_monolith.a")`). Carried along when the v8 example moved in #112; nothing reads the `include/` copy.
- **`KPlusPlusExtension.kt`** — corrected a now-false doc comment that pointed users to "drop back to the legacy `com.monkopedia.kplusplus.plugin` (still maintained for backwards compatibility)". The v1 plugin was **deleted** in #110, so that escape hatch no longer exists; the comment now just points at extending the `Fixup` sealed type.

Comment + dead-binary removal only; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)