### PR TITLE
fix(release): real .kexe extension on native tool binaries (Central Portal) + native-only publish scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,20 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      central_scope:
+        description: >-
+          Which coordinates to push to the Central Portal. `all` = the full set
+          (a fresh release). `native-binaries` = only the krapper_gen +
+          krapper_parse release binaries — use this to COMPLETE a partial release
+          where the jar coordinates already published but the native-binary
+          upload failed (the Portal rejects re-publishing an existing coordinate,
+          so a full re-run would fail on the already-live jars).
+        type: choice
+        default: all
+        options:
+          - all
+          - native-binaries
 
 jobs:
   publish:
@@ -81,7 +95,18 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-        run: ./gradlew publishAllToMavenCentral -PenableClang --no-configuration-cache
+        run: |
+          set -euxo pipefail
+          # `native-binaries` publishes ONLY the two native release-binary coordinates
+          # (krapper_gen + krapper_parse) — for completing a partial release. A release event
+          # (or the `all` default) publishes the whole set. Empty input (release event) => all.
+          scope="${{ github.event.inputs.central_scope || 'all' }}"
+          if [ "$scope" = "native-binaries" ]; then
+            ./gradlew :krapper_gen:publishToMavenCentral :krapper_parse:publishToMavenCentral \
+              -PenableClang --no-configuration-cache
+          else
+            ./gradlew publishAllToMavenCentral -PenableClang --no-configuration-cache
+          fi
 
       - name: Release notes
         run: |

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -564,7 +564,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
      * Models the #126 stage-0 consume seam (`resolveStage0Path` in
      * krapper_parse/build.gradle.kts): a resolvable [Configuration] with a single
      * dependency on `com.monkopedia.kplusplus:<tool>:<PLUGIN_VERSION>` selecting the
-     * `linuxX64` classifier + EMPTY extension (the publications are artifact-only, no
+     * `linuxX64` classifier + `.kexe` extension (the publications are artifact-only, no
      * `.jar`), `isTransitive=false`. The resolved artifact comes back mode 0644 (a
      * Maven repo drops the exec bit), so we copy it into the consumer's build dir and
      * `setExecutable(true)` — exactly what `resolveStage0Path` does — because the sync
@@ -589,7 +589,12 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                                 artifact { art ->
                                     art.name = tool
                                     art.classifier = "linuxX64"
-                                    art.extension = ""
+                                    // Real `.kexe` extension — the published release binary
+                                    // uses it (an empty extension makes a trailing-dot filename
+                                    // the Central Portal rejects). Must match the `extension`
+                                    // on the releaseBinary publications in krapper_gen/
+                                    // krapper_parse build.gradle.kts.
+                                    art.extension = "kexe"
                                 }
                             }
                         }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,11 +25,14 @@ with no manual release step.
 | `com.monkopedia.kplusplus:krapper_gen` (classifier `linuxX64`) | Central | resolve+codegen tool binary |
 | `com.monkopedia.kplusplus:krapper_parse` (classifier `linuxX64`) | Central | LLVM parser tool binary |
 
-The two native tool binaries are classified, extension-less artifacts (a Kotlin/Native `.kexe`
-is not a jar). Central still requires a complete POM + a sources jar + a javadoc jar + GPG
-signatures per coordinate, so each ships **empty (stub) sources + javadoc jars** alongside the
-binary. The `krapper_parse` stage-0 bootstrap anchor (`krapper_parse-stage0:0.2.3-stage0`) is a
-mavenLocal-only artifact and is deliberately **not** published to Central.
+The two native tool binaries are classified `.kexe` artifacts (a Kotlin/Native `.kexe` is not a
+jar). They carry a real `.kexe` extension, **not** an empty one: an empty extension produces the
+filename `krapper_gen-<v>-linuxX64.` (trailing dot), which the Central Portal's manifest builder
+rejects as a missing file. Central still requires a complete POM + a sources jar + a javadoc jar
++ GPG signatures per coordinate, so each ships **empty (stub) sources + javadoc jars** alongside
+the binary. The `krapper_parse` stage-0 bootstrap anchor (`krapper_parse-stage0:0.2.3-stage0`)
+is a mavenLocal-only artifact (extension-less is fine — it never reaches the Portal) and is
+deliberately **not** published to Central.
 
 ## Required GitHub Secrets
 

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -111,7 +111,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
 // krapper_gen is the resolve+codegen tool the kplusplus Gradle plugin invokes. A K/N linuxX64
 // .kexe is not a jar (no software-component to wire), so — exactly like the krapper_parse
 // release-binary publication — this is an ARTIFACT-ONLY MavenPublication: attach the raw
-// executable with a `linuxX64` classifier and an empty extension.
+// executable with a `linuxX64` classifier and a `.kexe` extension.
 //
 // Central-validity for a classified-binary-only artifact: the Central Portal still requires a
 // complete POM + a sources jar + a javadoc jar + GPG signatures for every file. There is no
@@ -142,7 +142,14 @@ publishing {
             artifactId = "krapper_gen"
             artifact(krapperGenBinary) {
                 classifier = "linuxX64"
-                extension = ""
+                // A real extension, NOT "" — an empty extension yields the filename
+                // `krapper_gen-<v>-linuxX64.` (trailing dot), which the Central Portal's
+                // manifest builder rejects as a missing file ("...-linuxX64. is missing").
+                // `.kexe` is the honest Kotlin/Native executable extension; the consumer
+                // resolves the same classifier + extension and chmod +x's it (a filename
+                // extension has no bearing on executing the staged binary). Kept in lockstep
+                // with resolvePublishedTool in the Gradle plugin.
+                extension = "kexe"
                 // Declare the producing task on the artifact so EVERY consumer of the .kexe —
                 // the sign task AND the publish tasks (mavenLocal + Central) — depends on it.
                 // (A per-publish-task dependsOn missed signReleaseBinaryPublication, which

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -498,7 +498,14 @@ publishing {
             // version inherited from the project (0.3.0).
             artifact(krapperParseBinary) {
                 classifier = "linuxX64"
-                extension = ""
+                // A real extension, NOT "" — an empty extension yields the filename
+                // `krapper_parse-<v>-linuxX64.` (trailing dot), which the Central Portal's
+                // manifest builder rejects as a missing file. `.kexe` is the honest K/N
+                // executable extension; the consumer resolves the same classifier + extension
+                // and chmod +x's it. (The stage0 anchor above stays extension-less: it is
+                // mavenLocal-only and never reaches the Central Portal.) Kept in lockstep with
+                // resolvePublishedTool in the Gradle plugin.
+                extension = "kexe"
                 // Producing task on the artifact so the sign task + both publish tasks depend
                 // on it (Gradle 9 rejects the sign task's undeclared use of the link output).
                 builtBy(tasks.named("linkReleaseExecutableKlinker"))


### PR DESCRIPTION
## What

Snag 5 of the 0.3.0 release. The `krapper_gen` / `krapper_parse` release binaries were attached with an **empty** extension, producing the Maven filename `<artifact>-0.3.0-linuxX64.` (trailing dot). The Central Portal's manifest builder rejects it:

```
Error on building manifests: File with path
'.../krapper_gen/0.3.0/krapper_gen-0.3.0-linuxX64.' is missing
```

The jar coordinates (Gradle plugin + marker + FIR plugin) published cleanly at 0.3.0; **both native-binary uploads failed on this.**

## Fix

- Give the binaries the honest Kotlin/Native **`.kexe`** extension on the **publish** side (`krapper_gen` + `krapper_parse` `releaseBinary` publications) and the **consume** side (`resolvePublishedTool` in the Gradle plugin), kept in lockstep. A filename extension is irrelevant to executing the staged binary (the consumer `chmod +x`'s it and launches via `ProcessBuilder`). The mavenLocal-only stage-0 anchor stays extension-less — it never reaches the Portal.
- Add a `central_scope` `workflow_dispatch` input to `release.yml`: `native-binaries` publishes **only** the two native release-binary coordinates, to **complete a partial release** where the jar coordinates already published (the Portal rejects re-publishing an existing coordinate, so a full re-run would fail on the already-live jars). `all` (default / release event) is unchanged.

## Validation (local, end-to-end)

- Signed publish → `<artifact>-0.3.0-linuxX64.kexe` (+ `.asc`), **no trailing-dot files**, POM carries `linuxX64` classifier + `kexe` extension.
- From-published consumer (`samples/minimal`, resolving from mavenLocal) **resolves the `.kexe` tools, generates bindings, links, and runs** (`Rect area: 6.0` / `distance … 5.0` / `center: (1.0, 1.5)`).
- Native-only publish graph dry-run contains only `:krapper_gen`/`:krapper_parse` release-binary uploads — no `:compiler:*` Central tasks (so the live jar coords aren't touched).

## Sequence to complete 0.3.0

After merge: dispatch `release.yml` with `central_scope=native-binaries` to publish the two missing native coordinates at 0.3.0. Follows #134 → #135 → #136 → #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)