### PR TITLE
cppfrontend self-generation seam: stage-0 override + PredefinedSugarType fixup (#122 step 1.1)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -546,6 +546,16 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
      */
     private fun resolveCppFrontend(target: Project): Pair<Any?, File> {
         val relBinary = "cppfrontend/build/bin/klinker/cppfrontendRelease/cppfrontend"
+        // Bootstrap override (#122, step 1.1): when an EXTERNAL stage-0 cppfrontend binary is
+        // supplied via -Pkpp.stageZeroCppFrontend=<abs-path>, use it and declare NO task
+        // dependency (null link task). This is what breaks the self-hosting cycle: building
+        // :cppfrontend via -Pkpp.frontend.cppfrontend=cpp would otherwise resolve the parser
+        // to :cppfrontend's own link task -> a Gradle dependency cycle. With a null task the
+        // caller (dependsOn only when non-null) wires no self-edge, and runCppFrontendSync
+        // uses this .second path as the parser. Additive + gated: absent property = today's
+        // behavior exactly.
+        (target.findProperty("kpp.stageZeroCppFrontend") as? String)?.takeIf { it.isNotBlank() }
+            ?.let { return null to File(it) }
         val direct = target.rootProject.findProject(":cppfrontend")
         if (direct != null) {
             return direct.tasks.findByName("linkReleaseExecutableKlinker") to

--- a/cppfrontend/build.gradle.kts
+++ b/cppfrontend/build.gradle.kts
@@ -219,6 +219,15 @@ kplusplus {
         removeMethod("llvm_APSInt_op_lt__long")
         removeMethod("llvm_APSInt_op_increment")
         removeMethod("llvm_APSInt_op_decrement")
+        // #122 (self-hosting spike): LLVM-22 added clang::ASTContext::getPredefinedSugarType,
+        // whose parameter is the PROTECTED enum clang::Type::PredefinedSugarKind. ASTContext
+        // is in the allowlist, so krapper_gen binds the method and emits a cast to the
+        // protected enum — `clang::Type::PredefinedSugarKind KD_cast = ...` — which the
+        // wrapper compile rejects ("protected member of 'clang::Type'"). The bridge doesn't
+        // need it (nothing here calls getPredefinedSugarType); remove it by uniqueCName until
+        // krapper_gen learns to skip methods over inaccessible types. The committed seed
+        // predates this LLVM surface, so it never carried the method.
+        removeMethod("clang_ASTContext_get_predefined_sugar_type")
     }
     // Materialize the range returns the walk iterates. Brick 3 walks members through
     // DeclContext::decls() (source order, all member kinds) instead of methods(), so the


### PR DESCRIPTION
Foundation for #122 (step 1.1 keystone). Additive + gated — **no-op for the default build.**

## What
Two small changes that unlock `:cppfrontend` self-generation (the compiler generating its own Clang-AST bindings instead of compiling the committed seed):

1. **`resolveCppFrontend` bootstrap override** — when `-Pkpp.stageZeroCppFrontend=<abs-path>` is set, use that external stage-0 cppfrontend binary and declare **no** task dependency. This breaks the Gradle self-cycle: building `:cppfrontend` via `-Pkpp.frontend.cppfrontend=cpp` would otherwise resolve the parser to `:cppfrontend`'s own link task → a dependency cycle. Absent property = today's behavior byte-for-byte.
2. **`removeMethod("clang_ASTContext_get_predefined_sugar_type")`** in cppfrontend's `fixup {}` — LLVM-22 added `ASTContext::getPredefinedSugarType`, whose param is the *protected* enum `clang::Type::PredefinedSugarKind`; the generated wrapper cast doesn't compile. Nothing in the bridge uses it. (Generalized fix tracked in #123.)

## Why it's safe to land now
- The default build has `kpp.frontend.cppfrontend=seed` and never sets `kpp.stageZeroCppFrontend`, so neither change is exercised — the override returns early only when the property is present, and `removeMethod` only runs on the `=cpp` generation path.
- It's the seam step 1.2 (stage-0 packaging) builds on.

## Proof (spike, not in this PR)
With these changes, the full two-stage self-rebuild works end to end: seed → stage-0 → stage-0 parses `clang_slice.h` (+ `kppbridge` + both `std::vector` forcings) → 124 generated binding files → stage-1 builds (3m14s) + runs + can re-parse its own header. The self-generated bindings are a **superset** of the committed seed (the 20 differing files are the *seed* being stale — missing #114/#62/LLVM-22 surface; self-gen is more current). Bootstrap closed and reproducible.

Refs #122. Does not close it (epic).
