### PR TITLE
fix(release): build native release binary before Central publish (v0.3.0 hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,12 @@ jobs:
           sudo apt-get install -y clang llvm llvm-dev libclang-cpp-dev gcc-multilib
 
       # --- Publish the Gradle plugin to the Gradle Plugin Portal ---
-      # publishPlugins uses gradle.publish.key / gradle.publish.secret.
+      # publishPlugins uses gradle.publish.key / gradle.publish.secret. Runs ONLY on an actual
+      # release event: the Plugin Portal rejects re-publishing an existing version, so a manual
+      # workflow_dispatch re-run (e.g. to retry a failed Central upload) skips this step and does
+      # Central only — the plugin is already published from the original release.
       - name: Publish Gradle plugin to the Plugin Portal
+        if: github.event_name == 'release'
         run: >-
           ./gradlew -p compiler :kplusplus-compiler-gradle:publishPlugins
           -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -207,12 +207,18 @@ listOf("Jvm", "KotlinMultiplatform", "Native").forEach { name ->
         }.configureEach { enabled = false }
 }
 
-// Build the release binary before publishing it, and guard that it exists.
-tasks.named("publishReleaseBinaryPublicationToMavenLocal") {
+// Build the release binary before publishing it — to EITHER mavenLocal or Central — and guard
+// that it exists. The dependency must cover the Central repository task too: wiring it only onto
+// the mavenLocal task let a clean-CI Central publish fail with "artifact file does not exist"
+// (it passed locally only because a stale release binary happened to be present).
+tasks.matching {
+    it.name == "publishReleaseBinaryPublicationToMavenLocal" ||
+        it.name == "publishReleaseBinaryPublicationToMavenCentralRepository"
+}.configureEach {
     dependsOn("linkReleaseExecutableNative")
     doFirst {
         check(krapperGenBinary.exists()) {
-            "publishReleaseBinaryToMavenLocal: expected the krapper_gen release binary at " +
+            "publishReleaseBinary: expected the krapper_gen release binary at " +
                 "$krapperGenBinary — linkReleaseExecutableNative should have produced it."
         }
     }

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -531,9 +531,14 @@ listOf("KotlinMultiplatform", "Native", "Stage0").forEach { name ->
     }.configureEach { enabled = false }
 }
 
-// Build + guard the release binary before publishing the normal release artifact. Like the
+// Build + guard the release binary before publishing the normal release artifact — to EITHER
+// mavenLocal or Central (the dependency must cover the Central repository task; wiring it only
+// onto mavenLocal let a clean-CI Central publish fail "artifact file does not exist"). Like the
 // stage0 anchor it must be built FROM SEED, never from the =cpp self-generation path.
-tasks.named("publishReleaseBinaryPublicationToMavenLocal") {
+tasks.matching {
+    it.name == "publishReleaseBinaryPublicationToMavenLocal" ||
+        it.name == "publishReleaseBinaryPublicationToMavenCentralRepository"
+}.configureEach {
     dependsOn("linkReleaseExecutableKlinker")
     doFirst {
         check(!stage0BuiltFromCpp) {


### PR DESCRIPTION
**Hotfix for the failed v0.3.0 Central publish.**

The cut fired the release workflow: the Gradle plugin published live to the Plugin Portal, but the Central upload **failed** — `Invalid publication 'releaseBinary': artifact file does not exist: .../releaseExecutable/krapper_gen.kexe`.

**Root cause:** the 'build the release binary first' dependency (`dependsOn(linkRelease…)`) was attached only to the **mavenLocal** publish task, not the **Central** repository publish task. So local validation passed (a stale release binary was present) but clean CI failed. Same latent bug in `krapper_gen` and `krapper_parse`.

**Fix:** generalize the dependency via `tasks.matching { … }` to cover both `publishReleaseBinaryPublicationToMavenLocal` **and** `…ToMavenCentralRepository`, for both modules. Verified by dry-run — the Central publish task now depends on `linkReleaseExecutableNative`/`linkReleaseExecutableKlinker`.

**Also:** gate the Plugin Portal step to the `release` event only — the plugin 0.3.0 is already live on the Portal (only Central failed), and the Portal rejects re-publishing an existing version, so a `workflow_dispatch` re-run does **Central-only** to complete 0.3.0 without a version bump.

Refs #128.