### PR TITLE
plugin: scope stage-0 cppfrontend override to :cppfrontend so self-gen composes into consumers (#122 capstone)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -554,8 +554,19 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // caller (dependsOn only when non-null) wires no self-edge, and runCppFrontendSync
         // uses this .second path as the parser. Additive + gated: absent property = today's
         // behavior exactly.
-        (target.findProperty("kpp.stageZeroCppFrontend") as? String)?.takeIf { it.isNotBlank() }
-            ?.let { return null to File(it) }
+        //
+        // SCOPE (#122 capstone): the override applies ONLY when resolving the front-end for
+        // :cppfrontend ITSELF — that is the sole module whose self-cycle the stage-0 breaks.
+        // A DOWNSTREAM consumer (featuregen/cppfixture) on the cpp path must resolve the LIVE
+        // :cppfrontend link task/binary so that, when :cppfrontend is simultaneously =cpp, the
+        // consumer is fed :cppfrontend's SELF-GENERATED binary — not the stage-0 seed directly.
+        // Without this scope the global property would short-circuit every consumer to the
+        // stage-0 seed, and the "cppfrontend=cpp feeding featuregen=cpp" composition could never
+        // exercise the self-generated parser. Absent property = today's behavior exactly.
+        if (target.name == "cppfrontend") {
+            (target.findProperty("kpp.stageZeroCppFrontend") as? String)?.takeIf { it.isNotBlank() }
+                ?.let { return null to File(it) }
+        }
         val direct = target.rootProject.findProject(":cppfrontend")
         if (direct != null) {
             return direct.tasks.findByName("linkReleaseExecutableKlinker") to


### PR DESCRIPTION
## What

Scopes the `-Pkpp.stageZeroCppFrontend` override in the plugin's `resolveCppFrontend` to `target.name == "cppfrontend"`, so the self-hosting composition **"cppfrontend=cpp feeding featuregen=cpp"** actually exercises the self-generated front-end.

## Why

Before this, the stage-0 override fired for **every** module. In a run that put both `:cppfrontend` and a downstream consumer on the cpp path, the global property short-circuited featuregen's parser to the stage-0 **seed** binary directly — featuregen never touched `:cppfrontend`'s **self-generated** binary, so the capstone composition could not be exercised. The stage-0 only needs to break `:cppfrontend`'s OWN self-cycle; downstream consumers must resolve the live `:cppfrontend` link task (which, when `:cppfrontend` is `=cpp`, is the self-generated stage-1 binary).

Additive + gated; absent property = unchanged behavior.

## Verification (the #122 functional capstone)

1. `:cppfrontend:publishStage0ToMavenLocal` — published the seed-built `cppfrontend-stage0:0.2.3-stage0` to mavenLocal.
2. `:cppfrontend:resolveStage0Path` — staged the anchor at `cppfrontend/build/stage0/cppfrontend-stage0`.
3. `:featuregen:nativeTest -PenableClang -Pkpp.frontend.cppfrontend=cpp -Pkpp.stageZeroCppFrontend=<stage0> -Pkpp.frontend.featuregen=cpp --rerun-tasks`

**Result: featuregen `nativeTest` = 188 tests / 0 failures / 0 errors (73 suites).**

Self-generation confirmed genuine:
- `:cppfrontend:kplusplusSync` parsed cppfrontend's own headers via the stage-0 (3 cpp-models) and produced 124 Kotlin bindings + `.def` under `krapped-cpp/`.
- `:cppfrontend:linkReleaseExecutableKlinker` re-linked a **distinct** stage-1 binary (sha `6390e87d…`, 17,200,832 B) — different from the stage-0 seed (sha `9adae489…`, 17,008,888 B).
- featuregen generated its 117 bindings via that self-generated stage-1 binary and ran 188/0 against them (system-libstdc++ link).

This proves the self-generated cppfrontend is fully functionally equivalent as the live front-end for a downstream consumer, not merely that it links.

Refs #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)