### PR TITLE
fix: complete the #144 seed-retirement config (main left inconsistent)

### DIFF
--- a/docs/design/memscope-context-params.md
+++ b/docs/design/memscope-context-params.md
@@ -418,6 +418,20 @@ to resolve a nested-scope ambiguity.
 
 ## 7. Opportunities unlocked
 
+**Status (Stage 5, post-#146):** the allocating-operator and "one scoping mechanism"
+opportunities below are **already realized by the #146 migration** — no follow-up codegen was
+needed. A value-returning operator flows through the same `defineArgsAndBody` predicate as any
+other by-value member (`allocatesByValueReturn`, which is operator-agnostic), so it emits
+`inline operator context(scope: MemScope) fun plus(...)` and allocates its `_Holder()` on the
+ambient scope. This is locked by the `FullKotlinTests` goldens (`operator context(scope:
+MemScope) fun plus/minus/times/…`) and exercised end-to-end by featuregen `OpArithmeticTest`
+(`val c = a + b` inside `memScoped { }`, result lands in the caller's arena). The three former
+scoping mechanisms are already collapsed onto the single `scopeContext()`/`scope.defer{}`
+primitive in `KotlinWriter`. The remaining bullets (copy-construction, smaller wrappers) are
+likewise inherent in the shipped design. The one genuinely-future item is the parked
+operator-decisions work (`operator==` → `equals`/`hashCode`, `operator<` → `compareTo`), which
+is a *separate* initiative gated on a product decision — see `project_operator_decisions`.
+
 - **Allocating operators become natural.** `Vec2.plus` today is
   `inline operator fun plus(o: Vec2): Vec2 { val r = memScope.Vec2_Holder(); … }` — it needs
   the receiver to carry a scope, which is exactly the lifetime footgun. With context params

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,10 @@ org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 # cpp (cpp-parseable today — LLVM/-PenableClang REQUIRED, the intended LLVM-mandatory end-state):
 kpp.frontend.featuregen=cpp
 kpp.frontend.cppfixture=cpp
-# seed (committed stage-0 seed; the modules that can't self-parse post-B5):
-kpp.frontend.krapper_parse=seed
+# krapper_parse SELF-HOSTS: regenerates its own bindings by parsing its headers with the
+# krapper_parse binary bundled in the last published release's plugin (pluginManagement pins the
+# version in settings.gradle.kts). The committed seed was retired in #144 (there is no
+# krapper_parse/krapped anymore).
+kpp.frontend.krapper_parse=cpp
+# seed (committed stage-0 seed): clangwalk is a dev-only self-hosting demo, not part of the release.
 kpp.frontend.clangwalk=seed

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -431,9 +431,9 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // For any class with a destructor we surface the dispose C wrapper (`Type_dispose`, the
     // same one the `_Holder` factory's `defer` calls) as two members:
     //   * `dispose()` — delete now, explicitly.
-    //   * `owned()`   — register `memScope.defer { Type_dispose(ptr) }` so the object is
-    //                   deleted at scope end, and return `this` for chaining
-    //                   (`makeFoo().owned()`).
+    //   * `owned()`   — `context(scope: MemScope) fun owned()` that registers
+    //                   `scope.defer { Type_dispose(ptr) }` so the object is deleted at scope
+    //                   end, and returns `this` for chaining (`makeFoo().owned()`).
     // Emitted for abstract classes too: `Type_dispose` runs `~Type()`, which is virtual-aware,
     // so disposing a base wrapper over a derived correctly runs the derived destructor.
     private fun KotlinCodeBuilder.generateDisposeMethods(cls: ResolvedClass) {
@@ -490,7 +490,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
 
     // Uniform offset-correct upcast methods (IH-multi-inherit). For every (transitive)
     // public, non-virtual base B of D, emit
-    //   fun asB(): B = B(D_as_B(ptr), memScope)
+    //   fun asB(): B = B(D_as_B(ptr))
     // returning a NON-owning wrapper over the same object viewed as its base subobject.
     // The `D_as_B` C helper does `static_cast<B*>(reinterpret_cast<D*>(p))`, which applies
     // B's (possibly non-zero) subobject offset — correct for a 2nd base and for a single
@@ -524,7 +524,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
     // reaching it as a (transitive) base B gets the NULLABLE
     //   fun asB(): B? {
     //       val raw = D_dyncast_B(ptr) ?: return null   // C shim: dyn_cast / dynamic_cast
-    //       return B(raw, memScope)                      // BORROWED, non-owning view
+    //       return B(raw)                                // BORROWED, non-owning view
     //   }
     // The result is the SAME object viewed as the derived type, so (like the up-cast) it is
     // a non-owning wrapper — no dispose. `?: return null` propagates the shim's null when the
@@ -1839,7 +1839,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
             //    NON-virtual (e.g. v8::Value's Int32Value/IsString) `<Base>Api` is an EMPTY
             //    marker — widening the deref return to it makes every concrete method
             //    unreachable (forcing a manual `as? Value` downcast). The body already builds
-            //    the concrete `Value(ptr, memScope)`, so keep the declared type concrete too;
+            //    the concrete `Value(ptr)`, so keep the declared type concrete too;
             //    genuine polymorphic METHOD positions (a method returning/taking a base) still
             //    remap, so subclass substitution there is unaffected.
             retType = type(
@@ -2699,7 +2699,7 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         when {
             // Check enum BEFORE wrapper: an enum-typed FIELD getter (e.g. ASTContext::TUKind:
             // TranslationUnitKind) resolves its type with isWrapper ALSO set, so the wrapper
-            // branch would emit an illegal `Enum(ptr, memScope)` construction ("enum cannot be
+            // branch would emit an illegal `Enum(ptr)` construction ("enum cannot be
             // instantiated"). An enum is never wrapper-constructed; its `fromValue` path always
             // wins. (Method-return enums have isWrapper=false, so the old ordering didn't break
             // them — this only corrects the field-getter path.)

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
     // The kplusplus compiler subplugin, resolved from its published mavenLocal marker
     // (R2, #128) — no includeBuild. Everything kplusplus-specific lives in the narrow
     // `kplusplus { ... }` block at the bottom of this file.
-    id("com.monkopedia.kplusplus.compiler") version "0.3.1"
+    id("com.monkopedia.kplusplus.compiler") version "0.3.2"
     id("com.monkopedia.klinker.plugin") version "0.2.0"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     // so their dev loop is still immediate; PLUGIN development happens in an example (samples/*)
     // that includeBuilds compiler. Bump this version on each release.
     plugins {
-        id("com.monkopedia.kplusplus.compiler") version "0.3.1"
+        id("com.monkopedia.kplusplus.compiler") version "0.3.2"
     }
 }
 


### PR DESCRIPTION
**Bug:** #144 deleted the committed seed but its config flip was never staged — only the deletions landed. main is inconsistent: seed gone, yet `kpp.frontend.krapper_parse=seed` + pluginManagement `0.3.1`. A **fresh checkout fails** (seed-mode against a deleted seed); local checkouts only work via a stale untracked `krapper_parse/krapped/`.

**Fix** — the config #144's message promised: pluginManagement 0.3.1→**0.3.2**, `kpp.frontend.krapper_parse` seed→**cpp**, samples/minimal→0.3.2. Now consistent: seed deleted + krapper_parse self-hosts from the published 0.3.2 bundled plugin (0.3.2 live on Central).

**Reviewer:** please validate on a **fresh worktree** (the gate that catches this) — `:featuregen:nativeTest -PenableClang` = 188/0 with the seed absent, resolving 0.3.2 from Central. This is the state #144 validated but never committed.

Surfaced by the Stage-5 coder; a fresh-checkout review would've caught it originally (#144 was self-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)