### PR TITLE
fix(release): declare generator dep on krapper_parse's KMP sources jars (Snag 4)

### DIFF
--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -523,6 +523,19 @@ mavenPublishing {
     if (signingConfigured) signAllPublications()
 }
 
+// Gradle 9 strict input/output validation: the KMP plugin auto-registers per-target SOURCES
+// jars (`metadataSourcesJar`/`nativeSourcesJar`/`sourcesJar`) that package this module's
+// Kotlin — which INCLUDES the klinker-GENERATED source (build/gen/klinker/krapper_parse/kotlin,
+// produced by `generateKotlinSourcekrapper_parse`) — but the KMP-registered jars don't declare
+// that producing task, so Gradle 9 rejects the undeclared use of its output. We don't ship
+// these KMP publications outward (only `releaseBinary` -> Central, `stage0` -> mavenLocal), but
+// `signAllPublications()` signs EVERY publication in CI, which builds their sources jars and so
+// surfaces the error there (and in a signed local publishToMavenLocal). Declare the generator
+// on each — the same class of fix as #135's `builtBy` on the binary artifacts, one level up.
+listOf("metadataSourcesJar", "nativeSourcesJar", "sourcesJar").forEach { jar ->
+    tasks.named(jar) { dependsOn("generateKotlinSourcekrapper_parse") }
+}
+
 // Ship ONLY the release binary to Central. The Kotlin plugin auto-registers
 // `native`/`kotlinMultiplatform` publications (krapper_parse is a TOOL run as a binary, not a
 // KMP library consumed by coordinate), and the `stage0` publication is a mavenLocal-only


### PR DESCRIPTION
## What

The 4th and final Gradle-9 strict-validation failure blocking the 0.3.0 Central publish.

`krapper_parse`'s KMP-registered per-target sources jars (`metadataSourcesJar` / `nativeSourcesJar` / `sourcesJar`) package this module's Kotlin — which **includes the klinker-generated source** from `generateKotlinSourcekrapper_parse` (`build/gen/klinker/krapper_parse/kotlin`) — but the auto-registered jars don't declare that producing task. Gradle 9 rejects the undeclared use of its output:

```
Task ':krapper_parse:nativeSourcesJar' uses this output of task
':krapper_parse:generateKotlinSourcekrapper_parse' without declaring an
explicit or implicit dependency.
```

We only ship `releaseBinary` (→ Central) and `stage0` (→ mavenLocal), but `signAllPublications()` signs **every** publication in CI, which builds their sources jars and surfaces the error there. Fix declares the generator on each — the same class of fix as #135's `builtBy` on the binary artifacts, one level up.

## Validation

Reproduced and fixed locally, no blind CI round-trip:
- The three sources jars build clean directly (before the fix they failed the validator).
- A **signed** `publishAllToMavenLocal` (throwaway in-memory GPG key) is green end-to-end — every publication signs, zero undeclared-dependency errors, and both `krapper_parse` and `krapper_gen` 0.3.0 artifacts land in mavenLocal with `.asc` signatures.
- Confirmed `krapper_gen` has no source-generating task, so it has no equivalent issue.

## Context

Snag sequence of the 0.3.0 release firefight: #134 (build binary before Central publish) → #135 (`builtBy` so the sign task depends on the link) → #136 (LLVM 22 install in CI) → **this** (KMP sources-jar generator dep). Plugin 0.3.0 is already live on the Gradle Plugin Portal; Central is 404 (nothing published). With this merged, re-dispatching `release.yml` (Central-only) completes 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)