### PR TITLE
fix(release): install LLVM 22 (apt.llvm.org) + CPATH in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,28 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # krapper_parse links against the system LLVM/Clang toolchain (libclang-cpp + libLLVM);
-      # the parser binary is built FROM SEED (a plain C++ recompile) but still needs clang++
-      # and the LLVM libs present on the runner. -PenableClang brings :krapper_parse into the
-      # build; the settings probe discovers the LLVM major + libdir from llvm-config.
-      - name: Install LLVM/Clang toolchain
+      # krapper_parse is built FROM SEED (a plain C++ recompile of its committed krapped/
+      # wrapper). That wrapper #includes <clang/AST/...> and was GENERATED against LLVM 22 —
+      # it only compiles against LLVM 22 (the cross-major C++ API drift proven in the
+      # portability probe), and apt.llvm.org puts those headers under /usr/lib/llvm-22/include,
+      # NOT the distro default path. So install LLVM 22 from apt.llvm.org (not the distro's
+      # clang) and surface its include/lib dirs via CPATH/LD_LIBRARY_PATH so the seed compile,
+      # the klinker link, and runtime all resolve. -PenableClang brings :krapper_parse into the
+      # build; the settings probe reads the LLVM major + libdir from llvm-config.
+      - name: Install LLVM/Clang 22 (apt.llvm.org)
         run: |
+          set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y clang llvm llvm-dev libclang-cpp-dev gcc-multilib
+          sudo apt-get install -y wget lsb-release gnupg ca-certificates software-properties-common
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 22 all
+          sudo ln -sf "$(command -v clang++-22)"     /usr/local/bin/clang++
+          sudo ln -sf "$(command -v clang-22)"       /usr/local/bin/clang
+          sudo ln -sf "$(command -v llvm-config-22)" /usr/local/bin/llvm-config
+          echo "clang++: $(clang++ --version | head -1); llvm-config: $(llvm-config --version)"
+          echo "CPATH=$(llvm-config --includedir)" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$(llvm-config --libdir)" >> "$GITHUB_ENV"
 
       # --- Publish the Gradle plugin to the Gradle Plugin Portal ---
       # publishPlugins uses gradle.publish.key / gradle.publish.secret. Runs ONLY on an actual


### PR DESCRIPTION
**Third v0.3.0 Central-publish fix.** The prior fixes (#134/#135) unmasked this by letting the build proceed past krapper_gen.

`:krapper_parse:kplusplusSync` failed: *'stage-0 seed wrapper compile failed'* — the release workflow installed the **distro** clang (`apt-get install clang llvm`), but krapper_parse's committed seed (`krapper_parse.cc`, `#includes <clang/AST/...>`) was **generated against LLVM 22** and only compiles against 22 (the cross-major API drift the portability probe characterized). apt.llvm.org's headers also live under `/usr/lib/llvm-22/include`, not the distro default path.

**Fix:** mirror the probe's proven install — LLVM 22 from apt.llvm.org, unversioned `clang++`/`llvm-config` symlinks, and `CPATH`/`LD_LIBRARY_PATH` from `llvm-config` so the seed compile + klinker link + runtime all resolve. (This same install is what the portability-probe build job used to compile krapper_parse successfully.)

Workflow-only; merging publishes nothing. After merge I re-dispatch → the build should now complete and reach the actual Central upload. Refs #128.