### PR TITLE
feat(plugin): bundle the tool binaries in the plugin jar (0.4.0 distribution)

### DIFF
--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -2,6 +2,7 @@ import com.vanniktech.maven.publish.GradlePlugin
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SourcesJar
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
+import org.gradle.language.jvm.tasks.ProcessResources
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -104,6 +105,33 @@ mavenPublishing {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+}
+
+// 0.4.0 distribution: BUNDLE the native tool binaries INTO the plugin jar so a consumer never
+// resolves a separate krapper_gen/krapper_parse Maven coordinate — the released plugin carries its
+// own tools (extractBundledTool in KPlusPlusCompilerGradlePlugin reads them back out at
+// /com/monkopedia/kplusplus/tools/linuxX64/<tool>). The compiler build is a SEPARATE included build
+// from the tool modules, so it can't depend on their link tasks; the release orchestration builds
+// the binaries in the root build and passes their absolute paths in via
+// -Pkpp.bundleTools.<tool>=<path>. Absent (the dev/in-tree build) => an unbundled jar: dev
+// consumers resolve the sibling :krapper_gen/:krapper_parse link output instead, so no bundling is
+// needed there. Only the released jar carries binaries.
+listOf("krapperGen" to "krapper_gen", "krapperParse" to "krapper_parse").forEach { (prop, tool) ->
+    providers.gradleProperty("kpp.bundleTools.$prop").orNull?.let { path ->
+        val bin = file(path)
+        tasks.named<ProcessResources>("processResources") {
+            doFirst {
+                check(bin.exists()) {
+                    "kpp.bundleTools.$prop=$path but no file exists there — build the $tool " +
+                        "release binary before bundling it into the plugin jar."
+                }
+            }
+            from(bin) {
+                into("com/monkopedia/kplusplus/tools/linuxX64")
+                rename { tool }
+            }
+        }
     }
 }
 

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -519,6 +519,39 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
      * disk in that case) plus the kexe File. The caller is expected to fail
      * fast at execution time if the kexe doesn't exist.
      */
+    /**
+     * Extract the tool binary BUNDLED in the plugin jar — the 0.4.0 distribution model. The
+     * released plugin carries its own `krapper_gen`/`krapper_parse` binaries on its classpath at
+     * `/com/monkopedia/kplusplus/tools/linuxX64/<tool>`, so a consumer NEVER resolves a separate
+     * tool Maven coordinate (that coordinate resolution is what collided with an in-build
+     * `:krapper_parse` project). Copy the binary to a per-plugin-version cache under the Gradle
+     * user home, chmod +x (jar entries carry no exec bit), and return it. Returns null when the
+     * jar carries no bundled binary (an unbundled in-tree/dev jar) so the caller can fall through
+     * to the sibling/includedBuild/published paths.
+     */
+    private fun extractBundledTool(target: Project, tool: String): File? {
+        val cache = File(
+            target.gradle.gradleUserHomeDir,
+            "kplusplus/tools/$PLUGIN_VERSION/$tool",
+        )
+        if (cache.exists() && cache.length() > 0L) return cache
+        val stream = javaClass.getResourceAsStream(
+            "/com/monkopedia/kplusplus/tools/linuxX64/$tool",
+        ) ?: return null
+        return try {
+            cache.parentFile.mkdirs()
+            val tmp = File(cache.parentFile, "$tool.part")
+            stream.use { input -> tmp.outputStream().use { out -> input.copyTo(out) } }
+            tmp.copyTo(cache, overwrite = true)
+            tmp.delete()
+            cache.setExecutable(true)
+            cache
+        } catch (e: Exception) {
+            target.logger.warn("kplusplus: failed to extract bundled $tool: ${e.message}")
+            null
+        }
+    }
+
     private fun resolveKrapperGen(target: Project): Pair<Any?, File> {
         val direct = target.rootProject.findProject(":krapper_gen")
         if (direct != null) {
@@ -540,12 +573,11 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 return taskRef to kexe
             }
         }
-        // Published-artifact fallback (R2, #128): no in-tree source (sibling or
-        // includedBuild), so this is a TRUE external consumer (declares the plugin +
-        // a repo, NO includeBuild). Resolve the krapper_gen tool from its published
-        // Maven coordinate — the SAME mechanism the #126 stage-0 seam uses for
-        // krapper_parse (resolveStage0Path). Requires mavenLocal() in the consumer's
-        // repositories. Additive + LAST: dev/self-build flows keep their in-tree path.
+        // Consumer path (no in-tree source): a TRUE external consumer that declares the plugin
+        // but no includeBuild. Prefer the binary BUNDLED in the plugin jar (0.4.0 model — the
+        // released plugin carries its tools). The published-coordinate resolution stays as a
+        // fallback for a plugin whose jar has no bundled binary (e.g. a 0.3.0 consumer).
+        extractBundledTool(target, "krapper_gen")?.let { return null to it }
         resolvePublishedTool(target, "krapper_gen")?.let { return null to it }
 
         // Final fallback: the legacy hardcoded path. The doLast will throw a
@@ -689,6 +721,9 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // The published krapper_parse binary is LLVM-linked and needs LLVM present at
         // RUNTIME — but a standalone consumer has no in-tree LLVM-gated modules, so no
         // -PenableClang is needed here (that flag only gates in-tree root-build modules).
+        // Consumer path: prefer the binary bundled in the plugin jar (0.4.0 model), then the
+        // published Maven coordinate (fallback for an unbundled/0.3.0 plugin jar).
+        extractBundledTool(target, "krapper_parse")?.let { return null to it }
         resolvePublishedTool(target, "krapper_parse")?.let { return null to it }
         return null to target.rootProject.file(relBinary)
     }


### PR DESCRIPTION
## Why

Consumers currently resolve `krapper_gen` + `krapper_parse` as two separate classified Maven artifacts, and the plugin chmods them. That coordinate resolution is the root of the self-host knot: any in-repo project named `krapper_parse` makes Gradle substitute the module dep with the local project. Having **the released plugin carry its own tools** removes the premise — no coordinate to resolve, nothing to collide with, and consumers just apply the plugin.

## What (mechanism only — this PR is additive + dormant)

- `extractBundledTool()` — reads `/com/monkopedia/kplusplus/tools/linuxX64/<tool>` from the plugin's own jar, caches it under the Gradle user home (keyed by plugin version), chmod +x. Returns null for an unbundled jar so callers fall through.
- `resolveKrapperGen` / `resolveKrapperParse` — the consumer path prefers the bundled binary; the published-coordinate resolution stays as a fallback (0.3.0 / unbundled jars).
- `compiler/gradle` — optional resource bundling via `-Pkpp.bundleTools.<tool>=<abs-path>`. The compiler build is a *separate included build* from the tool modules, so the release orchestration (root build) passes the built binary paths in. Absent ⇒ unbundled jar; the in-tree dev loop keeps resolving the sibling link output, unchanged.

Nothing changes by default: no property ⇒ no bundling; an unbundled jar ⇒ `extractBundledTool` returns null ⇒ the existing behaviour.

## Validated end-to-end

Published a **bundled** plugin to mavenLocal (jar contains `tools/linuxX64/krapper_gen` 8 MB + `krapper_parse` 17 MB), then **deleted** the standalone `krapper_gen`/`krapper_parse` 0.3.0 artifacts from `~/.m2` and cleared the extraction cache. `samples/minimal` still generated bindings and ran (`Rect area: 6.0` / `distance 5.0` / `center 1.0,1.5`) — so it resolved the tools purely from the jar.

## Follow-up (separate PR)

Wire `release.yml` to bundle at release time and **drop** the standalone `krapper_gen`/`krapper_parse` Central publications (kills the classified-binary / `.kexe` / empty-sources-jar machinery — the class of the 0.3.0 firefight). Then the seed/stage-0 retirement becomes a trivial follow-on, since krapper_parse is just an ordinary plugin consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)