### PR TITLE
cleanup: drop the dead v1-era v8.def from samples/v8

### DIFF
--- a/samples/v8/include/v8.def
+++ b/samples/v8/include/v8.def
@@ -1,2 +1,0 @@
-headers = v8config.h v8-cppgc.h v8-fast-api-calls.h v8.h v8-inspector.h v8-inspector-protocol.h v8-internal.h v8-metrics.h v8-platform.h v8-profiler.h v8-unwinder-state.h v8-util.h v8-value-serializer-version.h v8-version.h v8-version-string.h v8-wasm-trap-handler-posix.h
-staticLibraries = libv8_monolith.a


### PR DESCRIPTION
`samples/v8/include/v8.def` is a leftover hand-written cinterop `.def` from the v1 plugin era (it lists the v8 headers + `staticLibraries = libv8_monolith.a`). The v2 compiler plugin generates its own `.def` during `kplusplusSync`; **nothing** in the build (or anywhere outside `build/`) references this file — confirmed via `grep`. Flagged during the #113 review; this is the last sliver of the samples cleanup.

Dead-file removal only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)