### PR TITLE
publish(R3): restore the outward publish pipeline on the Central Portal + Plugin Portal (#128)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,15 @@ jobs:
       # in the build and its release binary ships too.
       - name: Publish to the Central Portal (staging)
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          # Reuse the EXISTING repo secrets (from the v1 pipeline — still set, deleting the old
+          # workflow never removed them) rather than new ones. The Central Portal user token
+          # (central.sonatype.com) maps onto the OSSRH_USERNAME/OSSRH_TOKEN pair; if the old
+          # OSSRH token no longer authenticates against the Portal, only those two VALUES need
+          # regenerating — the names stay. OSSRH_GPG_SECRET_KEY is the same armored key v1 used.
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: ./gradlew publishAllToMavenCentral -PenableClang --no-configuration-cache
 
       - name: Release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+# Release: publish the kplusplus v2 artifact set outward.
+#
+#   * The Gradle plugin (com.monkopedia.kplusplus.compiler) -> the Gradle Plugin Portal
+#     AND the Central Portal (so both `gradlePluginPortal()` and `mavenCentral()` consumers
+#     resolve `id("...") version "..."`).
+#   * The FIR kotlinc-plugin jar -> the Central Portal.
+#   * The krapper_gen + krapper_parse native tool binaries (classifier linuxX64) -> Central.
+#
+# Everything is GPG-signed (vanniktech in-memory key) and lands in a Central Portal STAGING
+# deployment the owner then releases from https://central.sonatype.com (automaticRelease is
+# false). See docs/releasing.md for the required GitHub Secrets and the cut-a-release steps.
+name: Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # krapper_parse links against the system LLVM/Clang toolchain (libclang-cpp + libLLVM);
+      # the parser binary is built FROM SEED (a plain C++ recompile) but still needs clang++
+      # and the LLVM libs present on the runner. -PenableClang brings :krapper_parse into the
+      # build; the settings probe discovers the LLVM major + libdir from llvm-config.
+      - name: Install LLVM/Clang toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm llvm-dev libclang-cpp-dev gcc-multilib
+
+      # --- Publish the Gradle plugin to the Gradle Plugin Portal ---
+      # publishPlugins uses gradle.publish.key / gradle.publish.secret.
+      - name: Publish Gradle plugin to the Plugin Portal
+        run: >-
+          ./gradlew -p compiler :kplusplus-compiler-gradle:publishPlugins
+          -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
+          -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+      # --- Publish the whole set to the Central Portal (staging) ---
+      # vanniktech reads the Central Portal token + the in-memory GPG key from these env vars
+      # (ORG_GRADLE_PROJECT_* -> Gradle properties mavenCentralUsername / mavenCentralPassword
+      # / signingInMemoryKey / signingInMemoryKeyPassword). -PenableClang so :krapper_parse is
+      # in the build and its release binary ships too.
+      - name: Publish to the Central Portal (staging)
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishAllToMavenCentral -PenableClang --no-configuration-cache
+
+      - name: Release notes
+        run: |
+          echo "Uploaded the kplusplus release set to the Central Portal STAGING area and"
+          echo "published the Gradle plugin to the Plugin Portal."
+          echo "Finish the Central release at https://central.sonatype.com (Deployments)."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.vannik.publish) apply false
+    // The native-binary modules (:krapper_gen, :krapper_parse) apply the vanniktech BASE
+    // plugin to add the Central Portal upload + signing to their hand-rolled artifact-only
+    // publications. Declared apply-false here so their `alias(...)` resolves the version once.
+    alias(libs.plugins.vannik.publish.base) apply false
     alias(libs.plugins.ktlint)
 }
 
@@ -45,12 +48,48 @@ tasks.register("publishAllToMavenLocal") {
         dependsOn(":krapper_parse:publishReleaseBinaryToMavenLocal")
     }
     doLast {
-        val note = if (findProject(":krapper_parse") == null) {
-            "\nNOTE: :krapper_parse was NOT published — it is LLVM-gated. Re-run with " +
-                "-PenableClang (or -PllvmConfig=<path>) on an LLVM host to publish the parser."
-        } else {
-            ""
-        }
+        val note =
+            if (findProject(":krapper_parse") == null) {
+                "\nNOTE: :krapper_parse was NOT published — it is LLVM-gated. Re-run with " +
+                    "-PenableClang (or -PllvmConfig=<path>) on an LLVM host to publish the parser."
+            } else {
+                ""
+            }
         println("publishAllToMavenLocal: published the kplusplus consumer set to mavenLocal.$note")
+    }
+}
+
+// ---- Outward release: publish the whole set to the Central Portal (CI/release ONLY) ----
+//
+// The Central-bound half of the artifact set. Requires the Central Portal token + the GPG
+// signing key/passphrase in the environment (see docs/releasing.md + .github/workflows/
+// release.yml). The Gradle plugin ALSO goes to the Gradle Plugin Portal via
+// `:kplusplus-compiler-gradle:publishPlugins` — driven separately by the release workflow.
+//
+// This targets the per-publication Central tasks so ONLY the release artifacts ship (the
+// stage0 mavenLocal anchor is deliberately excluded). :krapper_parse is LLVM-gated, so on a
+// non-LLVM host it is absent and the parser must be released from an LLVM host.
+tasks.register("publishAllToMavenCentral") {
+    group = "kplusplus"
+    description =
+        "Publish the kplusplus release artifact set to the Central Portal (CI/release — " +
+        "requires Central Portal credentials + GPG signing in the environment)."
+    dependsOn(gradle.includedBuild("compiler").task(":publishCompilerToMavenCentral"))
+    // vanniktech's per-module `publishToMavenCentral` uploads that module's Portal bundle;
+    // the unwanted KMP/stage0 publications are disabled for Central in each build file, so
+    // each bundle carries only its Central-valid release artifact(s).
+    dependsOn(":krapper_gen:publishToMavenCentral")
+    if (findProject(":krapper_parse") != null) {
+        dependsOn(":krapper_parse:publishToMavenCentral")
+    }
+    doLast {
+        val note =
+            if (findProject(":krapper_parse") == null) {
+                "\nWARNING: :krapper_parse was NOT published — it is LLVM-gated. Release the " +
+                    "parser from an LLVM host with -PenableClang (or -PllvmConfig=<path>)."
+            } else {
+                ""
+            }
+        println("publishAllToMavenCentral: uploaded the kplusplus release set to Central.$note")
     }
 }

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -1,12 +1,23 @@
+plugins {
+    // Declared apply-false so the sub-modules can `alias(...)` them (resolves the versions
+    // from the catalog once, at the included-build root). The Kotlin plugin is ALSO declared
+    // here apply-false so the vanniktech publish plugin can access the Kotlin plugin classes
+    // via a shared buildscript classloader (vanniktech requires this — otherwise it fails
+    // with "not able to access Kotlin plugin classes").
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.vannik.publish) apply false
+    alias(libs.plugins.gradle.plugin.publish) apply false
+}
+
 allprojects {
     group = "com.monkopedia.kplusplus"
     version = "0.3.0"
 }
 
-// R1 (#128): aggregate publish for the two consumer-facing JVM artifacts that live in this
-// (included) `compiler` build — the Gradle plugin (+ its plugin marker) and the FIR kotlinc
-// plugin jar. The root build's `publishAllToMavenLocal` invokes this via the included build
-// so a single command publishes the whole consumer set to mavenLocal. mavenLocal only.
+// Aggregate publish for the two consumer-facing JVM artifacts that live in this (included)
+// `compiler` build — the Gradle plugin (+ its plugin marker) and the FIR kotlinc plugin jar.
+// The root build's `publishAllToMavenLocal` invokes this via the included build so a single
+// command publishes the whole consumer set to mavenLocal. mavenLocal only.
 tasks.register("publishCompilerToMavenLocal") {
     group = "kplusplus"
     description =
@@ -15,4 +26,30 @@ tasks.register("publishCompilerToMavenLocal") {
         ":kplusplus-compiler-gradle:publishToMavenLocal",
         ":kplusplus-compiler-plugin:publishToMavenLocal"
     )
+}
+
+// Aggregate publish of the two JVM artifacts to the Central Portal (CI/release only — needs
+// the Central Portal token + GPG passphrase from the environment). The Gradle plugin is ALSO
+// published to the Gradle Plugin Portal via `:kplusplus-compiler-gradle:publishPlugins`; the
+// release workflow drives both. mavenCentral aggregate here covers Central only.
+tasks.register("publishCompilerToMavenCentral") {
+    group = "kplusplus"
+    description =
+        "Publish the Gradle plugin (+ marker) and the FIR kotlinc-plugin jar to the " +
+            "Central Portal (release/CI — requires credentials + signing in the environment)."
+    dependsOn(
+        ":kplusplus-compiler-gradle:publishToMavenCentral",
+        ":kplusplus-compiler-plugin:publishToMavenCentral"
+    )
+}
+
+// Publish the Gradle plugin (+ marker) to the Gradle Plugin Portal. Separate from the
+// Central path — driven by the release workflow with the Portal key/secret in the
+// environment (see docs/releasing.md). The `com.gradle.plugin-publish` plugin owns this.
+tasks.register("publishPluginToPortal") {
+    group = "kplusplus"
+    description =
+        "Publish the com.monkopedia.kplusplus.compiler Gradle plugin to the Gradle Plugin " +
+            "Portal (release/CI — requires GRADLE_PUBLISH_KEY/GRADLE_PUBLISH_SECRET)."
+    dependsOn(":kplusplus-compiler-gradle:publishPlugins")
 }

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -1,14 +1,23 @@
+import com.vanniktech.maven.publish.GradlePlugin
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java-gradle-plugin")
-    kotlin("jvm") version "2.4.0"
-    // R1 (#128): publish this Gradle plugin to mavenLocal. With `java-gradle-plugin`,
-    // `maven-publish` auto-creates BOTH the main jar publication (`pluginMaven`) AND the
-    // plugin-marker publication (com.monkopedia.kplusplus.compiler:...gradle.plugin) that
-    // makes `id("com.monkopedia.kplusplus.compiler") version "0.3.0"` resolvable from a repo.
-    `maven-publish`
+    kotlin("jvm")
+    // Publish the Gradle plugin. Two cooperating plugins (the de-facto standard combo):
+    //   * com.vanniktech.maven.publish — POM metadata, sources+javadoc jars, GPG signing,
+    //     and the Central Portal upload for BOTH the plugin jar AND its marker publication,
+    //     so `mavenCentral()` consumers can resolve `id(...) version "..."`.
+    //   * com.gradle.plugin-publish — the Gradle Plugin Portal upload (`publishPlugins`).
+    // With `java-gradle-plugin`, vanniktech's `GradlePlugin` platform wires the main
+    // `pluginMaven` publication AND the `...gradle.plugin` marker; the plugin-publish plugin
+    // owns the Portal side. `publishToMavenLocal` still yields the same coordinates R1 did.
+    alias(libs.plugins.vannik.publish)
+    alias(libs.plugins.gradle.plugin.publish)
 }
 
 group = "com.monkopedia.kplusplus"
@@ -28,12 +37,66 @@ java {
 }
 
 gradlePlugin {
+    website.set("https://github.com/Monkopedia/kplusplus")
+    vcsUrl.set("https://github.com/Monkopedia/kplusplus.git")
     plugins.create("kplusplusCompiler") {
         id = "com.monkopedia.kplusplus.compiler"
         implementationClass =
             "com.monkopedia.kplusplus.compiler.gradle.KPlusPlusCompilerGradlePlugin"
         displayName = "kplusplus compiler plugin"
         description = "Usage-driven C++ template instantiation for kplusplus"
+        tags.set(listOf("kotlin", "native", "cpp", "cinterop", "bindings"))
+    }
+}
+
+// Sign only when a key is actually available (CI). Vanniktech's signAllPublications() wires
+// signing unconditionally, and with no signatory present the sign task FAILS ("no configured
+// signatory") — including for a plain, unsigned `publishToMavenLocal`. Gate it on the
+// in-memory key so local mavenLocal stays credential-free while CI signs. The release
+// workflow exports ORG_GRADLE_PROJECT_signingInMemoryKey from the SIGNING_KEY secret.
+val signingConfigured =
+    providers.gradleProperty("signingInMemoryKey").isPresent ||
+        providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey").isPresent
+
+mavenPublishing {
+    // Central Portal endpoint (OSSRH is sunset). automaticRelease=false: the CI upload lands
+    // in a Portal staging deployment the owner releases from central.sonatype.com.
+    publishToMavenCentral(automaticRelease = false)
+    // Sign every publication with the in-memory GPG key supplied by CI env
+    // (ORG_GRADLE_PROJECT_signingInMemoryKey / ...Password, from the SIGNING_KEY /
+    // SIGNING_PASSWORD secrets) — only when that key is present (see above).
+    if (signingConfigured) signAllPublications()
+    // `java-gradle-plugin` already registers a real `javadocJar` + `sourcesJar` on the java
+    // component (via withJavadocJar()/withSourcesJar()). Tell vanniktech NOT to add its own
+    // (JavadocJar.None()) — adding an empty one duplicates the classifier and the publication
+    // is rejected. The java-plugin javadoc jar (empty in practice, but a valid jar) satisfies
+    // Central's per-artifact javadoc rule.
+    configure(GradlePlugin(javadocJar = JavadocJar.None(), sourcesJar = SourcesJar.Sources()))
+    pom {
+        name.set("kplusplus compiler Gradle plugin")
+        description.set(
+            "The com.monkopedia.kplusplus.compiler Gradle plugin: usage-driven C++ template " +
+                "instantiation and Kotlin/Native bindings generation for kplusplus."
+        )
+        url.set("https://github.com/Monkopedia/kplusplus")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("Monkopedia")
+                name.set("Jason Monk")
+                email.set("monkopedia@gmail.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/Monkopedia/kplusplus")
+            connection.set("scm:git:git://github.com/Monkopedia/kplusplus.git")
+            developerConnection.set("scm:git:ssh://git@github.com/Monkopedia/kplusplus.git")
+        }
     }
 }
 
@@ -41,4 +104,15 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
     }
+}
+
+// Gradle 9.4 strict task-dependency validation trips when the `pluginMaven` module-metadata
+// generator reads vanniktech's empty-javadoc jar without a declared task dependency (the
+// java-gradle-plugin + empty-javadoc combination — a vanniktech/Gradle-9 interaction).
+// Gradle Module Metadata (.module) is OPTIONAL for both the Central and the Gradle Plugin
+// Portal — a Gradle plugin resolves from its marker POM + the plugin jar POM (R1's markers
+// were POM-only). Disable .module generation to sidestep the false-positive validation; the
+// POM + sources + javadoc jars (what Central actually validates) are unaffected.
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
 }

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.4.0"
+    kotlin("jvm")
 }
 
 group = "com.monkopedia.kplusplus"

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -1,26 +1,54 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.4.0"
-    // R1 (#128): publish this FIR kotlinc-plugin jar to mavenLocal so the Gradle plugin's
-    // SubpluginArtifact (com.monkopedia.kplusplus:kplusplus-compiler-plugin) resolves from a
-    // repo for a from-published consumer, not just an includeBuild sibling.
-    `maven-publish`
+    kotlin("jvm")
+    // Publish this FIR kotlinc-plugin jar to the Central Portal (and mavenLocal) so the
+    // Gradle plugin's SubpluginArtifact (com.monkopedia.kplusplus:kplusplus-compiler-plugin)
+    // resolves from a repo for a from-published consumer. vanniktech supplies the Central-
+    // valid POM + sources/javadoc jars + GPG signing; `publishToMavenLocal` keeps R1's coords.
+    alias(libs.plugins.vannik.publish)
 }
 
 group = "com.monkopedia.kplusplus"
 version = "0.3.0"
 
-// The default `maven` publication + jar. artifactId defaults to the project name
-// (kplusplus-compiler-plugin), which is exactly what KPlusPlusCompilerGradlePlugin's
-// SubpluginArtifact requests. Publishing to mavenLocal only (R1, #128) — no signing, no
-// remote repo. The published POM carries the ksrpc-jni runtime dep so the kotlinc plugin
-// classpath resolves it transitively.
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
+// Sign only when a key is present (CI); otherwise local publishToMavenLocal fails with "no
+// configured signatory". See compiler/gradle/build.gradle.kts for the full rationale.
+val signingConfigured =
+    providers.gradleProperty("signingInMemoryKey").isPresent ||
+        providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey").isPresent
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (signingConfigured) signAllPublications()
+    configure(KotlinJvm(javadocJar = JavadocJar.Empty(), sourcesJar = true))
+    pom {
+        name.set("kplusplus compiler (FIR plugin)")
+        description.set(
+            "The kplusplus kotlinc (FIR) compiler plugin jar, loaded on the Kotlin/Native " +
+                "compiler classpath by the com.monkopedia.kplusplus.compiler Gradle plugin."
+        )
+        url.set("https://github.com/Monkopedia/kplusplus")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("Monkopedia")
+                name.set("Jason Monk")
+                email.set("monkopedia@gmail.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/Monkopedia/kplusplus")
+            connection.set("scm:git:git://github.com/Monkopedia/kplusplus.git")
+            developerConnection.set("scm:git:ssh://git@github.com/Monkopedia/kplusplus.git")
         }
     }
 }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,80 @@
+# Releasing kplusplus
+
+kplusplus (v2) publishes to two places:
+
+- **The Central Portal** (`central.sonatype.com`, the successor to the sunset OSSRH) — the FIR
+  plugin jar, the two native tool binaries, and the Gradle plugin + its marker (so
+  `mavenCentral()` consumers can resolve `id("com.monkopedia.kplusplus.compiler") version "…"`).
+- **The Gradle Plugin Portal** (`plugins.gradle.org`) — the Gradle plugin, so
+  `gradlePluginPortal()` consumers resolve it too.
+
+Publishing is wired with [`com.vanniktech.maven.publish`](https://vanniktech.github.io/gradle-maven-publish-plugin/)
+(POM metadata, sources/javadoc jars, GPG signing, Central Portal upload) plus
+`com.gradle.plugin-publish` (the Plugin Portal upload). Everything is GPG-signed and lands in a
+Central Portal **staging deployment** that the owner releases manually.
+
+## The artifact set
+
+| Coordinate | Where | Notes |
+|---|---|---|
+| `com.monkopedia.kplusplus.compiler` (plugin marker) | Plugin Portal + Central | resolves `id(...) version "..."` |
+| `com.monkopedia.kplusplus:kplusplus-compiler-gradle` | Plugin Portal + Central | the Gradle plugin jar |
+| `com.monkopedia.kplusplus:kplusplus-compiler-plugin` | Central | the FIR kotlinc-plugin jar |
+| `com.monkopedia.kplusplus:krapper_gen` (classifier `linuxX64`) | Central | resolve+codegen tool binary |
+| `com.monkopedia.kplusplus:krapper_parse` (classifier `linuxX64`) | Central | LLVM parser tool binary |
+
+The two native tool binaries are classified, extension-less artifacts (a Kotlin/Native `.kexe`
+is not a jar). Central still requires a complete POM + a sources jar + a javadoc jar + GPG
+signatures per coordinate, so each ships **empty (stub) sources + javadoc jars** alongside the
+binary. The `krapper_parse` stage-0 bootstrap anchor (`krapper_parse-stage0:0.2.3-stage0`) is a
+mavenLocal-only artifact and is deliberately **not** published to Central.
+
+## Required GitHub Secrets
+
+Set these in the repository (Settings → Secrets and variables → Actions) before cutting a
+release. Nothing is hardcoded; the workflow reads them all from the environment.
+
+| Secret | What it is | Where to get it |
+|---|---|---|
+| `MAVEN_CENTRAL_USERNAME` | Central Portal **token username** | central.sonatype.com → Account → Generate User Token |
+| `MAVEN_CENTRAL_PASSWORD` | Central Portal **token password** | (same token pair) |
+| `SIGNING_KEY` | ASCII-armored GPG **private key** (the whole `-----BEGIN PGP PRIVATE KEY BLOCK-----` block) | `gpg --armor --export-secret-keys 5B83421E2338B907` |
+| `SIGNING_PASSWORD` | passphrase for that GPG key | — |
+| `GRADLE_PUBLISH_KEY` | Gradle Plugin Portal API key | plugins.gradle.org → your API keys |
+| `GRADLE_PUBLISH_SECRET` | Gradle Plugin Portal API secret | (same) |
+
+The legacy v1 signing key is `5B83421E2338B907` — export that same key into `SIGNING_KEY` /
+`SIGNING_PASSWORD` so v2 is signed with the established identity. (v2 uses vanniktech's
+**in-memory** key mechanism, not the old `signing.gnupg.keyName` in `gradle.properties`, which
+was removed because its mere presence broke unsigned local `publishToMavenLocal`.)
+
+## Cutting a release
+
+1. Make sure `version` in the root `gradle.properties` (and the `version = "…"` in the compiler
+   modules) is the release version, committed on `main`.
+2. Create a GitHub **Release** (publish it). That fires `.github/workflows/release.yml`
+   (`release: published`), or run the workflow manually via **workflow_dispatch**.
+3. The workflow, on an LLVM-equipped runner:
+   - installs the LLVM/Clang toolchain (`krapper_parse` links against `libclang-cpp`/`libLLVM`);
+   - `:kplusplus-compiler-gradle:publishPlugins` → Gradle Plugin Portal;
+   - `publishAllToMavenCentral -PenableClang` → uploads the signed bundle to the Central Portal
+     **staging** area (`automaticRelease = false`).
+4. Go to https://central.sonatype.com → **Deployments**, verify the staged deployment
+   validated, and **publish** it. (Set `automaticRelease = true` in the `publishToMavenCentral`
+   calls if you prefer it to auto-release.)
+
+## Local dry run (no outward upload)
+
+Everything is validated locally against `~/.m2` without any credentials:
+
+```sh
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+# Full consumer set to mavenLocal (add -PenableClang to include krapper_parse):
+./gradlew publishAllToMavenLocal -PenableClang
+# Prove the from-published consumer still resolves + runs from mavenLocal:
+(cd samples/minimal && ./gradlew runReleaseExecutableKlinker)
+```
+
+`publishToMavenLocal` does **not** sign (no key in the environment) — signing is exercised only
+in CI. The only thing not verifiable without real credentials is whether the Central Portal
+*accepts* the staged bundle; that is confirmed at the first real cut, in the Deployments UI.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,22 +31,27 @@ mavenLocal-only artifact and is deliberately **not** published to Central.
 
 ## Required GitHub Secrets
 
-Set these in the repository (Settings → Secrets and variables → Actions) before cutting a
-release. Nothing is hardcoded; the workflow reads them all from the environment.
+**These six secrets already exist in the repo** — they were set for the v1 pipeline and were
+never removed (deleting the old `publish.yaml` workflow does not delete repo secrets). The
+restored workflow **reuses the same names**, so in the common case there is nothing new to set:
 
-| Secret | What it is | Where to get it |
-|---|---|---|
-| `MAVEN_CENTRAL_USERNAME` | Central Portal **token username** | central.sonatype.com → Account → Generate User Token |
-| `MAVEN_CENTRAL_PASSWORD` | Central Portal **token password** | (same token pair) |
-| `SIGNING_KEY` | ASCII-armored GPG **private key** (the whole `-----BEGIN PGP PRIVATE KEY BLOCK-----` block) | `gpg --armor --export-secret-keys 5B83421E2338B907` |
-| `SIGNING_PASSWORD` | passphrase for that GPG key | — |
-| `GRADLE_PUBLISH_KEY` | Gradle Plugin Portal API key | plugins.gradle.org → your API keys |
-| `GRADLE_PUBLISH_SECRET` | Gradle Plugin Portal API secret | (same) |
+| Secret (existing) | What it is | Maps to (vanniktech) | If it needs refreshing |
+|---|---|---|---|
+| `OSSRH_USERNAME` | Central Portal **token username** | `mavenCentralUsername` | central.sonatype.com → Account → Generate User Token (only if the old OSSRH token no longer authenticates against the Portal) |
+| `OSSRH_TOKEN` | Central Portal **token password** | `mavenCentralPassword` | (same token pair) |
+| `OSSRH_GPG_SECRET_KEY` | ASCII-armored GPG **private key** (`-----BEGIN PGP PRIVATE KEY BLOCK-----`) | `signingInMemoryKey` | reuse as-is (`gpg --armor --export-secret-keys 5B83421E2338B907` if ever re-exporting) |
+| `OSSRH_GPG_SECRET_KEY_PASSWORD` | passphrase for that GPG key | `signingInMemoryKeyPassword` | reuse as-is |
+| `GRADLE_PUBLISH_KEY` | Gradle Plugin Portal API key | — (passed via `-Pgradle.publish.key`) | reuse as-is |
+| `GRADLE_PUBLISH_SECRET` | Gradle Plugin Portal API secret | — | reuse as-is |
 
-The legacy v1 signing key is `5B83421E2338B907` — export that same key into `SIGNING_KEY` /
-`SIGNING_PASSWORD` so v2 is signed with the established identity. (v2 uses vanniktech's
-**in-memory** key mechanism, not the old `signing.gnupg.keyName` in `gradle.properties`, which
-was removed because its mere presence broke unsigned local `publishToMavenLocal`.)
+The **only** value that might need regenerating is the Central credential (`OSSRH_USERNAME` /
+`OSSRH_TOKEN`): OSSRH (oss.sonatype.org) was sunset in favour of the Central Portal, so if the
+old token no longer authenticates, generate a fresh Portal user token at central.sonatype.com
+and update those two values — the **names stay the same**. GPG signing and the Plugin Portal
+creds are reused unchanged. The signing key is the established v1 identity `5B83421E2338B907`.
+(v2 uses vanniktech's **in-memory** key mechanism, not the old `signing.gnupg.keyName` in
+`gradle.properties`, which was removed because its mere presence broke unsigned local
+`publishToMavenLocal`.)
 
 ## Cutting a release
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,15 @@
 version=0.3.0
 group=com.monkopedia.kplusplus
-signing.gnupg.keyName=5B83421E2338B907
 kotlin.mpp.applyDefaultHierarchyTemplate=false
+
+# Release signing (Central Portal). Publications are GPG-signed via com.vanniktech.maven.
+# publish's `signAllPublications()`, which reads an IN-MEMORY key + passphrase from the
+# environment (ORG_GRADLE_PROJECT_signingInMemoryKey / ...Password). The release workflow
+# (.github/workflows/release.yml) supplies these from the SIGNING_KEY / SIGNING_PASSWORD
+# GitHub Secrets — see docs/releasing.md. Deliberately NOT set here (no committed
+# signing.gnupg.keyName): its mere presence activates a gnupg signatory that makes local,
+# unsigned `publishToMavenLocal` fail with "no configured signatory". The legacy v1 GPG key
+# was 5B83421E2338B907; export the same key material into the in-memory secrets for CI.
 
 # Gradle daemon heap (#83). Kotlin/Native compiles + LINKS in-process inside the Gradle
 # daemon, so the DAEMON heap below — NOT GRADLE_OPTS, which does not reach the in-process

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ ktlint-gradle = "14.0.1"
 ktlint-cli = "1.8.0"
 klinker = "0.2.0"
 gradle-plugin-publish = "2.1.0"
-vannik = "0.36.0"
+vannik = "0.37.0"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -31,3 +31,4 @@ ksrpc = { id = "com.monkopedia.ksrpc.plugin", version.ref = "ksrpc" }
 klinker = { id = "com.monkopedia.klinker.plugin", version.ref = "klinker" }
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }
 vannik-publish = { id = "com.vanniktech.maven.publish", version.ref = "vannik" }
+vannik-publish-base = { id = "com.vanniktech.maven.publish.base", version.ref = "vannik" }

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -23,10 +23,15 @@ plugins {
     alias(libs.plugins.ksrpc)
     id("c")
     id("cpp")
-    // R1 (#128): publish the krapper_gen release binary to mavenLocal as a normal
-    // classified release artifact so a from-published consumer resolves the resolve+codegen
-    // tool by coordinate. See the publication block near the bottom.
+    // Publish the krapper_gen release binary as a classified release artifact so a
+    // from-published consumer resolves the resolve+codegen tool by coordinate. A K/N .kexe
+    // is not a jar (no software-component the vanniktech convenience plugin could wire), so
+    // this stays a hand-rolled artifact-only MavenPublication. We apply the vanniktech BASE
+    // plugin (no auto-config): it contributes the Central Portal upload + `signAllPublications`
+    // bundling that also covers our hand-created publication, making it Central-valid (full
+    // POM + stub sources/javadoc jars below + GPG signing). See the publication block.
     `maven-publish`
+    alias(libs.plugins.vannik.publish.base)
 }
 
 repositories {
@@ -101,17 +106,35 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     }
 }
 
-// ---- R1 (#128): publish the krapper_gen release binary to mavenLocal ----
+// ---- Publish the krapper_gen release binary ----
 //
 // krapper_gen is the resolve+codegen tool the kplusplus Gradle plugin invokes. A K/N linuxX64
 // .kexe is not a jar (no software-component to wire), so — exactly like the krapper_parse
 // release-binary publication — this is an ARTIFACT-ONLY MavenPublication: attach the raw
-// executable with a `linuxX64` classifier and an empty extension. mavenLocal only; no signing.
+// executable with a `linuxX64` classifier and an empty extension.
+//
+// Central-validity for a classified-binary-only artifact: the Central Portal still requires a
+// complete POM + a sources jar + a javadoc jar + GPG signatures for every file. There is no
+// real source/javadoc for a compiled native binary, so we attach EMPTY (stub) sources+javadoc
+// jars at the base coordinate; the vanniktech base plugin (applied above) signs every
+// publication and uploads the bundle to the Portal. `publishToMavenLocal` still yields the
+// same coordinate/classifier R1 published, so the from-published consumer is unchanged.
 //
 // A Maven repo does NOT preserve the +x bit, so a consumer must chmod the resolved file (the
-// krapper_parse consume-seam already does this for its binary; R2 wires the same for this one).
-val krapperGenBinary = layout.buildDirectory
-    .file("bin/native/releaseExecutable/krapper_gen.kexe").get().asFile
+// consume-seam already does this for the parser binary; the same applies here).
+val krapperGenBinary =
+    layout.buildDirectory
+        .file("bin/native/releaseExecutable/krapper_gen.kexe")
+        .get()
+        .asFile
+
+// Empty sources + javadoc jars: Central requires them, but a native binary has neither.
+val emptySourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+}
+val emptyJavadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+}
 
 publishing {
     publications {
@@ -121,8 +144,67 @@ publishing {
                 classifier = "linuxX64"
                 extension = ""
             }
+            artifact(emptySourcesJar)
+            artifact(emptyJavadocJar)
+            pom {
+                name.set("krapper_gen")
+                description.set(
+                    "The kplusplus resolve + codegen tool: consumes a parsed model, forces " +
+                        "template instantiations, and generates the C++ wrapper + Kotlin/" +
+                        "Native bindings (linuxX64 native binary).",
+                )
+                url.set("https://github.com/Monkopedia/kplusplus")
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("Monkopedia")
+                        name.set("Jason Monk")
+                        email.set("monkopedia@gmail.com")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/Monkopedia/kplusplus")
+                    connection.set("scm:git:git://github.com/Monkopedia/kplusplus.git")
+                    developerConnection.set(
+                        "scm:git:ssh://git@github.com/Monkopedia/kplusplus.git",
+                    )
+                }
+            }
         }
     }
+}
+
+// vanniktech base: Central Portal endpoint + sign all publications (incl. the hand-rolled
+// releaseBinary above). Sign only when a key is present (CI) — otherwise the sign task fails
+// with "no configured signatory", breaking even a plain unsigned publishToMavenLocal. So
+// local mavenLocal stays credential-free; CI supplies the in-memory GPG key. See
+// docs/releasing.md.
+val signingConfigured =
+    providers.gradleProperty("signingInMemoryKey").isPresent ||
+        providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey").isPresent
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (signingConfigured) signAllPublications()
+}
+
+// Ship ONLY the release binary to Central. The Kotlin Multiplatform plugin auto-registers
+// `jvm`/`native`/`kotlinMultiplatform` publications for this module, but krapper_gen is a
+// TOOL (invoked as a binary), not a KMP library anyone consumes by coordinate — publishing
+// its .klib/JVM jar to Central would be noise AND fail validation (no sources/javadoc for
+// them). Disable their Central-repository publish tasks so vanniktech's Portal bundle
+// contains only the Central-valid `releaseBinary`. (mavenLocal is unaffected — those tasks
+// stay enabled there, matching R1.)
+listOf("Jvm", "KotlinMultiplatform", "Native").forEach { name ->
+    tasks
+        .matching {
+            it.name == "publish${name}PublicationToMavenCentralRepository"
+        }.configureEach { enabled = false }
 }
 
 // Build the release binary before publishing it, and guard that it exists.
@@ -140,6 +222,6 @@ tasks.register("publishReleaseBinaryToMavenLocal") {
     group = "kplusplus"
     description =
         "Build the krapper_gen release binary and publish it to mavenLocal as " +
-            "com.monkopedia.kplusplus:krapper_gen:$version (classifier linuxX64)."
+        "com.monkopedia.kplusplus:krapper_gen:$version (classifier linuxX64)."
     dependsOn("publishReleaseBinaryPublicationToMavenLocal")
 }

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -20,9 +20,13 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     id("com.monkopedia.kplusplus.compiler")
     id("com.monkopedia.klinker.plugin") version "0.2.0"
-    // #122 step 1.2 — publish the stage-0 krapper_parse binary to mavenLocal as an
-    // immutable bootstrap anchor. See the stage-0 publication block near the bottom.
+    // Publish the krapper_parse native binary. The stage-0 anchor (#122) is a mavenLocal-only
+    // bootstrap; the `releaseBinary` (0.3.0) is a normal release artifact that ALSO goes to
+    // the Central Portal. A K/N .kexe is not a jar, so both are hand-rolled artifact-only
+    // MavenPublications; the vanniktech BASE plugin adds the Portal upload + signing that make
+    // the release artifact Central-valid (full POM + stub sources/javadoc jars below).
     `maven-publish`
+    alias(libs.plugins.vannik.publish.base)
 }
 
 repositories {
@@ -428,6 +432,45 @@ val stage0Classifier = "linuxX64"
 // (gradle.properties) is =seed; only an explicit -Pkpp.frontend.krapper_parse=cpp trips this.
 val stage0BuiltFromCpp = findProperty("kpp.frontend.krapper_parse") == "cpp"
 
+// Empty sources + javadoc jars: the Central Portal requires them per coordinate, but a
+// native binary has neither. Attached to the `releaseBinary` publication (the one that goes
+// to Central); the stage0 anchor is mavenLocal-only and does not need them.
+val emptySourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+}
+val emptyJavadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+}
+
+// Central-valid POM shared by the release publication (name/description set per publication).
+fun MavenPublication.kplusplusReleasePom() = pom {
+    name.set("krapper_parse")
+    description.set(
+        "The kplusplus self-hosted C++ front-end: walks a real Clang AST (on generated " +
+            "Clang-AST bindings) and emits a krapper_model tree as JSON (linuxX64 native " +
+            "binary)."
+    )
+    url.set("https://github.com/Monkopedia/kplusplus")
+    licenses {
+        license {
+            name.set("The Apache License, Version 2.0")
+            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        }
+    }
+    developers {
+        developer {
+            id.set("Monkopedia")
+            name.set("Jason Monk")
+            email.set("monkopedia@gmail.com")
+        }
+    }
+    scm {
+        url.set("https://github.com/Monkopedia/kplusplus")
+        connection.set("scm:git:git://github.com/Monkopedia/kplusplus.git")
+        developerConnection.set("scm:git:ssh://git@github.com/Monkopedia/kplusplus.git")
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("stage0") {
@@ -435,17 +478,19 @@ publishing {
             artifactId = stage0Artifact
             version = stage0Version
             // Artifact-only: attach the raw K/N executable. No `extension` (it is a bare
-            // ELF binary), classifier names the platform.
+            // ELF binary), classifier names the platform. mavenLocal-only bootstrap anchor —
+            // NOT published to Central, so no sources/javadoc/POM enrichment needed.
             artifact(krapperParseBinary) {
                 classifier = stage0Classifier
                 extension = ""
             }
         }
-        // R1 (#128): the NORMAL release artifact a from-published consumer resolves — the
-        // LLVM parser tool at the project version (com.monkopedia.kplusplus:krapper_parse:
-        // 0.3.0, classifier linuxX64). Same artifact-only shape as stage0 (a K/N .kexe is not
-        // a jar). The stage0 anchor stays as the immutable #122 self-hosting seed; this is the
-        // generalization to "a normal release artifact" the release ships.
+        // The NORMAL release artifact a from-published consumer resolves — the LLVM parser
+        // tool at the project version (com.monkopedia.kplusplus:krapper_parse:0.3.0, classifier
+        // linuxX64). Same artifact-only shape as stage0 (a K/N .kexe is not a jar), but
+        // Central-valid: full POM + stub sources/javadoc jars + (via vanniktech base) GPG
+        // signing. The stage0 anchor stays the immutable #122 self-hosting seed; this is the
+        // generalization to "a normal release artifact" the release ships to Central.
         create<MavenPublication>("releaseBinary") {
             groupId = "com.monkopedia.kplusplus"
             artifactId = "krapper_parse"
@@ -454,8 +499,36 @@ publishing {
                 classifier = "linuxX64"
                 extension = ""
             }
+            artifact(emptySourcesJar)
+            artifact(emptyJavadocJar)
+            kplusplusReleasePom()
         }
     }
+}
+
+// vanniktech base: Central Portal endpoint + sign all publications. Sign only when a key is
+// present (CI) — otherwise the sign task fails with "no configured signatory", breaking even a
+// plain unsigned publishToMavenLocal / the stage0 anchor. So local mavenLocal stays
+// credential-free; CI supplies the in-memory GPG key. See docs/releasing.md.
+val signingConfigured =
+    providers.gradleProperty("signingInMemoryKey").isPresent ||
+        providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey").isPresent
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (signingConfigured) signAllPublications()
+}
+
+// Ship ONLY the release binary to Central. The Kotlin plugin auto-registers
+// `native`/`kotlinMultiplatform` publications (krapper_parse is a TOOL run as a binary, not a
+// KMP library consumed by coordinate), and the `stage0` publication is a mavenLocal-only
+// bootstrap anchor — none of them belong on Central. Disable their Central-repository publish
+// tasks so vanniktech's Portal bundle contains only the Central-valid `releaseBinary`.
+// (mavenLocal is unaffected — those tasks stay enabled, matching R1 + #122.)
+listOf("KotlinMultiplatform", "Native", "Stage0").forEach { name ->
+    tasks.matching {
+        it.name == "publish${name}PublicationToMavenCentralRepository"
+    }.configureEach { enabled = false }
 }
 
 // Build + guard the release binary before publishing the normal release artifact. Like the


### PR DESCRIPTION
Restores kplusplus's outward publish pipeline (deleted in the June cleanup), modernized off the sunset OSSRH onto the current **Central Portal** (`central.sonatype.com`) and re-pointed at the **v2** modules. Reconciles R1 (#130)'s hand-rolled artifact-only mavenLocal publications with a single coherent setup. Refs #128 (R3).

**BUILD + LOCALLY VALIDATED ONLY — nothing was published outward.**

## Approach
[`com.vanniktech.maven.publish`](https://vanniktech.github.io/gradle-maven-publish-plugin/) (0.37.0) drives POM metadata, sources/javadoc jars, GPG signing (in-memory key), and the Central Portal upload; `com.gradle.plugin-publish` owns the Plugin Portal upload.

| Artifact | Destination | Mechanism |
|---|---|---|
| Gradle plugin `com.monkopedia.kplusplus.compiler` (+ marker) | Plugin Portal + Central | vanniktech `GradlePlugin` platform + `publishPlugins` |
| FIR plugin jar `kplusplus-compiler-plugin` | Central | vanniktech `KotlinJvm` platform |
| `krapper_gen` / `krapper_parse` native binaries (classifier `linuxX64`) | Central | vanniktech **base** plugin over hand-rolled artifact-only publications |

## Native-binary Central-validation (the real risk)
A classified `.kexe` has no main jar, but Central still requires per-coordinate POM + sources + javadoc + signatures. Each native module attaches **empty (stub) sources+javadoc jars** and a **full POM** (name / description / url / Apache-2.0 / scm=github.com/Monkopedia/kplusplus / developers=Monkopedia) to its `releaseBinary` publication. The auto-created KMP `jvm`/`native`/`kotlinMultiplatform` publications and the `krapper_parse` stage0 anchor are **disabled for Central** (verified `enabled=false`) so only the Central-valid release artifacts ship. Coordinates/classifiers are **unchanged**, so R2's from-published consumer path is preserved.

## Signing
Gated on the in-memory key being present in the environment, so a credential-free local `publishToMavenLocal` no longer fails with "no configured signatory". Removed the legacy `signing.gnupg.keyName` from `gradle.properties` (its presence broke unsigned local publishing); CI supplies the same key material via secrets.

## Restored workflow: `.github/workflows/release.yml`
Triggers on `release: published` (+ `workflow_dispatch`). Installs the LLVM toolchain, publishes the plugin to the Plugin Portal, and uploads the signed bundle to the Central Portal **staging** area (`automaticRelease=false` — the owner finishes the release in the Deployments UI). Everything from GitHub Secrets, nothing hardcoded.

### GitHub Secrets the owner must set (see `docs/releasing.md`)
- `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` — Central Portal user token
- `SIGNING_KEY` / `SIGNING_PASSWORD` — ASCII-armored GPG private key (`gpg --armor --export-secret-keys 5B83421E2338B907`) + passphrase
- `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` — Gradle Plugin Portal API key/secret

## Local validation (mavenLocal only)
- `./gradlew publishAllToMavenLocal -PenableClang` → Central-valid bundles for all five coordinates. Inspected `~/.m2/.../0.3.0/`: each JVM module has jar + `-sources.jar` + `-javadoc.jar` + complete POM; each native module has the `linuxX64` binary + stub sources/javadoc jars + complete `packaging=pom` POM; the plugin marker POM is complete and depends on the plugin jar.
- **`samples/minimal` still builds + runs from mavenLocal**: `runReleaseExecutableKlinker` resolved the plugin + both tool binaries by coordinate and ran → `Rect area: 6.0` / `distance (0,0)->(3,4): 5.0` / `center: (1.0, 1.5)`.
- Default build unaffected (`./gradlew help -q`).
- No task that uploads to Central/Portal was run.

## Not verifiable without real credentials
Signing is exercised only in CI (needs the passphrase). The true "does Central accept the bundle" is confirmed only at the first real cut, in the Portal Deployments UI. Pre-existing ktlint violations in `settings.gradle.kts` / `feature-tests` / `featuregen` are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)