### PR TITLE
feat(release): publish plugin with bundled tools; drop standalone tool artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 #
 #   * The Gradle plugin (com.monkopedia.kplusplus.compiler) -> the Gradle Plugin Portal
 #     AND the Central Portal (so both `gradlePluginPortal()` and `mavenCentral()` consumers
-#     resolve `id("...") version "..."`).
+#     resolve `id("...") version "..."`). The krapper_gen + krapper_parse native tool binaries
+#     are BUNDLED INSIDE this plugin jar (0.4.0 model), not shipped as separate coordinates.
 #   * The FIR kotlinc-plugin jar -> the Central Portal.
-#   * The krapper_gen + krapper_parse native tool binaries (classifier linuxX64) -> Central.
 #
 # Everything is GPG-signed (vanniktech in-memory key) and uploaded to the Central Portal, which
 # AUTO-RELEASES the deployment once it passes validation (automaticRelease = true; a bundle that
@@ -14,20 +14,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      central_scope:
-        description: >-
-          Which coordinates to push to the Central Portal. `all` = the full set
-          (a fresh release). `native-binaries` = only the krapper_gen +
-          krapper_parse release binaries — use this to COMPLETE a partial release
-          where the jar coordinates already published but the native-binary
-          upload failed (the Portal rejects re-publishing an existing coordinate,
-          so a full re-run would fail on the already-live jars).
-        type: choice
-        default: all
-        options:
-          - all
-          - native-binaries
 
 jobs:
   publish:
@@ -67,49 +53,55 @@ jobs:
           echo "CPATH=$(llvm-config --includedir)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(llvm-config --libdir)" >> "$GITHUB_ENV"
 
-      # --- Publish the Gradle plugin to the Gradle Plugin Portal ---
+      # Build the two native tool binaries so the publish steps can BUNDLE them into the plugin
+      # jar (the 0.4.0 distribution model — the released plugin carries its own tools; consumers
+      # no longer resolve separate krapper_gen/krapper_parse coordinates). -PenableClang brings
+      # :krapper_parse into the build and links it against the LLVM installed above.
+      - name: Build the tool binaries (to bundle into the plugin)
+        run: >-
+          ./gradlew
+          :krapper_gen:linkReleaseExecutableNative
+          :krapper_parse:linkReleaseExecutableKlinker
+          -PenableClang --no-configuration-cache
+
+      # --- Publish the Gradle plugin (tools bundled) to the Gradle Plugin Portal ---
       # publishPlugins uses gradle.publish.key / gradle.publish.secret. Runs ONLY on an actual
       # release event: the Plugin Portal rejects re-publishing an existing version, so a manual
       # workflow_dispatch re-run (e.g. to retry a failed Central upload) skips this step and does
-      # Central only — the plugin is already published from the original release.
+      # Central only. -Pkpp.bundleTools.<tool>=<abs-path> packs the just-built binaries into the
+      # plugin jar (see compiler/gradle/build.gradle.kts + extractBundledTool in the plugin).
       - name: Publish Gradle plugin to the Plugin Portal
         if: github.event_name == 'release'
         run: >-
           ./gradlew -p compiler :kplusplus-compiler-gradle:publishPlugins
           -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
           -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+          -Pkpp.bundleTools.krapperGen=$GITHUB_WORKSPACE/krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe
+          -Pkpp.bundleTools.krapperParse=$GITHUB_WORKSPACE/krapper_parse/build/bin/klinker/krapper_parseRelease/krapper_parse
 
-      # --- Publish the whole set to the Central Portal (auto-released on validation) ---
-      # vanniktech reads the Central Portal token + the in-memory GPG key from these env vars
-      # (ORG_GRADLE_PROJECT_* -> Gradle properties mavenCentralUsername / mavenCentralPassword
-      # / signingInMemoryKey / signingInMemoryKeyPassword). -PenableClang so :krapper_parse is
-      # in the build and its release binary ships too.
+      # --- Publish the plugin set (tools bundled) to the Central Portal (auto-released) ---
+      # `-p compiler publishToMavenCentral` uploads ONLY the compiler build's coordinates — the
+      # Gradle plugin (+ marker) and the FIR plugin jar — as one signed bundle. The native tool
+      # binaries ride INSIDE the plugin jar (bundleTools), so there are NO standalone
+      # krapper_gen/krapper_parse Central artifacts anymore (that whole classified-binary path is
+      # gone — it was the source of the 0.3.0 firefight). vanniktech reads the Portal token + the
+      # in-memory GPG key from the ORG_GRADLE_PROJECT_* env vars below.
       - name: Publish to the Central Portal (auto-release on validation)
         env:
-          # Reuse the EXISTING repo secrets (from the v1 pipeline — still set, deleting the old
-          # workflow never removed them) rather than new ones. The Central Portal user token
-          # (central.sonatype.com) maps onto the OSSRH_USERNAME/OSSRH_TOKEN pair; if the old
-          # OSSRH token no longer authenticates against the Portal, only those two VALUES need
-          # regenerating — the names stay. OSSRH_GPG_SECRET_KEY is the same armored key v1 used.
+          # Reuse the EXISTING repo secrets (from the v1 pipeline). The Central Portal user token
+          # (central.sonatype.com) maps onto the OSSRH_USERNAME/OSSRH_TOKEN pair; OSSRH_GPG_SECRET_KEY
+          # is the same armored key v1 used.
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-        run: |
-          set -euxo pipefail
-          # `native-binaries` publishes ONLY the two native release-binary coordinates
-          # (krapper_gen + krapper_parse) — for completing a partial release. A release event
-          # (or the `all` default) publishes the whole set. Empty input (release event) => all.
-          scope="${{ github.event.inputs.central_scope || 'all' }}"
-          if [ "$scope" = "native-binaries" ]; then
-            ./gradlew :krapper_gen:publishToMavenCentral :krapper_parse:publishToMavenCentral \
-              -PenableClang --no-configuration-cache
-          else
-            ./gradlew publishAllToMavenCentral -PenableClang --no-configuration-cache
-          fi
+        run: >-
+          ./gradlew -p compiler publishToMavenCentral --no-configuration-cache
+          -Pkpp.bundleTools.krapperGen=$GITHUB_WORKSPACE/krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe
+          -Pkpp.bundleTools.krapperParse=$GITHUB_WORKSPACE/krapper_parse/build/bin/klinker/krapper_parseRelease/krapper_parse
 
       - name: Release notes
         run: |
-          echo "Published the kplusplus release set to the Central Portal (auto-released on"
-          echo "validation) and the Gradle plugin to the Plugin Portal."
+          echo "Published the kplusplus plugin set (native tools bundled in the plugin jar) to"
+          echo "the Central Portal (auto-released on validation) and the Gradle Plugin Portal."
           echo "Check status at https://central.sonatype.com (Deployments)."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,19 +20,21 @@ with no manual release step.
 | Coordinate | Where | Notes |
 |---|---|---|
 | `com.monkopedia.kplusplus.compiler` (plugin marker) | Plugin Portal + Central | resolves `id(...) version "..."` |
-| `com.monkopedia.kplusplus:kplusplus-compiler-gradle` | Plugin Portal + Central | the Gradle plugin jar |
+| `com.monkopedia.kplusplus:kplusplus-compiler-gradle` | Plugin Portal + Central | the Gradle plugin jar — **carries the bundled tool binaries** |
 | `com.monkopedia.kplusplus:kplusplus-compiler-plugin` | Central | the FIR kotlinc-plugin jar |
-| `com.monkopedia.kplusplus:krapper_gen` (classifier `linuxX64`) | Central | resolve+codegen tool binary |
-| `com.monkopedia.kplusplus:krapper_parse` (classifier `linuxX64`) | Central | LLVM parser tool binary |
 
-The two native tool binaries are classified `.kexe` artifacts (a Kotlin/Native `.kexe` is not a
-jar). They carry a real `.kexe` extension, **not** an empty one: an empty extension produces the
-filename `krapper_gen-<v>-linuxX64.` (trailing dot), which the Central Portal's manifest builder
-rejects as a missing file. Central still requires a complete POM + a sources jar + a javadoc jar
-+ GPG signatures per coordinate, so each ships **empty (stub) sources + javadoc jars** alongside
-the binary. The `krapper_parse` stage-0 bootstrap anchor (`krapper_parse-stage0:0.2.3-stage0`)
-is a mavenLocal-only artifact (extension-less is fine — it never reaches the Portal) and is
-deliberately **not** published to Central.
+That's the whole set — three jars, no separate native artifacts. The `krapper_gen` +
+`krapper_parse` **native tool binaries are bundled INSIDE the Gradle plugin jar** (under
+`/com/monkopedia/kplusplus/tools/linuxX64/`), so a consumer just applies the plugin and it
+extracts + runs its own tools — no separate classified `.kexe` coordinates to resolve or chmod.
+This is the 0.4.0 distribution model; it replaced the standalone
+`com.monkopedia.kplusplus:krapper_gen` / `krapper_parse` classified artifacts that 0.3.0 shipped
+(those remain published + immutable for 0.3.0 consumers, but are not produced going forward).
+
+The release builds the binaries in the root build, then passes their paths to the plugin publish
+via `-Pkpp.bundleTools.krapperGen=<path>` / `-Pkpp.bundleTools.krapperParse=<path>` (the compiler
+build is a separate included build, so it can't depend on the tool modules directly). The plugin
+jar is a normal jar — no classified-binary / empty-sources-jar machinery.
 
 ## Required GitHub Secrets
 
@@ -66,10 +68,14 @@ creds are reused unchanged. The signing key is the established v1 identity `5B83
    (`release: published`), or run the workflow manually via **workflow_dispatch**.
 3. The workflow, on an LLVM-equipped runner:
    - installs the LLVM/Clang toolchain (`krapper_parse` links against `libclang-cpp`/`libLLVM`);
-   - `:kplusplus-compiler-gradle:publishPlugins` → Gradle Plugin Portal;
-   - `publishAllToMavenCentral -PenableClang` → uploads the signed bundle to the Central Portal
-     and **auto-releases it once it passes Portal validation** (`automaticRelease = true`). A
-     bundle that fails validation is NOT released, so an invalid upload can't ship.
+   - **builds the two tool binaries** (`:krapper_gen:linkReleaseExecutableNative` +
+     `:krapper_parse:linkReleaseExecutableKlinker -PenableClang`) so the publish steps can bundle
+     them into the plugin jar (`-Pkpp.bundleTools.<tool>=<path>`);
+   - `:kplusplus-compiler-gradle:publishPlugins` → Gradle Plugin Portal (bundled);
+   - `-p compiler publishToMavenCentral` → uploads the signed bundle (plugin + marker + FIR jar,
+     tools bundled inside the plugin) to the Central Portal and **auto-releases it once it passes
+     Portal validation** (`automaticRelease = true`). A bundle that fails validation is NOT
+     released, so an invalid upload can't ship.
 4. Nothing further to do on the Central side — the deployment releases itself after validation.
    Watch the workflow run (and, if you want, https://central.sonatype.com → **Deployments**) for
    status. The Gradle plugin publish to the Plugin Portal is also live immediately.
@@ -82,9 +88,12 @@ Everything is validated locally against `~/.m2` without any credentials:
 
 ```sh
 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
-# Full consumer set to mavenLocal (add -PenableClang to include krapper_parse):
-./gradlew publishAllToMavenLocal -PenableClang
-# Prove the from-published consumer still resolves + runs from mavenLocal:
+# 1. Build the tool binaries, then publish the plugin (tools bundled) to mavenLocal:
+./gradlew :krapper_gen:linkReleaseExecutableNative :krapper_parse:linkReleaseExecutableKlinker -PenableClang
+./gradlew -p compiler publishToMavenLocal \
+  -Pkpp.bundleTools.krapperGen="$PWD/krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe" \
+  -Pkpp.bundleTools.krapperParse="$PWD/krapper_parse/build/bin/klinker/krapper_parseRelease/krapper_parse"
+# 2. Prove a from-published consumer resolves the bundled tools + runs from mavenLocal:
 (cd samples/minimal && ./gradlew runReleaseExecutableKlinker)
 ```
 


### PR DESCRIPTION
Turns on the 0.4.0 distribution model (mechanism in #139): the release bundles the native tool binaries into the plugin jar and publishes only the three jar coordinates — no standalone `krapper_gen`/`krapper_parse` Central artifacts.

## release.yml
- New **Build the tool binaries** step (`krapper_gen` + `krapper_parse`, `-PenableClang`).
- Both publish steps pass `-Pkpp.bundleTools.<tool>=<abs-path>` so the **Plugin Portal jar and the Central jar carry the tools**.
- Central step is now `-p compiler publishToMavenCentral` (plugin + marker + FIR as one signed bundle) instead of `publishAllToMavenCentral` — the standalone classified-binary publications are simply never invoked. This removes the classified-binary / `.kexe` / empty-sources-jar path that caused the 0.3.0 firefight, and the split-deployment partial-publish risk.
- Dropped the now-moot `central_scope` `workflow_dispatch` input.

## Validated locally
Fresh `-p compiler publishToMavenLocal -Pkpp.bundleTools.*`:
- plugin jar contains `tools/linuxX64/krapper_gen` (8 MB) + `krapper_parse` (17 MB) — md5-matched between `build/libs` and mavenLocal;
- publishes exactly the 3 jar coordinates, **no standalone tool coordinates**;
- samples/minimal resolves + runs off the bundled tools with the standalone 0.3.0 artifacts deleted from `~/.m2`.

## Note
The standalone `krapper_gen`/`krapper_parse` publications still exist in their `build.gradle.kts` (now dead — the release doesn't call them). They'll be deleted alongside the seed/stage-0 cleanup, to keep this PR focused on the release path.

Follows #139. 0.3.0's standalone artifacts remain published + immutable; this is the go-forward model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)