### PR TITLE
code-health: dedup InstantiationRequest spec (#116) + looping-template guard idiom (#118)

### DIFF
--- a/krapper_gen/src/commonMain/kotlin/KrapperService.kt
+++ b/krapper_gen/src/commonMain/kotlin/KrapperService.kt
@@ -30,7 +30,14 @@ data class IndexRequest(
 )
 
 @Serializable
-data class InstantiationRequest(val base: String, val args: List<String>)
+data class InstantiationRequest(val base: String, val args: List<String>) {
+    /**
+     * The canonical `base<arg, arg>` specialization spelling. This is the string every
+     * consumer keys instantiations on (forcing-model paths, the requested set), so it lives
+     * here to keep those sites in lockstep instead of being hand-rebuilt at each one.
+     */
+    val spec: String get() = "$base<${args.joinToString(", ")}>"
+}
 
 @KsService
 interface KrapperService : RpcBidiService {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -202,10 +202,10 @@ class KrapperGen : CliktCommand() {
             val idx = entry.indexOf('=')
             require(idx > 0) { "--forcingModel must be '<spec>=<path>', got: $entry" }
             val req = parseInstantiation(entry.substring(0, idx))
-            "${req.base}<${req.args.joinToString(", ")}>" to entry.substring(idx + 1)
+            req.spec to entry.substring(idx + 1)
         }
         val missing = instantiate.map { parseInstantiation(it) }
-            .map { "${it.base}<${it.args.joinToString(", ")}>" }
+            .map { it.spec }
             .filter { it !in cppForcingModelPaths }
         require(missing.isEmpty()) {
             "Every --instantiate spec requires a matching --forcingModel '<spec>=<path>' " +

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -132,7 +132,7 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
     }
 
     override suspend fun requestInstantiation(req: InstantiationRequest) {
-        val target = "${req.base}<${req.args.joinToString(", ")}>"
+        val target = req.spec
         requested.add(target)
         // The forcing struct's name + header content are SHARED with the cpp front-end
         // (ForcingHeader, :krapper_model): the cppfrontend binary synthesizes the same

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedTemplateType.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedTemplateType.kt
@@ -25,8 +25,10 @@ class WrappedTemplateType(val baseType: WrappedType, val templateArgs: List<Wrap
         }
 
     init {
-        if (baseType.toString().endsWith("<${templateArgs.joinToString(", ")}>")) {
-            IllegalArgumentException("Looping templates $baseType $templateArgs").printStackTrace()
+        // A base whose spelling already ends in this exact `<args>` is a self-referential
+        // (looping) template we can't model; fail loudly rather than build a degenerate type.
+        require(!baseType.toString().endsWith("<${templateArgs.joinToString(", ")}>")) {
+            "Looping templates $baseType $templateArgs"
         }
     }
 


### PR DESCRIPTION
Two small cleanups from the nightly code-health pass (both approved by the owner to `agent-workable`).

## #116 — duplication: `InstantiationRequest` spec string
The canonical `base<arg, arg>` specialization spelling was reconstructed by hand at three sites that must stay byte-for-byte in lockstep (the forcing-model keys in `App.kt` ×2, and `IndexedServiceImpl.requestInstantiation`) — a silent coupling flagged by the code's own comment. Added a single `spec` computed property on `InstantiationRequest` and routed the three sites through it. It's a getter, not a constructor parameter, so the `@Serializable` shape is unchanged.

## #118 — idiom: `WrappedTemplateType.init` looping guard
The init block constructed an `IllegalArgumentException` only to `printStackTrace()` it (the **only** `printStackTrace` in the tree) and then continued, building a degenerate self-referential type. Replaced with `require(...)`, matching the three sibling `error(...)` invariant guards already in the same class — fail loudly rather than fake a looping template. `krapper_model` has no logger seam, so `require`/`error` is the file-idiomatic choice.

## Verification
- `:krapper_gen:nativeTest` → **288/0**
- `:featuregen:nativeTest -PenableClang` → **188/0** (the mandatory codegen gate)
- The new `require(...)` guard **did not fire** anywhere in the featuregen corpus (grep count 0), so #118 is behavior-neutral in practice — it only removes the java-ism and hardens the impossible-state path.

Closes #116
Closes #118

(Sibling #117 from the same pass was closed as a false positive — the "duplicate" native file is gitignored `syncSource` output, not a committed copy.)