### PR TITLE
krapper_gen: Local<PolymorphicBase>.reference() returns the concrete base, not the empty Api marker (#107)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -1714,6 +1714,14 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         // `fun in(...)` (won't parse). Back-tick-escape it (mirrors the param/field path).
         .escapeKotlinKeyword()
 
+    // The C++ dereference operators `operator*` ([ResolvedOperator.REFERENCE]) and
+    // `operator->` ([ResolvedOperator.POINTER_REFERENCE]) on a `Local<T>`/pointer wrapper.
+    // Their declared return must stay CONCRETE (not the base-interface remap) — see #107 and
+    // the retType comment in [generateBasicMethod].
+    private fun isDerefAccessor(method: ResolvedMethod): Boolean =
+        method.operator == ResolvedOperator.REFERENCE ||
+            method.operator == ResolvedOperator.POINTER_REFERENCE
+
     private fun KotlinCodeBuilder.generateBasicMethod(
         method: ResolvedMethod,
         uniqueCName: Symbol,
@@ -1726,16 +1734,30 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
             name = methodName.kotlinMethodName()
             // Declared return upcast to a base interface when applicable; body keeps the
             // concrete returnType (constructs the concrete wrapper). See onGenerate(method).
-            // EXCEPT the index get: it returns a CONTAINER ELEMENT, which must stay
-            // CONCRETE — the synthesized `Iterable<Elem>`/`iterator()` (detectIndexIterable)
-            // declares the raw element type, and the element's own methods (e.g. a walked
-            // `clang::Decl`'s getDeclKindName/asNamedDecl) live on the concrete class, not the
-            // (member-less) base interface. Remapping the get to `DeclApi` both mismatched
-            // `next()` and made the elements useless. This covers BOTH the `[]` operator
-            // ([ResolvedOperator.IND]) AND the `get`/`at`-keyed fallbacks (via the
-            // [keepConcreteElement] flag the named-method path sets from [isIndexGetMethod]).
+            // EXCEPT positions that must stay CONCRETE:
+            //  - the index get: it returns a CONTAINER ELEMENT — the synthesized
+            //    `Iterable<Elem>`/`iterator()` (detectIndexIterable) declares the raw element
+            //    type, and the element's own methods (e.g. a walked `clang::Decl`'s
+            //    getDeclKindName/asNamedDecl) live on the concrete class, not the (member-less)
+            //    base interface. Remapping the get to `DeclApi` both mismatched `next()` and
+            //    made the elements useless. Covers BOTH the `[]` operator ([ResolvedOperator.IND])
+            //    AND the `get`/`at`-keyed fallbacks (via the [keepConcreteElement] flag the
+            //    named-method path sets from [isIndexGetMethod]).
+            //  - the dereference accessors `reference()`/`pointer_reference()` (operator*/->
+            //    on a `Local<T>`/pointer wrapper, [isDerefAccessor]): they yield the WRAPPED
+            //    element, which must stay CONCRETE. The base interface only carries VIRTUAL
+            //    methods (baseInterfaceMethods, #107), so for a base whose instance methods are
+            //    NON-virtual (e.g. v8::Value's Int32Value/IsString) `<Base>Api` is an EMPTY
+            //    marker — widening the deref return to it makes every concrete method
+            //    unreachable (forcing a manual `as? Value` downcast). The body already builds
+            //    the concrete `Value(ptr, memScope)`, so keep the declared type concrete too;
+            //    genuine polymorphic METHOD positions (a method returning/taking a base) still
+            //    remap, so subclass substitution there is unaffected.
             retType = type(
-                if (method.operator == ResolvedOperator.IND || keepConcreteElement) {
+                if (method.operator == ResolvedOperator.IND ||
+                    isDerefAccessor(method) ||
+                    keepConcreteElement
+                ) {
                     method.returnType
                 } else {
                     remapReturnType(method.returnType)

--- a/krapper_gen/src/nativeTest/kotlin/PolymorphicReferenceTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/PolymorphicReferenceTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.ReferencePolicy
+import com.monkopedia.krapper.generator.codegen.File
+import com.monkopedia.krapper.generator.codegen.KotlinWriter
+import com.monkopedia.krapper.generator.model.MethodType
+import com.monkopedia.krapper.generator.model.WrappedBase
+import com.monkopedia.krapper.generator.model.WrappedClass
+import com.monkopedia.krapper.generator.model.WrappedConstructor
+import com.monkopedia.krapper.generator.model.WrappedMethod
+import com.monkopedia.krapper.generator.model.WrappedNamespace
+import com.monkopedia.krapper.generator.model.WrappedTU
+import com.monkopedia.krapper.generator.model.type.WrappedType
+import com.monkopedia.krapper.generator.resolvedmodel.ResolvedClass
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Issue #107 — `Local<PolymorphicBase>.reference()` must return the CONCRETE base, not the
+ * (often empty) base-interface marker.
+ *
+ * A class used as a base gets a generated `interface <Name>Api` whose method surface is
+ * built by `baseInterfaceMethods`, which includes ONLY VIRTUAL instance methods (the
+ * interface exists for polymorphic dispatch). When a polymorphic base's instance methods are
+ * all NON-virtual (e.g. v8::Value's `Int32Value`/`IsString`), `<Name>Api` collapses to an
+ * EMPTY marker (`interface ValueApi { val ptr: COpaquePointer }`).
+ *
+ * The dereference accessors `reference()`/`pointer_reference()` (C++ `operator*`/`operator->`
+ * on a `Local<T>`/pointer wrapper) had their DECLARED return type widened to that marker via
+ * the base->interface remap, so a dereferenced `Local<Value>` exposed none of the concrete
+ * methods — a manual `as? Value` downcast was required. The fix keeps the deref return
+ * CONCRETE (the body already constructs the concrete `Value(ptr, memScope)`); genuine
+ * polymorphic METHOD positions still remap, so subclass substitution there is unaffected.
+ *
+ * This locks both halves: the marker really is empty for a non-virtual-method base (the root
+ * cause), and the wrapper's `reference()` returns the concrete `Base` so its methods are
+ * reachable without a cast.
+ */
+class PolymorphicReferenceTest {
+    private val writer = KotlinWriter("test.pkg")
+    private val testDir = File("/tmp/polyRefTestDir")
+
+    @BeforeTest
+    fun setup() {
+        if (testDir.exists()) testDir.rmR()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (testDir.exists()) testDir.rmR()
+    }
+
+    private fun method(name: String, returnType: WrappedType) =
+        WrappedMethod(name, returnType, MethodType.METHOD)
+
+    /**
+     * Build + resolve a three-class model: a polymorphic `Base` with a NON-virtual instance
+     * method, a `Derived` that names it as a base (so `Base` is treated as a base and gets a
+     * `BaseApi`), and a `Local` wrapper whose `operator*` returns `Base`.
+     */
+    private fun resolveModel(): List<ResolvedClass> = runBlocking {
+        val baseType = WrappedType("Poly::Base")
+        val base = WrappedClass("Base").apply {
+            metadata.hasConstructor = true
+            addChild(WrappedConstructor("Base", baseType, false, true))
+            // Non-virtual instance method — the shape that makes BaseApi an empty marker.
+            addChild(method("get_value", WrappedType("int")))
+        }
+        val derived = WrappedClass("Derived").apply {
+            metadata.hasConstructor = true
+            addChild(WrappedBase(baseType))
+            addChild(WrappedConstructor("Derived", WrappedType("Poly::Derived"), false, true))
+        }
+        val local = WrappedClass("Local").apply {
+            metadata.hasConstructor = true
+            addChild(WrappedConstructor("Local", WrappedType("Poly::Local"), false, true))
+            // operator* (the deref accessor) returns the base by reference.
+            addChild(method("operator*", baseType))
+        }
+        val tu = WrappedTU().also { tu ->
+            tu.addChild(
+                WrappedNamespace("Poly").also { ns ->
+                    ns.parent = tu
+                    listOf(base, derived, local).forEach {
+                        ns.addChild(it)
+                        it.parent = ns
+                    }
+                }
+            )
+        }
+        DropLedger.reset()
+        GenerationContext.reset(null)
+        val resolver = ParsedResolver(tu)
+        resolver.findClasses { defaultFilter() }
+            .resolveAll(resolver, ReferencePolicy.IGNORE_MISSING)
+            .filterIsInstance<ResolvedClass>()
+    }
+
+    @Test
+    fun referenceAccessorReturnsConcreteBaseNotEmptyApiMarker() {
+        writer.generate(testDir, resolveModel())
+
+        // Root cause: BaseApi is generated (Base is a base) but is an EMPTY marker — the
+        // base's only instance method is NON-virtual, so baseInterfaceMethods excludes it.
+        val baseApi = File(testDir, "poly_BaseApi.kt")
+        assertTrue(baseApi.exists(), "BaseApi interface should be generated for the base class")
+        val baseApiText = baseApi.readText()
+        assertTrue("interface BaseApi" in baseApiText, "BaseApi marker should be emitted")
+        assertFalse(
+            "fun " in baseApiText,
+            "BaseApi is an empty marker (non-virtual methods excluded); got:\n$baseApiText"
+        )
+
+        // The fix: the wrapper's `reference()` (operator*) returns the CONCRETE `Base`, so the
+        // non-virtual `get_value()` is reachable through the deref — NOT the empty `BaseApi`.
+        val localText = File(testDir, "poly_Local.kt").readText()
+        assertTrue(
+            "fun reference(): Base" in localText,
+            "reference() must return the concrete Base; got:\n$localText"
+        )
+        assertFalse(
+            "BaseApi" in localText,
+            "reference() must NOT widen to the empty BaseApi marker (#107); got:\n$localText"
+        )
+    }
+}

--- a/samples/v8/src/nativeMain/kotlin/Main.kt
+++ b/samples/v8/src/nativeMain/kotlin/Main.kt
@@ -11,7 +11,6 @@ import v8.MaybeLocal__ObjectTemplate.Companion.MaybeLocal__ObjectTemplate
 import v8.MaybeLocal__Value.Companion.MaybeLocal__Value
 import v8.NewStringType
 import v8.Script.Companion.Compile
-import v8.Value
 import v8.String.Companion.NewFromUtf8
 import v8.V8.Companion.Dispose
 import v8.V8.Companion.DisposePlatform
@@ -133,15 +132,12 @@ fun main(args: Array<String>) {
                     ).ToLocalChecked()
                     val numScript = Compile(context, numSource, null).ToLocalChecked()
                     val numResult = numScript.reference()?.Run(context)?.ToLocalChecked()
-                    // Local<Value>.reference() returns the EMPTY marker interface ValueApi (a
-                    // polymorphic base gets only `val ptr`, with the real methods on the concrete
-                    // Value class), so the `as? Value` downcast recovers them — reference() does
-                    // construct a real Value under the hood, so the cast always succeeds. See the
-                    // tracked generator gap (#107): a Local<PolymorphicBase>.reference() should
-                    // expose the base's instance methods directly. Int32Value -> Maybe<int>;
-                    // FromJust() unwraps the present value (the script always produces a number).
-                    val numValue = numResult?.reference() as? Value
-                    val computed = numValue?.Int32Value(context)?.FromJust()
+                    // Local<Value>.reference() now returns the CONCRETE Value (#107 fixed):
+                    // the deref accessor keeps the concrete type, so Value's instance methods
+                    // (here the NON-virtual Int32Value) are reachable directly — no `as? Value`
+                    // downcast. Int32Value -> Maybe<int>; FromJust() unwraps the present value
+                    // (the script always produces a number).
+                    val computed = numResult?.reference()?.Int32Value(context)?.FromJust()
                     println("Computed: $computed")
                 }
             }


### PR DESCRIPTION
## Root cause
A class used as a base gets a generated `interface <Name>Api`. Its method surface (`baseInterfaceMethods` in `KotlinWriter.kt`) includes **only VIRTUAL instance methods** — the interface exists for polymorphic dispatch. When a polymorphic base's instance methods are all **non-virtual** (e.g. `v8::Value`'s `Int32Value`/`IsString`), `<Name>Api` collapses to an **empty marker**: `interface ValueApi { val ptr: COpaquePointer }`.

Separately, the dereference accessors `reference()` / `pointer_reference()` (C++ `operator*` / `operator->` on a `Local<T>` / pointer wrapper) had their **declared return type widened to that marker** via the base→interface remap (`remapReturnType`). So a dereferenced `Local<Value>` was typed `ValueApi?` and exposed none of the concrete methods — a manual `as? Value` downcast was required.

## Fix
Keep the deref-accessor return **concrete**, mirroring the existing index-get carve-out in `generateBasicMethod`. The body already constructs the concrete `Value(ptr, memScope)`, so the declared type just matches what is actually returned. Genuine polymorphic **method positions** (a method that returns/takes a base, so a subclass can substitute) still remap — only the `reference()`/`pointer_reference()` deref of a wrapper changed.

`KotlinWriter.generateBasicMethod` now keeps `method.returnType` when `isDerefAccessor(method)` (operator is `REFERENCE` or `POINTER_REFERENCE`), alongside the pre-existing `IND`/`keepConcreteElement` cases.

## Test
New `PolymorphicReferenceTest` (krapper_gen nativeTest): a polymorphic base with a non-virtual instance method + a subclass + an `operator*` wrapper. Asserts both halves — `BaseApi` is an empty marker (root cause) **and** the wrapper's `reference()` returns the concrete `Base` (not `BaseApi`), so the non-virtual method is reachable.

## Verification
- **featuregen cpp-parity gate: 188/0** (`:featuregen:nativeTest -PenableClang`). The `Ih*` polymorphic/cast tests are unchanged — no abstract-base refinement was needed (`IhAbstractTest` still green), because the change only touches the deref-accessor declared return, not method positions or the cast machinery.
- **krapper_gen nativeTest: 288/0** (incl. the new test).
- **samples/v8** drops the `as? Value` downcast (and the #107 comment): `numResult?.reference()?.Int32Value(context)?.FromJust()` now resolves directly. The sample still runs and prints `Got: Hello, Worldy!` and `Computed: 42`.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)