### PR TITLE
release: bump to 0.3.1 (first bundled-tools release)

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.monkopedia.kplusplus"
-    version = "0.3.0"
+    version = "0.3.1"
 }
 
 // Aggregate publish for the two consumer-facing JVM artifacts that live in this (included)

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.0"
+version = "0.3.1"
 
 dependencies {
     implementation(kotlin("stdlib"))

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -877,7 +877,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         const val PLUGIN_ID = "com.monkopedia.kplusplus.compiler"
         const val PLUGIN_GROUP = "com.monkopedia.kplusplus"
         const val PLUGIN_NAME = "kplusplus-compiler-plugin"
-        const val PLUGIN_VERSION = "0.3.0"
+        const val PLUGIN_VERSION = "0.3.1"
         const val MIN_KOTLIN_VERSION = "2.3.20"
 
         // The C++ standard the cpp front-end parses (and krapper_gen compiles the wrapper)

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.0"
+version = "0.3.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.0"
+version = "0.3.1"
 
 // Sign only when a key is present (CI); otherwise local publishToMavenLocal fails with "no
 // configured signatory". See compiler/gradle/build.gradle.kts for the full rationale.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.0
+version=0.3.1
 group=com.monkopedia.kplusplus
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
     // The kplusplus compiler subplugin, resolved from its published mavenLocal marker
     // (R2, #128) — no includeBuild. Everything kplusplus-specific lives in the narrow
     // `kplusplus { ... }` block at the bottom of this file.
-    id("com.monkopedia.kplusplus.compiler") version "0.3.0"
+    id("com.monkopedia.kplusplus.compiler") version "0.3.1"
     id("com.monkopedia.klinker.plugin") version "0.2.0"
 }
 


### PR DESCRIPTION
0.3.1 is the clean release on the bundled-tools distribution (#139/#140): **three jar coordinates, no standalone native artifacts**, none of the classified-binary/`.kexe`/split-deployment machinery that made 0.3.0 a firefight. It supersedes 0.3.0 and becomes the durable bundled anchor the in-tree build migrates onto next (to drop the committed seed).

Version 0.3.0 → 0.3.1 in the root + four compiler modules + `PLUGIN_VERSION` + the samples/minimal consumer.

Validated locally: fresh build bundles `krapper_gen` + `krapper_parse` into the 0.3.1 plugin jar, publishes only the 3 jar coordinates, and samples/minimal @0.3.1 resolves + runs off the bundled tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)