### PR TITLE
fix: don't wire a cppfrontend dependency into the wrong included build (#120)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -553,6 +553,16 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                     .file("bin/klinker/cppfrontendRelease/cppfrontend").get().asFile
         }
         for (included in target.gradle.includedBuilds) {
+            // Only the build that actually HOSTS the cppfrontend module is a candidate.
+            // The root kplusplus build ALWAYS pulls in the `compiler` build via
+            // includeBuild("compiler"), and IncludedBuild.task(":cppfrontend:...") returns
+            // a LAZY reference that does NOT validate the project exists — so without this
+            // guard the `compiler` build (which has no :cppfrontend) falsely matches when
+            // :cppfrontend isn't in the root build (no -PenableClang) yet the module is on
+            // the cpp front-end, and we wire a dependsOn to a project that lives in neither
+            // build → "Project with path ':cppfrontend' not found in build ':compiler'" at
+            // graph-resolution time (breaking even IDE sync). Filter on the module dir.
+            if (!File(included.projectDir, "cppfrontend").isDirectory) continue
             val taskRef = try {
                 included.task(":cppfrontend:linkReleaseExecutableKlinker")
             } catch (_: Throwable) {


### PR DESCRIPTION
Fixes #120.

## Problem
Opening the project on a fresh machine — IntelliJ Gradle sync, or any CLI task that resolves `:featuregen:kplusplusSync`'s dependencies — **without** `-PenableClang` crashed at graph-resolution time:

```
Could not determine the dependencies of task ':featuregen:kplusplusSync'.
> Project with path ':cppfrontend' not found in build ':compiler'.
```

The stack trace was IntelliJ's `GradleModelFetchAction`, so it broke IDE import entirely.

## Root cause
`resolveCppFrontend()` iterates `target.gradle.includedBuilds` and calls `included.task(":cppfrontend:linkReleaseExecutableKlinker")`. `IncludedBuild.task(path)` returns a **lazy** `TaskReference` that does **not** validate the project exists. The root build always pulls in the `compiler` build via `includeBuild("compiler")`, which has no `:cppfrontend`. When `:cppfrontend` isn't in the root build (no `-PenableClang`) but the module is on the cpp front-end (`kpp.frontend.featuregen=cpp`, the committed default), the loop falsely matched the `compiler` build and wired a `dependsOn` to a `:cppfrontend` that lives in neither build — crashing *before* the intended actionable `-PenableClang` message could fire.

## Fix
One guard: only consider an included build that actually hosts the cppfrontend module (`File(included.projectDir, "cppfrontend").isDirectory`). The kplusplus build (the standalone-consumer / v8 `includeBuild` layout) still matches; the `compiler` build is skipped.

## Verification (all reproduced locally)
- `./gradlew :featuregen:kplusplusSync -m` (no `-PenableClang`) → **BUILD SUCCESSFUL** (was the crash) — IDE sync now works.
- Executing `:featuregen:kplusplusSync` without LLVM (binary absent) → clean **actionable** message: *"...but the cppfrontend binary was not found... build with -PenableClang..."* — no crash.
- `./gradlew :featuregen:kplusplusSync -m -PenableClang` → `:cppfrontend:linkReleaseExecutableKlinker` is in the graph as a dependency (enabled path unchanged, no regression).

Note: this does **not** change the deliberate design that `featuregen`/`cppfixture` require LLVM by default (main is LLVM-mandatory post-flip). It only ensures that state fails with the intended actionable guidance and, crucially, that **IDE sync / project open succeeds** on a no-LLVM machine so the LLVM-free modules are still usable.
