### PR TITLE
release(prep): 0.3.2 + krapper_parse self-bootstrap capability

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.monkopedia.kplusplus"
-    version = "0.3.1"
+    version = "0.3.2"
 }
 
 // Aggregate publish for the two consumer-facing JVM artifacts that live in this (included)

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.1"
+version = "0.3.2"
 
 dependencies {
     implementation(kotlin("stdlib"))

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -685,8 +685,17 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // stage-0 seed, and the "krapper_parse=cpp feeding featuregen=cpp" composition could never
         // exercise the self-generated parser. Absent property = today's behavior exactly.
         if (target.name == "krapper_parse") {
+            // (1) Explicit path override — offline / a locally-built stage-0.
             (target.findProperty("kpp.stageZeroKrapperParse") as? String)?.takeIf { it.isNotBlank() }
                 ?.let { return null to File(it) }
+            // (2) SELF-HOST: krapper_parse builds its own bindings by parsing them with the
+            // krapper_parse binary BUNDLED in the applied (published) plugin — the same last-release
+            // tool any consumer gets. This is a resource read from the plugin's own jar (no Gradle
+            // coordinate), so it never self-references the in-build :krapper_parse project (the
+            // circular sibling below). Present only when the applied plugin is a bundled RELEASE; a
+            // dev-composite unbundled plugin returns null and falls through (use =seed or an
+            // override there).
+            extractBundledTool(target, "krapper_parse")?.let { return null to it }
         }
         val direct = target.rootProject.findProject(":krapper_parse")
         if (direct != null) {
@@ -877,7 +886,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         const val PLUGIN_ID = "com.monkopedia.kplusplus.compiler"
         const val PLUGIN_GROUP = "com.monkopedia.kplusplus"
         const val PLUGIN_NAME = "kplusplus-compiler-plugin"
-        const val PLUGIN_VERSION = "0.3.1"
+        const val PLUGIN_VERSION = "0.3.2"
         const val MIN_KOTLIN_VERSION = "2.3.20"
 
         // The C++ standard the cpp front-end parses (and krapper_gen compiles the wrapper)

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.1"
+version = "0.3.2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.1"
+version = "0.3.2"
 
 // Sign only when a key is present (CI); otherwise local publishToMavenLocal fails with "no
 // configured signatory". See compiler/gradle/build.gradle.kts for the full rationale.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.1
+version=0.3.2
 group=com.monkopedia.kplusplus
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 


### PR DESCRIPTION
Prep for retiring the committed seed. Both changes are **dormant until the flip that follows 0.3.2's release**.

- **Version 0.3.1 → 0.3.2** (root + 4 compiler modules + `PLUGIN_VERSION`). `pluginManagement` stays 0.3.1 and krapper_parse stays `=seed` here — the 0.3.2 release build consumes the *prior* release (0.3.2 isn't published during its own build) and builds krapper_parse from the seed one last time to bundle it.
- **Plugin self-bootstrap:** `resolveKrapperParse` for target krapper_parse now reads its OWN bundled binary (`extractBundledTool` from the applied plugin jar) before the sibling path. A resource read from the plugin's own jar — no Gradle coordinate — so it never self-references the in-build `:krapper_parse` project (the circular sibling). Only fires when the applied plugin is a bundled RELEASE.

## Validated locally
Built a bundled 0.3.2 plugin to mavenLocal, flipped (pluginManagement 0.3.2 + krapper_parse=cpp), and **krapper_parse regenerated its 124 binding files via the bundled tool with NO seed → featuregen 188/0.**

Next: cut 0.3.2 → then the flip PR (pluginManagement→0.3.2, krapper_parse=cpp, delete the seed + `-stage0` anchor + dead publications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)