### PR TITLE
consumer(R2): from-published tool resolution + samples/minimal as a real external consumer (#128)

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -99,7 +99,15 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             val ext = target.extensions.findByType(KPlusPlusExtension::class.java)
             val hasHeadersAtConfig = ext?.headers?.isNotEmpty() == true
             if (!seedMode) {
-                it.inputs.file(kexe).withPropertyName("krapperGenKexe")
+                // inputs.files (plural), NOT inputs.file (singular): for a from-published
+                // consumer (R2, #128) the kexe is a mavenLocal artifact staged under
+                // build/ (resolvePublishedTool). If a `clean` in the SAME invocation wipes
+                // build/ AFTER configuration staged it, singular inputs.file would abort at
+                // validation on the missing path; the plural form tolerates a non-existent
+                // entry, lets the task run, and the doLast re-stages it via resolveKrapperGen
+                // (idempotent) or fails fast on a genuinely-missing tool. When the file is
+                // present it still drives the up-to-date check identically.
+                it.inputs.files(kexe).withPropertyName("krapperGenKexe")
                     .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.NONE)
             }
             it.inputs.files(manifestFile).withPropertyName("requestedManifest")
@@ -138,15 +146,22 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                     return@doLast
                 }
                 if (target.findProperty("kpp.frontend.$moduleName") == "cpp") {
-                    if (!kexe.exists()) {
+                    // Re-resolve at execution time: for the published path this re-stages
+                    // the tool from mavenLocal if build/ was wiped by a same-invocation
+                    // `clean` after configuration staged it (resolvePublishedTool is
+                    // idempotent). For the in-tree paths this returns the same kexe.
+                    val execKexe = resolveKrapperGen(target).second
+                    if (!execKexe.exists()) {
                         throw GradleException(
-                            "kplusplusSync: krapper_gen kexe not found at $kexe. Either run " +
-                                ":krapper_gen:linkDebugExecutableNative in the kplusplus " +
-                                "included build, or check the includeBuild(\"...\") path in " +
-                                "your settings.gradle.kts."
+                            "kplusplusSync: krapper_gen kexe not found at $execKexe. Either " +
+                                "run :krapper_gen:linkDebugExecutableNative in the kplusplus " +
+                                "included build, check the includeBuild(\"...\") path in your " +
+                                "settings.gradle.kts, or (for a from-published consumer) " +
+                                "declare mavenLocal() so " +
+                                "com.monkopedia.kplusplus:krapper_gen:$PLUGIN_VERSION resolves."
                         )
                     }
-                    runKrapperParseSync(target, ext, moduleName, krappedDir, kexe)
+                    runKrapperParseSync(target, ext, moduleName, krappedDir, execKexe)
                     return@doLast
                 }
                 throw GradleException(
@@ -525,11 +540,80 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 return taskRef to kexe
             }
         }
+        // Published-artifact fallback (R2, #128): no in-tree source (sibling or
+        // includedBuild), so this is a TRUE external consumer (declares the plugin +
+        // a repo, NO includeBuild). Resolve the krapper_gen tool from its published
+        // Maven coordinate — the SAME mechanism the #126 stage-0 seam uses for
+        // krapper_parse (resolveStage0Path). Requires mavenLocal() in the consumer's
+        // repositories. Additive + LAST: dev/self-build flows keep their in-tree path.
+        resolvePublishedTool(target, "krapper_gen")?.let { return null to it }
+
         // Final fallback: the legacy hardcoded path. The doLast will throw a
         // helpful error if it doesn't exist.
         return null to target.rootProject.file(
             "krapper_gen/build/bin/native/debugExecutable/krapper_gen.kexe"
         )
+    }
+
+    /**
+     * Published-artifact fallback (R2, #128) — resolve a tool binary
+     * (`krapper_gen` / `krapper_parse`) from its published Maven coordinate for a
+     * TRUE external consumer that declares the plugin + a repository but NO
+     * `includeBuild` (neither sibling project nor included build is present).
+     *
+     * Models the #126 stage-0 consume seam (`resolveStage0Path` in
+     * krapper_parse/build.gradle.kts): a resolvable [Configuration] with a single
+     * dependency on `com.monkopedia.kplusplus:<tool>:<PLUGIN_VERSION>` selecting the
+     * `linuxX64` classifier + EMPTY extension (the publications are artifact-only, no
+     * `.jar`), `isTransitive=false`. The resolved artifact comes back mode 0644 (a
+     * Maven repo drops the exec bit), so we copy it into the consumer's build dir and
+     * `setExecutable(true)` — exactly what `resolveStage0Path` does — because the sync
+     * launches these via ProcessBuilder, which needs +x.
+     *
+     * Returns the staged, executable File, or null if resolution fails (no mavenLocal
+     * repo / artifact not published) — the caller then falls through to its
+     * fail-fast-at-execution error path. The consumer must declare `mavenLocal()`.
+     */
+    private fun resolvePublishedTool(target: Project, tool: String): File? {
+        return try {
+            val coordinate = "$PLUGIN_GROUP:$tool:$PLUGIN_VERSION"
+            val configName = "kplusplusTool${tool.replaceFirstChar { it.uppercase() }}"
+            val config = target.configurations.findByName(configName)
+                ?: target.configurations.create(configName) {
+                    it.isCanBeConsumed = false
+                    it.isCanBeResolved = true
+                    it.dependencies.add(
+                        target.dependencies.create(coordinate).also { dep ->
+                            (dep as? org.gradle.api.artifacts.ModuleDependency)?.apply {
+                                isTransitive = false
+                                artifact { art ->
+                                    art.name = tool
+                                    art.classifier = "linuxX64"
+                                    art.extension = ""
+                                }
+                            }
+                        }
+                    )
+                }
+            val resolved = config.resolve().singleOrNull() ?: return null
+            if (!resolved.exists()) return null
+            // Maven drops the exec bit — stage an executable copy under the build dir.
+            val staged = File(
+                target.layout.buildDirectory.get().asFile,
+                "kplusplus/tools/$tool"
+            )
+            staged.parentFile.mkdirs()
+            if (!staged.exists() ||
+                staged.length() != resolved.length() ||
+                staged.lastModified() < resolved.lastModified()
+            ) {
+                resolved.copyTo(staged, overwrite = true)
+                staged.setExecutable(true)
+            }
+            staged
+        } catch (_: Exception) {
+            null
+        }
     }
 
     /**
@@ -594,6 +678,13 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 return taskRef to binary
             }
         }
+        // Published-artifact fallback (R2, #128): a TRUE external consumer has neither
+        // a sibling :krapper_parse project nor an includeBuild that hosts it. Resolve
+        // the LLVM parser tool from its published Maven coordinate (needs mavenLocal()).
+        // The published krapper_parse binary is LLVM-linked and needs LLVM present at
+        // RUNTIME — but a standalone consumer has no in-tree LLVM-gated modules, so no
+        // -PenableClang is needed here (that flag only gates in-tree root-build modules).
+        resolvePublishedTool(target, "krapper_parse")?.let { return null to it }
         return null to target.rootProject.file(relBinary)
     }
 

--- a/samples/minimal/README.md
+++ b/samples/minimal/README.md
@@ -4,6 +4,11 @@ The smallest end-to-end kplusplus sample: a tiny hand-written C++ geometry libra
 to Kotlin/Native and run. No standard-library template surface, no 62 MB monolith — the
 fastest first contact with kplusplus.
 
+This is a **true from-published consumer** (#128, R2): it declares the plugin by version and
+`mavenLocal()` — **no `includeBuild`**. The plugin marker, the FIR plugin, and the
+`krapper_gen` / `krapper_parse` tool binaries are all resolved by Maven coordinate from
+mavenLocal. This is the same standalone path k++ uses to self-host as its own first consumer.
+
 ## What it binds
 
 [`cpp/geometry.h`](cpp/geometry.h) — two plain structs in `namespace geo`:
@@ -21,9 +26,21 @@ The generated Kotlin API and the `main` that drives it live in
 
 ## Run it
 
+First publish the kplusplus consumer set to your local Maven repo (from the repo root, once):
+
 ```
-./gradlew runReleaseExecutableKlinker -PenableClang
+./gradlew publishAllToMavenLocal -PenableClang
 ```
+
+Then, from this directory:
+
+```
+./gradlew runReleaseExecutableKlinker
+```
+
+No `-PenableClang` is needed here: a standalone consumer has no in-tree LLVM-gated modules;
+the `krapper_parse` tool is resolved as a published binary from mavenLocal (`-PenableClang`
+only gates modules inside the kplusplus root build, which this consumer does not include).
 
 Expected output:
 
@@ -36,9 +53,9 @@ center: (1.0, 1.5)
 ## Requirements
 
 kplusplus's front-end is **self-hosted on Clang** (it parses your headers on
-generated Clang-AST bindings), so a build-time **LLVM/Clang toolchain is required** and the
-front-end is gated behind `-PenableClang`. `clang++` must be on `PATH` — it both parses the
-header and compiles `cpp/geometry.cc`. JDK 21 is required to run the build.
+generated Clang-AST bindings). The published `krapper_parse` tool binary is LLVM-linked, so a
+**LLVM/Clang toolchain must be present at runtime**; `clang++` must be on `PATH` — it both
+parses the header and compiles `cpp/geometry.cc`. JDK 21 is required to run the build.
 
 The first build is slow (it builds the self-hosted front-end, generates the bindings, then
 compiles and links the generated C++ wrapper); later runs are incremental.

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -23,9 +23,10 @@ buildscript {
 }
 plugins {
     kotlin("multiplatform") version "2.4.0"
-    // The kplusplus compiler subplugin. Everything kplusplus-specific lives in the
-    // narrow `kplusplus { ... }` block at the bottom of this file.
-    id("com.monkopedia.kplusplus.compiler")
+    // The kplusplus compiler subplugin, resolved from its published mavenLocal marker
+    // (R2, #128) — no includeBuild. Everything kplusplus-specific lives in the narrow
+    // `kplusplus { ... }` block at the bottom of this file.
+    id("com.monkopedia.kplusplus.compiler") version "0.3.0"
     id("com.monkopedia.klinker.plugin") version "0.2.0"
 }
 

--- a/samples/minimal/gradle.properties
+++ b/samples/minimal/gradle.properties
@@ -1,6 +1,10 @@
 kotlin.native.cacheKind.linuxX64=none
 org.gradle.jvmargs=-Xmx4096m
 # Self-host the geometry bindings through the cpp front-end (built on generated
-# libclang-cpp bindings). Requires -PenableClang on the command line (the front-end
-# is LLVM-gated). The property key is this project's rootProject.name (minimal).
+# libclang-cpp bindings). As a from-published consumer (R2, #128) the krapper_parse
+# tool binary is resolved by coordinate from mavenLocal — there are NO in-tree
+# LLVM-gated modules here, so -PenableClang is NOT needed (that flag only gates
+# modules in the kplusplus root build). The published krapper_parse is LLVM-linked
+# and needs an LLVM/Clang toolchain present at RUNTIME (clang++ on PATH).
+# The property key is this project's rootProject.name (minimal).
 kpp.frontend.minimal=cpp

--- a/samples/minimal/settings.gradle.kts
+++ b/samples/minimal/settings.gradle.kts
@@ -16,13 +16,14 @@
 rootProject.name = "minimal"
 pluginManagement {
     repositories {
+        // A TRUE from-published consumer (R2, #128): NO includeBuild. The kplusplus
+        // compiler subplugin is resolved from its published mavenLocal plugin marker
+        // (com.monkopedia.kplusplus.compiler → kplusplus-compiler-gradle 0.3.0), and
+        // the tool binaries (krapper_gen / krapper_parse) are resolved by coordinate
+        // from mavenLocal by the plugin itself. This is the same standalone path k++
+        // uses to self-host as its own first consumer.
+        mavenLocal()
         gradlePluginPortal()
         mavenCentral()
-        mavenLocal()
     }
-    // The v2 compiler subplugin lives in the main kplusplus repo, pulled in as an
-    // included build. samples/minimal is two levels below the repo root, so `../../`
-    // is that root (whose settings.gradle.kts publishes the subplugin). This holds
-    // both in the canonical checkout and in a .claude/worktrees/<id>/ worktree.
-    includeBuild("../../")
 }


### PR DESCRIPTION
## R2 (epic #128) — prove a REAL from-published consumer works

Starts from R1/#130 (version unified to 0.3.0, the full consumer set published to mavenLocal). Today the plugin only finds the `krapper_gen`/`krapper_parse` tool binaries as in-tree sibling projects or `includeBuild`s. A true external consumer (declares the plugin + a repo, **NO `includeBuild`**) has neither. This makes that work end-to-end against mavenLocal and proves it by converting `samples/minimal` into a genuine from-published consumer that BUILDS AND RUNS — the same path k++ will use to self-host as its own first consumer.

### (A) Plugin — resolve the tool binaries from published Maven artifacts
`KPlusPlusCompilerGradlePlugin.kt`:
- New `resolvePublishedTool()`: a resolvable `Configuration` depending on `com.monkopedia.kplusplus:<tool>:0.3.0` with the `linuxX64` classifier + empty extension + `isTransitive=false`, resolved to a `File`, copied to `build/kplusplus/tools/<tool>` and `setExecutable(true)` (Maven drops the exec bit). Modeled directly on the #126 stage-0 consume seam (`resolveStage0Path`).
- `resolveKrapperGen` / `resolveKrapperParse` append this fallback **LAST** → resolution order is **in-tree sibling → includedBuild → published**. Existing dev/self-build flows are byte-for-byte unchanged; the fallback only fires when there is no in-tree tool.
- The FIR plugin jar keeps resolving via `getPluginArtifact()`'s `SubpluginArtifact` (Kotlin pulls it from the consumer's declared repos) — confirmed a `mavenLocal()` consumer picks it up.
- Robustness: `krapperGenKexe` becomes an `inputs.files` (plural — tolerates a staged path wiped by a same-invocation `clean`) and the cpp `doLast` re-resolves/re-stages the tool at execution time, so `clean run` in one invocation works.

### (B) `samples/minimal` → pure from-published consumer
- `settings.gradle.kts`: drop `includeBuild("../../")`; `pluginManagement { repositories { mavenLocal(); gradlePluginPortal(); mavenCentral() } }` resolves the plugin marker.
- `build.gradle.kts`: apply `id("com.monkopedia.kplusplus.compiler") version "0.3.0"`; `repositories` already carry `mavenLocal()`+`mavenCentral()` for the tool config + FIR plugin + ksrpc-jni.
- `gradle.properties`/`README`: **`-PenableClang` is NOT needed** for a standalone consumer (it only gates modules inside the kplusplus root build, which this consumer does not include); the published `krapper_parse` is LLVM-linked and needs `clang++` on `PATH` at runtime.

## Verification
- **From-published build + RUN** (no `includeBuild`, no `-PenableClang`), from a wiped `build/`:
  ```
  PARITY_BASE .../build/krapped-cpp/cpp-models/base_model.json
  kplusplusSync[minimal]: krapper_gen (cpp model) over 0 instantiation(s) ... -> .../build/krapped-cpp
  kplusplusSync[minimal]: cpp front-end generated 3 Kotlin file(s).
  Rect area: 6.0
  distance (0,0)->(3,4): 5.0
  center: (1.0, 1.5)
  BUILD SUCCESSFUL
  ```
- Tools resolved from `~/.m2`: staged `build/kplusplus/tools/{krapper_gen,krapper_parse}` are **byte-identical (md5)** to `~/.m2/repository/com/monkopedia/kplusplus/{krapper_gen,krapper_parse}/0.3.0/...-linuxX64`.
- `clean runReleaseExecutableKlinker` in a single invocation also passes (re-stage-on-execute robustness).
- **In-tree dev flow unbroken**: `:featuregen:kplusplusSync -PenableClang -m` (dry-run) still resolves via the sibling `:krapper_gen:linkDebugExecutableNative` / `:krapper_parse:linkReleaseExecutableKlinker` link tasks — no mavenLocal fallback, no tool staging.

`samples/v8` still uses `includeBuild` — left as-is.

Refs #128 (R2). mavenLocal only; nothing outward. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)