### PR TITLE
fix(release): builtBy on native artifacts so the sign task depends on the link task

### DIFF
--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -143,6 +143,11 @@ publishing {
             artifact(krapperGenBinary) {
                 classifier = "linuxX64"
                 extension = ""
+                // Declare the producing task on the artifact so EVERY consumer of the .kexe —
+                // the sign task AND the publish tasks (mavenLocal + Central) — depends on it.
+                // (A per-publish-task dependsOn missed signReleaseBinaryPublication, which
+                // Gradle 9 rejects as an undeclared implicit dependency.)
+                builtBy(tasks.named("linkReleaseExecutableNative"))
             }
             artifact(emptySourcesJar)
             artifact(emptyJavadocJar)

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -483,6 +483,7 @@ publishing {
             artifact(krapperParseBinary) {
                 classifier = stage0Classifier
                 extension = ""
+                builtBy(tasks.named("linkReleaseExecutableKlinker"))
             }
         }
         // The NORMAL release artifact a from-published consumer resolves — the LLVM parser
@@ -498,6 +499,9 @@ publishing {
             artifact(krapperParseBinary) {
                 classifier = "linuxX64"
                 extension = ""
+                // Producing task on the artifact so the sign task + both publish tasks depend
+                // on it (Gradle 9 rejects the sign task's undeclared use of the link output).
+                builtBy(tasks.named("linkReleaseExecutableKlinker"))
             }
             artifact(emptySourcesJar)
             artifact(emptyJavadocJar)


### PR DESCRIPTION
**Second v0.3.0 Central-publish fix** (the first, #134, moved the failure).

The Central publish now failed at signing: `':krapper_gen:signReleaseBinaryPublication' uses this output of task ':krapper_gen:linkReleaseExecutableNative' without declaring an explicit or implicit dependency` — Gradle 9 rejects it. #134's per-publish-task `dependsOn` covered the *publish* tasks but not the *sign* task.

**Fix:** declare `builtBy(linkRelease…)` on the artifact itself, so **every** consumer of the .kexe — the sign task and both publish tasks (mavenLocal + Central) — depends on the producing link task. Applied to `krapper_gen` (`linkReleaseExecutableNative`) and **both** `krapper_parse` artifacts, releaseBinary + stage0 (`linkReleaseExecutableKlinker`).

**Validated locally** (not just dry-run): with a throwaway in-memory GPG key, `:krapper_gen:publishReleaseBinaryPublicationToMavenLocal` runs `linkReleaseExecutableNative → signReleaseBinaryPublication → publish` **BUILD SUCCESSFUL** with no implicit-dependency error — reproducing the exact failing CI path.

Sign runs before upload, so the failed run published nothing to Central (verified 404). Refs #128.