### PR TITLE
release(R1): unify versions to 0.3.0 + publish the full consumer set to mavenLocal (#128)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,3 +16,41 @@ subprojects {
         android.set(true)
     }
 }
+
+// ---- R1 (#128): publish the whole consumer artifact set to mavenLocal at 0.3.0 ----
+//
+// One convenience entry point that publishes everything a from-published consumer (and
+// k++'s own self-build) needs to resolve from a repo:
+//   * com.monkopedia.kplusplus:com.monkopedia.kplusplus.compiler.gradle.plugin (plugin marker)
+//   * com.monkopedia.kplusplus:kplusplus-compiler-gradle           (the Gradle plugin jar)
+//   * com.monkopedia.kplusplus:kplusplus-compiler-plugin           (the FIR kotlinc plugin jar)
+//   * com.monkopedia.kplusplus:krapper_gen:<ver> (classifier linuxX64) (resolve+codegen tool)
+//   * com.monkopedia.kplusplus:krapper_parse:<ver> (classifier linuxX64) (LLVM parser tool)
+//
+// The two JVM plugin jars live in the `compiler` INCLUDED build, so they are published via
+// that build's own aggregate task (`:publishCompilerToMavenLocal`). The native tool binaries
+// are LLVM-gated modules (:krapper_gen is always present; :krapper_parse only under
+// -PenableClang), so their publish tasks are wired lazily.
+//
+// mavenLocal only — nothing outward.
+tasks.register("publishAllToMavenLocal") {
+    group = "kplusplus"
+    description = "Publish the full kplusplus consumer artifact set to mavenLocal (0.3.0)."
+    // The compiler included build's aggregate (Gradle plugin + marker + FIR plugin jar).
+    dependsOn(gradle.includedBuild("compiler").task(":publishCompilerToMavenLocal"))
+    // krapper_gen is always in the build.
+    dependsOn(":krapper_gen:publishReleaseBinaryToMavenLocal")
+    // krapper_parse is only in the build under -PenableClang / -PllvmConfig.
+    if (findProject(":krapper_parse") != null) {
+        dependsOn(":krapper_parse:publishReleaseBinaryToMavenLocal")
+    }
+    doLast {
+        val note = if (findProject(":krapper_parse") == null) {
+            "\nNOTE: :krapper_parse was NOT published — it is LLVM-gated. Re-run with " +
+                "-PenableClang (or -PllvmConfig=<path>) on an LLVM host to publish the parser."
+        } else {
+            ""
+        }
+        println("publishAllToMavenLocal: published the kplusplus consumer set to mavenLocal.$note")
+    }
+}

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -1,4 +1,18 @@
 allprojects {
     group = "com.monkopedia.kplusplus"
-    version = "0.2.2"
+    version = "0.3.0"
+}
+
+// R1 (#128): aggregate publish for the two consumer-facing JVM artifacts that live in this
+// (included) `compiler` build — the Gradle plugin (+ its plugin marker) and the FIR kotlinc
+// plugin jar. The root build's `publishAllToMavenLocal` invokes this via the included build
+// so a single command publishes the whole consumer set to mavenLocal. mavenLocal only.
+tasks.register("publishCompilerToMavenLocal") {
+    group = "kplusplus"
+    description =
+        "Publish the Gradle plugin (+ marker) and the FIR kotlinc-plugin jar to mavenLocal."
+    dependsOn(
+        ":kplusplus-compiler-gradle:publishToMavenLocal",
+        ":kplusplus-compiler-plugin:publishToMavenLocal"
+    )
 }

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -4,10 +4,15 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("java-gradle-plugin")
     kotlin("jvm") version "2.4.0"
+    // R1 (#128): publish this Gradle plugin to mavenLocal. With `java-gradle-plugin`,
+    // `maven-publish` auto-creates BOTH the main jar publication (`pluginMaven`) AND the
+    // plugin-marker publication (com.monkopedia.kplusplus.compiler:...gradle.plugin) that
+    // makes `id("com.monkopedia.kplusplus.compiler") version "0.3.0"` resolvable from a repo.
+    `maven-publish`
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.2.2"
+version = "0.3.0"
 
 dependencies {
     implementation(kotlin("stdlib"))

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -746,7 +746,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         const val PLUGIN_ID = "com.monkopedia.kplusplus.compiler"
         const val PLUGIN_GROUP = "com.monkopedia.kplusplus"
         const val PLUGIN_NAME = "kplusplus-compiler-plugin"
-        const val PLUGIN_VERSION = "0.2.2"
+        const val PLUGIN_VERSION = "0.3.0"
         const val MIN_KOTLIN_VERSION = "2.3.20"
 
         // The C++ standard the cpp front-end parses (and krapper_gen compiles the wrapper)

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.2.2"
+version = "0.3.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -3,10 +3,27 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "2.4.0"
+    // R1 (#128): publish this FIR kotlinc-plugin jar to mavenLocal so the Gradle plugin's
+    // SubpluginArtifact (com.monkopedia.kplusplus:kplusplus-compiler-plugin) resolves from a
+    // repo for a from-published consumer, not just an includeBuild sibling.
+    `maven-publish`
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.2.2"
+version = "0.3.0"
+
+// The default `maven` publication + jar. artifactId defaults to the project name
+// (kplusplus-compiler-plugin), which is exactly what KPlusPlusCompilerGradlePlugin's
+// SubpluginArtifact requests. Publishing to mavenLocal only (R1, #128) — no signing, no
+// remote repo. The published POM carries the ksrpc-jni runtime dep so the kotlinc plugin
+// classpath resolves it transitively.
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+}
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.2.3
+version=0.3.0
 group=com.monkopedia.kplusplus
 signing.gnupg.keyName=5B83421E2338B907
 kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -23,6 +23,10 @@ plugins {
     alias(libs.plugins.ksrpc)
     id("c")
     id("cpp")
+    // R1 (#128): publish the krapper_gen release binary to mavenLocal as a normal
+    // classified release artifact so a from-published consumer resolves the resolve+codegen
+    // tool by coordinate. See the publication block near the bottom.
+    `maven-publish`
 }
 
 repositories {
@@ -95,4 +99,47 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     }
+}
+
+// ---- R1 (#128): publish the krapper_gen release binary to mavenLocal ----
+//
+// krapper_gen is the resolve+codegen tool the kplusplus Gradle plugin invokes. A K/N linuxX64
+// .kexe is not a jar (no software-component to wire), so — exactly like the krapper_parse
+// release-binary publication — this is an ARTIFACT-ONLY MavenPublication: attach the raw
+// executable with a `linuxX64` classifier and an empty extension. mavenLocal only; no signing.
+//
+// A Maven repo does NOT preserve the +x bit, so a consumer must chmod the resolved file (the
+// krapper_parse consume-seam already does this for its binary; R2 wires the same for this one).
+val krapperGenBinary = layout.buildDirectory
+    .file("bin/native/releaseExecutable/krapper_gen.kexe").get().asFile
+
+publishing {
+    publications {
+        create<MavenPublication>("releaseBinary") {
+            artifactId = "krapper_gen"
+            artifact(krapperGenBinary) {
+                classifier = "linuxX64"
+                extension = ""
+            }
+        }
+    }
+}
+
+// Build the release binary before publishing it, and guard that it exists.
+tasks.named("publishReleaseBinaryPublicationToMavenLocal") {
+    dependsOn("linkReleaseExecutableNative")
+    doFirst {
+        check(krapperGenBinary.exists()) {
+            "publishReleaseBinaryToMavenLocal: expected the krapper_gen release binary at " +
+                "$krapperGenBinary — linkReleaseExecutableNative should have produced it."
+        }
+    }
+}
+
+tasks.register("publishReleaseBinaryToMavenLocal") {
+    group = "kplusplus"
+    description =
+        "Build the krapper_gen release binary and publish it to mavenLocal as " +
+            "com.monkopedia.kplusplus:krapper_gen:$version (classifier linuxX64)."
+    dependsOn("publishReleaseBinaryPublicationToMavenLocal")
 }

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -441,7 +441,46 @@ publishing {
                 extension = ""
             }
         }
+        // R1 (#128): the NORMAL release artifact a from-published consumer resolves — the
+        // LLVM parser tool at the project version (com.monkopedia.kplusplus:krapper_parse:
+        // 0.3.0, classifier linuxX64). Same artifact-only shape as stage0 (a K/N .kexe is not
+        // a jar). The stage0 anchor stays as the immutable #122 self-hosting seed; this is the
+        // generalization to "a normal release artifact" the release ships.
+        create<MavenPublication>("releaseBinary") {
+            groupId = "com.monkopedia.kplusplus"
+            artifactId = "krapper_parse"
+            // version inherited from the project (0.3.0).
+            artifact(krapperParseBinary) {
+                classifier = "linuxX64"
+                extension = ""
+            }
+        }
     }
+}
+
+// Build + guard the release binary before publishing the normal release artifact. Like the
+// stage0 anchor it must be built FROM SEED, never from the =cpp self-generation path.
+tasks.named("publishReleaseBinaryPublicationToMavenLocal") {
+    dependsOn("linkReleaseExecutableKlinker")
+    doFirst {
+        check(!stage0BuiltFromCpp) {
+            "publishReleaseBinaryToMavenLocal: refusing to publish a krapper_parse release " +
+                "binary built with -Pkpp.frontend.krapper_parse=cpp — build it FROM SEED (the " +
+                "gradle.properties default). Drop the =cpp override and re-run."
+        }
+        check(krapperParseBinary.exists()) {
+            "publishReleaseBinaryToMavenLocal: expected the krapper_parse release binary at " +
+                "$krapperParseBinary — linkReleaseExecutableKlinker should have produced it."
+        }
+    }
+}
+
+tasks.register("publishReleaseBinaryToMavenLocal") {
+    group = "kplusplus"
+    description =
+        "Build the krapper_parse release binary FROM SEED and publish it to mavenLocal as " +
+            "com.monkopedia.kplusplus:krapper_parse:$version (classifier linuxX64)."
+    dependsOn("publishReleaseBinaryPublicationToMavenLocal")
 }
 
 // Build the stage-0 binary from seed, then publish ONLY the stage0 publication to mavenLocal.


### PR DESCRIPTION
First release-machinery brick for epic #128 (first shippable v2 release, target 0.3.0). The model: k++ ships a real release and **builds itself as its own first consumer** — no special stage-0 artifact — so the release must publish the full set of artifacts a consumer (including k++'s own build) resolves from a repo. This brick maps that set, unifies versions to 0.3.0, and publishes everything to **mavenLocal** (nothing outward).

## 1. The consumer artifact set

A from-published consumer applies `id("com.monkopedia.kplusplus.compiler")` and its native module compiles generated bindings. It needs, resolvable from a repo:

| Artifact | Coordinate | Why the consumer needs it |
|---|---|---|
| Gradle plugin marker | `com.monkopedia.kplusplus.compiler:com.monkopedia.kplusplus.compiler.gradle.plugin:0.3.0` | makes `id(...) version "0.3.0"` resolvable |
| Gradle plugin jar | `com.monkopedia.kplusplus:kplusplus-compiler-gradle:0.3.0` | the plugin impl (`KPlusPlusCompilerGradlePlugin`) |
| FIR kotlinc plugin jar | `com.monkopedia.kplusplus:kplusplus-compiler-plugin:0.3.0` | loaded onto the kotlinc plugin classpath via `getPluginArtifact()`'s `SubpluginArtifact` (artifactId + version = `PLUGIN_NAME`/`PLUGIN_VERSION`) |
| krapper_gen binary | `com.monkopedia.kplusplus:krapper_gen:0.3.0` (classifier `linuxX64`) | the resolve+codegen tool the plugin invokes |
| krapper_parse binary | `com.monkopedia.kplusplus:krapper_parse:0.3.0` (classifier `linuxX64`) | the LLVM parser tool the cpp front-end invokes |

**Where the binding annotations live (checked):** `krapper.CppBinding` / `krapper.CppTemplate` are NOT a published runtime library — krapper_gen **generates them inline** into each consumer's `krapped/src/CppBinding.kt` (`IndexedServiceImpl.writeCppBindingAnnotation`). So there is **no annotations runtime lib** to ship.

**`krapper_model` is NOT published:** it is a pure Kotlin library statically linked into the krapper_gen/krapper_parse K/N binaries; no consumer resolves it at runtime. (If a future brick wants to build *against* the model as a lib, that's separable.)

**`compiler/native` (`kplusplus-compiler-plugin-native`) is NOT consumer-facing:** Kotlin 2.4 removed `getPluginArtifactForNative`, so the single `getPluginArtifact()` jar (`kplusplus-compiler-plugin`) serves native compilations too.

**External deps the consumer already pulls from Central:** `com.monkopedia.ksrpc:ksrpc-jni` (auto-added to the compiler-plugin classpath) — not ours to publish.

## 2. Published to mavenLocal at 0.3.0 (verified present in ~/.m2)

All five coordinates land under `~/.m2/repository/com/monkopedia/kplusplus/.../0.3.0/`; both binaries verified valid `ELF 64-bit executable`. Native binaries are artifact-only `MavenPublication`s (a K/N `.kexe` is not a jar) with classifier `linuxX64` + empty extension — mirroring the existing krapper_parse stage-0 pattern.

## 3. Version unification (0.2.3 root / 0.2.2 compiler -> 0.3.0)

`gradle.properties`, `compiler/build.gradle.kts`, `compiler/gradle/build.gradle.kts`, `compiler/plugin/build.gradle.kts`, `compiler/native/build.gradle.kts`, and `KPlusPlusCompilerGradlePlugin.PLUGIN_VERSION`.

## 4. krapper_parse-stage0

**Kept intact** (the #122 self-hosting consume-seam depends on the immutable `0.2.3-stage0` anchor) and **added alongside** a normal release artifact `krapper_parse:0.3.0` (classifier `linuxX64`), built FROM SEED with the same anti-`=cpp` guard.

## 5. Aggregate + verification

- `./gradlew publishAllToMavenLocal -PenableClang` publishes the whole set (invokes the compiler included-build's `:publishCompilerToMavenLocal` + both native release-binary publishes). BUILD SUCCESSFUL.
- Default build unaffected: `./gradlew help -q` and `./gradlew :krapper_parse:help -PenableClang -q` both configure clean.
- Everything mavenLocal-only; no signing, no remote repo.

## 6. Gap for R2 (plugin resolves these from a repo instead of includeBuild/sibling)

R1 only makes the artifacts *resolvable*; the plugin still finds the tools via sibling-project/`includeBuild` filesystem paths (`resolveKrapperGen`/`resolveKrapperParse` return `build/bin/...` paths). For a real no-`includeBuild` consumer, R2 needs to:
- resolve the `krapper_gen` / `krapper_parse` binaries by Maven coordinate (a `configurations`/`dependencies` seam like the krapper_parse stage-0 consume-seam) instead of sibling `build/bin/...` paths, and `chmod +x` the resolved file (Maven drops the executable bit);
- switch the samples (`samples/minimal`, `samples/v8`) off `includeBuild("../../")` to `id(...) version "0.3.0"` from mavenLocal to prove the from-published path end-to-end.

Refs #128. mavenLocal only — nothing outward. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)