### PR TITLE
refactor(build): flat repo consuming the published plugin (drop the composite)

### DIFF
--- a/samples/v8/settings.gradle.kts
+++ b/samples/v8/settings.gradle.kts
@@ -20,12 +20,12 @@ pluginManagement {
         mavenCentral()
         mavenLocal()
     }
-    // v2 plugin lives in the main repo as an included build. Two layouts
-    // are supported:
-    //   * The canonical /home/jmonk/git/kplusplus checkout — `../../`.
-    //   * A worktree under .claude/worktrees/<id>/samples/v8,
-    //     where `../../` is the worktree root.
-    // Either way, `../../` is the kplusplus root that knows about the
-    // compiler subplugin via its own settings.gradle.kts.
+    // This example is the IN-TREE dev loop: it composites the whole repo so edits to the
+    // plugin AND the tools take effect immediately. `../../` supplies the tool modules
+    // (krapper_gen/krapper_parse); `../../compiler` supplies the plugin itself. (The main repo is
+    // now a FLAT build that consumes the PUBLISHED plugin, so it no longer includeBuilds compiler
+    // — the composite lives here in the example, per design.) `../../` also works from a worktree
+    // under .claude/worktrees/<id>/samples/v8, where it is the worktree root.
     includeBuild("../../")
+    includeBuild("../../compiler")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,9 +6,17 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
+    // FLAT build (no composite): the repo consumes the PUBLISHED kplusplus plugin rather than
+    // includeBuild("compiler"). A composite substitutes any com.monkopedia.kplusplus:* module
+    // dependency with the matching in-build project — which is what shadowed our own coordinates
+    // and blocked krapper_parse from ever resolving a published tool. Flat has no such
+    // substitution. The tool modules (krapper_gen/krapper_parse/krapper_model) stay siblings here,
+    // so their dev loop is still immediate; PLUGIN development happens in an example (samples/*)
+    // that includeBuilds compiler. Bump this version on each release.
+    plugins {
+        id("com.monkopedia.kplusplus.compiler") version "0.3.1"
+    }
 }
-
-includeBuild("compiler")
 
 include(":krapper_gen")
 include(":krapper_model")


### PR DESCRIPTION
Removes the root cause of the whole seed / stage-0 / shadow saga: the `includeBuild("compiler")` made the repo a **composite**, and composite substitution replaces any `com.monkopedia.kplusplus:*` module dependency with the matching in-build project — so our own coordinates could never resolve to the published artifact. Flat has no such substitution.

## Change
- **settings.gradle.kts**: drop `includeBuild("compiler")`; declare `id("com.monkopedia.kplusplus.compiler") version "0.3.1"` in `pluginManagement { plugins { } }`, so the four consumer modules apply the **published** plugin (mavenLocal/Central) with no per-module edits.
- Tool modules (`krapper_gen`/`krapper_parse`/`krapper_model`) stay **siblings** → dev loop stays immediate, and krapper_parse keeps its `krapper_model` source dep (no separate build, no publishing krapper_model).
- **samples/v8**: now `includeBuild`s both `../../` (tools) and `../../compiler` (plugin) — plugin dev happens in the example composite, by design. samples/minimal stays a pure from-published consumer.

## Validated
- featuregen `nativeTest` = **188/0** on the flat build (published 0.3.1 plugin + fresh sibling tools; 73 classes, fresh run).
- samples/v8 configures with the two includeBuilds.

## Follow-on
krapper_parse still builds from its committed seed. Retiring it needs one plugin-capability change (`resolveKrapperParse` reads its own bundled binary for target krapper_parse) shipped in a release, then krapper_parse flips to `=cpp` consuming it — clean now that the composite/shadow is gone.

Follows the 0.3.1 release (#141) + bundling (#139/#140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)