### PR TITLE
equals/hashCode: gate member-fold hashCode on defaulted operator==; identity fallback for custom ==

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -195,21 +195,29 @@ All rows 🟢 (scaffolded by an orchestrated subagent; `UcConstructTest`,
 | UC-method-ret | value-returning method | `int compute(int) const` | `w.compute(5)` | • return reflects state+arg; arg round-trips | 🟢 | |
 | UC-const-method | const method | `double scaled() const` | `w.scaled()` | • callable; does not mutate | 🟢 | const `this` wrapped |
 | UC-static-method | static factory | `static Widget make(int)` | `with(Widget){ ms.make(7) }` | • returns a constructed Widget by value; fields correct | 🟢 | return-by-value (Holder placement-new) |
-| UC-operator-eq | equality operator | `bool operator==(const Widget&) const` | `a eq b` | • equal→true, differing→false | 🟢 | **maps to `infix fun eq`, NOT Kotlin `==`** — asymmetric with `operator+` |
+| UC-operator-eq | equality operator (hand-written) | `bool operator==(const Widget&) const` | `a.valueEquals(b)` | • value equality via `valueEquals`; Kotlin `==` is identity | 🟢 | hand-written `==` → IDENTITY `equals`/`hashCode` + `valueEquals` (see the equals/hashCode note) |
 | UC-operator-plus | arithmetic operator (by value) | `Widget operator+(const Widget&) const` | `a + b` | • sum combines fields; operands unchanged; independent result | 🟢 | maps to a real `operator fun plus` |
 
 **Note:** operator mapping is asymmetric — `operator+` becomes Kotlin `operator fun plus`
-(`a + b` works), but `operator==` currently becomes `infix fun eq` (not `==`/`equals`).
+(`a + b` works). `operator==`'s mapping is gated on whether it is C++20 **defaulted**.
 
-**`operator==` → `equals` + `hashCode` (BUILT 🟢).** `operator==` now maps to a real
-Kotlin `equals(other: Any?)` override (`other is T && T_op_eq(ptr, other.ptr)`), so
-`==` works idiomatically — unconditionally (a conditional `equals`-vs-`eq` mapping was
-rejected as confusing). An `equals`-bearing class always also gets a `hashCode()` that
-folds its public fields (`return 0` when none) to honour the contract — a
-poor-distribution hashCode is still contract-*correct* as it's derived from the same
-state `==` compares (equal ⇒ equal hash). (`operator<` → `compareTo` is now built: a
-single `operator<` synthesizes the whole ordering — `this<o → -1`, `o<this → 1`, else
-`0` — and Kotlin derives `>`/`>=`/`<=`. See OP-compare.)
+**`operator==` → `equals` + `hashCode`, gated on defaulted-ness (BUILT 🟢).** The mapping
+depends on whether the C++ `operator==` is `= default`:
+
+- **Defaulted `==`** (`bool operator==(const T&) const = default;`) — the compiler
+  guarantees a MEMBERWISE comparison over all members, so it maps to a real Kotlin
+  `equals(other: Any?)` override (`other is T && T_op_eq(ptr, other.ptr)`) PAIRED with a
+  `hashCode()` that folds the public fields (`return 0` when none). Equal objects have all
+  members equal, so the fold agrees — the equals/hashCode contract is provably sound.
+- **Hand-written `==`** — can't be statically classified as memberwise (it may compare only
+  a subset of state), so binding it to Kotlin `equals` against a field-fold hashCode would
+  break the contract. Instead: `equals` is IDENTITY on the backing pointer, `hashCode()` is
+  `ptr.hashCode()`, and the C++ comparison stays reachable as `valueEquals(other: T): Boolean`
+  (delegating to the same `_op_eq` C wrapper the delegating `equals` would have used).
+
+(`operator<` → `compareTo` is now built: a single `operator<` synthesizes the whole
+ordering — `this<o → -1`, `o<this → 1`, else `0` — and Kotlin derives `>`/`>=`/`<=`. See
+OP-compare.)
 
 ## Operators on user value types
 
@@ -220,7 +228,8 @@ operators (see `Operators.kt`); the gaps are `Vec2&`-returning compound ops and
 
 | ID | C++ | Generated Kotlin | Status | Notes |
 |---|---|---|---|---|
-| OP-eq | `operator==` | `override fun equals(other: Any?)` + `override fun hashCode()` | 🟢 | idiomatic `a == b`; `equals` does `other is T && T_op_eq(...)`; an always-generated `hashCode` folds the public fields (`return 0` if none) to honour the contract |
+| OP-eq | `operator==` (hand-written) | `override fun equals` (IDENTITY on ptr) + `override fun hashCode` (`ptr.hashCode()`) + `valueEquals(o)` | 🟢 | Vec2's `==` is hand-written → Kotlin `==` is identity; the C++ value comparison is `valueEquals`; contract-sound. `OpRelationalTest` |
+| OP-eq-defaulted | `operator== = default` | `override fun equals(other: Any?)` (delegating) + `override fun hashCode()` (field-fold) | 🟢 | a C++20 defaulted `==` is memberwise, so `a == b` runs the C++ `==` and the field-fold hashCode is sound (equal ⇒ equal hash). VecEq, `OpRelationalTest` |
 | OP-neq | `operator!=` | `infix fun neq(o): Boolean` | 🟢 | |
 | OP-plus | `operator+` | `operator fun plus(o): Vec2` | 🟢 | real `a + b`; return-by-value via Holder |
 | OP-minus | `operator-` (binary) | `operator fun minus(o): Vec2` | 🟢 | |

--- a/featuregen/src/cppMain/include/strings_feature.h
+++ b/featuregen/src/cppMain/include/strings_feature.h
@@ -133,6 +133,20 @@ struct Vec2 {
     double operator()(double s) const { return x * s + y * s; }            // OP-call → operator_call
 };
 
+// OP-eq-defaulted (T-op): a C++20 `= default`-ed operator==, which the compiler
+// GUARANTEES is a memberwise comparison over ALL members. krapper trusts that
+// guarantee: it binds this to a real Kotlin `equals` (so `a == b` runs the C++
+// `==`) PAIRED with a field-fold `hashCode` — the contract is provably sound
+// because equal objects have all members equal. Contrast Vec2's hand-written
+// `operator==`, which krapper can't prove memberwise so it falls back to an
+// identity `equals` (pointer) + a `valueEquals` for the value comparison.
+struct VecEq {
+    double x, y;
+    VecEq() : x(0.0), y(0.0) {}
+    VecEq(double x_, double y_) : x(x_), y(y_) {}
+    bool operator==(const VecEq& o) const = default;   // OP-eq-defaulted
+};
+
 // OB-* : passing/returning user objects across the boundary. A small aggregate
 // (Point2) + a struct of static methods, one per convention (krapper wraps only
 // struct/class members, not namespace-scope free functions).

--- a/featuregen/src/nativeTest/kotlin/OpRelationalTest.kt
+++ b/featuregen/src/nativeTest/kotlin/OpRelationalTest.kt
@@ -1,5 +1,6 @@
 import kotlinx.cinterop.memScoped
 import root.Vec2
+import root.VecEq
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -7,25 +8,53 @@ import kotlin.test.assertTrue
 
 // OP-eq / OP-neq / OP-compare / OP-index: comparison + subscript operators.
 //
-// NAMING NOTE: krapper maps C++ operator== to a real Kotlin `equals` override
-// (so idiomatic `a == b` works), and ALWAYS pairs it with a `hashCode` override
-// derived from the same public fields (equal ⇒ equal hash). C++ operator< maps
-// to a real Kotlin `operator fun compareTo(other): Int`, synthesized from the
-// single `<` by calling the `_op_lt` C wrapper twice with swapped operands, so
-// idiomatic `a < b`, `a > b`, `compareTo`, and `sorted()` all work. operator!=
-// -> `neq` remains an INFIX METHOD (no Kotlin `!=`). operator[] DOES map to
-// `operator fun get(i: Int): Double`, so real Kotlin `v[i]` subscript works
-// (returns a primitive Double directly).
+// NAMING NOTE: krapper's mapping of C++ operator== depends on whether it is a
+// C++20 DEFAULTED (`= default`) comparison or HAND-WRITTEN:
+//  * DEFAULTED == (VecEq) is guaranteed memberwise over all members, so it maps
+//    to a real Kotlin `equals` override (idiomatic `a == b`) PAIRED with a
+//    field-fold `hashCode` (equal ⇒ equal hash) — the contract is sound.
+//  * HAND-WRITTEN == (Vec2) can't be proven memberwise, so binding it to Kotlin
+//    `equals` would risk the equals/hashCode contract. It instead gets an
+//    IDENTITY `equals` (backing-pointer equality; hashCode is ptr.hashCode()),
+//    and the C++ value comparison stays reachable as `valueEquals(other)`.
+// C++ operator< maps to a real Kotlin `operator fun compareTo(other): Int`,
+// synthesized from the single `<` by calling the `_op_lt` C wrapper twice with
+// swapped operands, so idiomatic `a < b`, `a > b`, `compareTo`, and `sorted()`
+// all work. operator!= -> `neq` remains an INFIX METHOD (no Kotlin `!=`).
+// operator[] DOES map to `operator fun get(i: Int): Double`, so real Kotlin
+// `v[i]` subscript works (returns a primitive Double directly).
 class OpRelationalTest {
 
-    // OP-eq: identical Vec2 compare true via `==`; differing in x or y compare
-    // false; self-comparison true. Equal instances must share a hashCode.
-    @Test fun eq_compares_components() = memScoped {
+    // OP-eq (hand-written ==): Vec2's `operator==` is hand-written, so Kotlin `==`
+    // is IDENTITY on the backing pointer — two distinct-but-equal-valued instances
+    // are NOT `==`, but ARE `valueEquals`. hashCode is identity (ptr.hashCode()), so
+    // the equals/hashCode contract still holds: `a == a` ⇒ same hash.
+    @Test fun eq_is_identity_for_handwritten() = memScoped {
         with(Vec2) {
             val a = Vec2__double_double(1.0, 2.0)
-            val b = Vec2__double_double(1.0, 2.0)
-            val diffX = Vec2__double_double(9.0, 2.0)
-            val diffY = Vec2__double_double(1.0, 9.0)
+            val sameValue = Vec2__double_double(1.0, 2.0)
+            val diff = Vec2__double_double(9.0, 2.0)
+            // Kotlin `==` is identity: same value, different instance ⇒ NOT equal.
+            assertTrue(a == a) // self-comparison (same backing pointer)
+            assertFalse(a == sameValue)
+            assertFalse(a == diff)
+            // The C++ value comparison is still reachable via valueEquals.
+            assertTrue(a.valueEquals(sameValue))
+            assertFalse(a.valueEquals(diff))
+            // equals/hashCode contract: an object hashes equal to itself.
+            assertEquals(a.hashCode(), a.hashCode())
+        }
+    }
+
+    // OP-eq-defaulted: VecEq's `operator== = default` IS memberwise over all members,
+    // so Kotlin `==` runs the C++ comparison and a field-fold hashCode agrees — two
+    // distinct-but-equal-valued instances ARE `==` and hash equal.
+    @Test fun eq_defaulted_compares_components() = memScoped {
+        with(VecEq) {
+            val a = VecEq__double_double(1.0, 2.0)
+            val b = VecEq__double_double(1.0, 2.0)
+            val diffX = VecEq__double_double(9.0, 2.0)
+            val diffY = VecEq__double_double(1.0, 9.0)
             assertTrue(a == b)
             assertTrue(a == a) // self-comparison
             assertFalse(a == diffX)
@@ -35,18 +64,19 @@ class OpRelationalTest {
         }
     }
 
-    // OP-neq: differing instances return true; identical return false; logically
-    // consistent with `==` (neq == !equals).
-    @Test fun neq_is_inverse_of_eq() = memScoped {
+    // OP-neq: differing instances return true; identical return false. `neq` is Vec2's
+    // C++ `operator!=` (a VALUE comparison, infix method), so it is the inverse of the
+    // VALUE comparison `valueEquals` — NOT of Kotlin's identity `==` (see eq test).
+    @Test fun neq_is_inverse_of_valueEquals() = memScoped {
         with(Vec2) {
             val a = Vec2__double_double(1.0, 2.0)
             val same = Vec2__double_double(1.0, 2.0)
             val diff = Vec2__double_double(1.0, 3.0)
             assertTrue(a neq diff)
             assertFalse(a neq same)
-            // consistency with ==
-            assertEquals(a == same, !(a neq same))
-            assertEquals(a == diff, !(a neq diff))
+            // consistency with the value comparison
+            assertEquals(a.valueEquals(same), !(a neq same))
+            assertEquals(a.valueEquals(diff), !(a neq diff))
         }
     }
 

--- a/featuregen/src/nativeTest/kotlin/UcStaticOpTest.kt
+++ b/featuregen/src/nativeTest/kotlin/UcStaticOpTest.kt
@@ -7,10 +7,13 @@ import kotlin.test.assertTrue
 
 // UC-static-method / UC-operator-eq / UC-operator-plus: the static factory
 // `make(count_)` returning a Widget by value (placement-new into a Holder), and
-// the two operators. NOTE the operator mapping: `operator==` maps to a real
-// Kotlin `equals` override (so `a == b` works) plus an always-generated
-// `hashCode`. `operator+` maps to a real Kotlin `operator fun plus`, so `a + b`
-// works.
+// the two operators. NOTE the operator mapping: Widget's `operator==` is
+// HAND-WRITTEN, so it can't be proven memberwise and maps to an IDENTITY Kotlin
+// `equals` (backing-pointer equality; hashCode is ptr.hashCode()) with the C++
+// value comparison exposed as `valueEquals` — NOT a delegating `==`. (A C++20
+// `= default`-ed `operator==` would instead keep the delegating `equals`; see
+// OpRelationalTest's VecEq.) `operator+` maps to a real Kotlin `operator fun
+// plus`, so `a + b` works.
 class UcStaticOpTest {
     // UC-static-method: static make() returns a constructed Widget by value.
     @Test fun static_make_returns_widget() = memScoped {
@@ -21,20 +24,24 @@ class UcStaticOpTest {
         assertEquals(1.0, w.scale) // make() fixes scale to 1.0
     }
 
-    // UC-operator-eq: equal widgets compare true, differing compare false.
-    // Surfaces as idiomatic Kotlin `a == b` (equals override), with a paired
-    // hashCode that agrees for equal instances.
+    // UC-operator-eq: Widget's `operator==` is hand-written, so Kotlin `==` is IDENTITY
+    // (distinct instances are never `==`), and the C++ field comparison is reachable via
+    // `valueEquals`. hashCode is identity (ptr.hashCode()), so the contract still holds.
     @Test fun equality_operator_compares_fields() = memScoped {
         with(Widget) {
             val a = Widget__int_double(3, 1.5)
             val b = Widget__int_double(3, 1.5)
             val c = Widget__int_double(3, 2.0) // differing scale
             val d = Widget__int_double(4, 1.5) // differing count
-            assertTrue(a == b)
-            assertFalse(a == c)
-            assertFalse(a == d)
-            // equal objects must hash equal
-            assertEquals(a.hashCode(), b.hashCode())
+            // Kotlin `==` is identity: same value, different instance ⇒ NOT equal.
+            assertTrue(a == a)
+            assertFalse(a == b)
+            // The C++ value comparison stays reachable via valueEquals.
+            assertTrue(a.valueEquals(b))
+            assertFalse(a.valueEquals(c))
+            assertFalse(a.valueEquals(d))
+            // equals/hashCode contract: an object hashes equal to itself.
+            assertEquals(a.hashCode(), a.hashCode())
         }
     }
 

--- a/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedMethod.kt
+++ b/krapper_gen/src/commonMain/kotlin/resolvedmodel/ResolvedMethod.kt
@@ -179,6 +179,14 @@ open class ResolvedMethod(
     // primary-constructor param); also serialized for the model round-trip.
     var isVirtual: Boolean = false
 
+    // Mirror of WrappedMethod.isDefaulted: true for a C++20 `= default`-ed method. Only
+    // consulted for a defaulted `operator==`, which the compiler guarantees is a memberwise
+    // comparison over ALL members — KotlinWriter gates the equals/hashCode contract on it
+    // (defaulted `==` → delegating equals + field-fold hashCode; hand-written `==` →
+    // identity contract on the backing pointer + a `valueEquals` for the C++ comparison).
+    // A `var` so resolve()/copy() propagate it; serialized for the model round-trip.
+    var isDefaulted: Boolean = false
+
     // Mirror of WrappedMethod.returnsPairSecond: the underlying C++ method returns
     // `std::pair<iterator, bool>` whose iterator half can't be wrapped, so the
     // returnType has been rewritten to `bool` and CppWriter must emit the call's
@@ -222,6 +230,7 @@ open class ResolvedMethod(
     ).also {
         it.parent = parent
         it.isVirtual = isVirtual
+        it.isDefaulted = isDefaulted
         it.returnsPairSecond = returnsPairSecond
         it.returnViaMemberCall = returnViaMemberCall
         it.rangeElementType = rangeElementType

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelResolution.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ModelResolution.kt
@@ -584,6 +584,7 @@ private suspend fun WrappedMethod.resolvePlainMethod(
         qualified
     ).also {
         it.isVirtual = isVirtual
+        it.isDefaulted = isDefaulted
         it.returnsPairSecond = returnsPairSecond
         it.returnViaMemberCall = returnViaMemberCall
         it.rangeElementType = rangeElementType

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -703,10 +703,13 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                 codeGenerationPolicy.onGenerateMethodFailed(cls, method, t)
             }
         }
-        // A class with `operator==` got an `equals` override above; emit the paired
-        // `hashCode` override here so the equals/hashCode contract is always honoured.
-        if (methods.any { it.operator == ResolvedOperator.EQ }) {
-            generateHashCode(cls)
+        // A class with `operator==` got an `equals`/`valueEquals` override above; emit the
+        // paired `hashCode` override here so the equals/hashCode contract is always honoured.
+        // The field-fold hashCode is only sound when the `==` is a DEFAULTED (memberwise-over-
+        // all-members) comparison; a hand-written `==` gets an identity hashCode keyed on the
+        // backing pointer (matching the identity `equals` generateEquals emitted for it).
+        methods.find { it.operator == ResolvedOperator.EQ }?.let {
+            generateHashCode(cls, it.isDefaulted)
         }
         // Index-accessible containers (detected by size() + index get) get a synthesized
         // `operator fun iterator()` so `for (x in v)` and the full Iterable surface work.
@@ -2284,12 +2287,16 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         cls: ResolvedClass,
         method: ResolvedMethod
     ) {
-        // C++ operator== maps to an idiomatic Kotlin `equals` override (so `a == b`
-        // works) rather than an `infix fun eq`. The matching `hashCode` override is
-        // emitted alongside in onGenerateMethods to keep the equals/hashCode
-        // contract.
+        // C++ operator== maps to Kotlin equality. A DEFAULTED `==` (C++20 `= default`) is
+        // guaranteed memberwise over ALL members, so it becomes an idiomatic `equals`
+        // override (so `a == b` works) whose paired field-fold `hashCode` (emitted in
+        // onGenerateMethods) is contract-sound. A HAND-WRITTEN `==` may compare only a
+        // subset of state, which would break the equals/hashCode contract against the
+        // field-fold hashCode; it instead gets an IDENTITY `equals` (backing-pointer
+        // equality) + a `valueEquals` method exposing the C++ comparison. The matching
+        // `hashCode` override is emitted alongside in onGenerateMethods either way.
         if (operator == ResolvedOperator.EQ) {
-            generateEquals(cls, method)
+            if (method.isDefaulted) generateEquals(cls, method) else generateValueEquals(cls, method)
             return
         }
         // C++ `operator<` maps to an idiomatic Kotlin `operator fun compareTo`
@@ -2378,10 +2385,12 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
     }
 
-    // C++ `operator==` → an idiomatic Kotlin `equals` override. The body narrows
-    // `other` to the wrapper type, then delegates the actual comparison to the
-    // generated `_op_eq` C function over the two backing pointers. Using the
-    // extensionMethod Call (rather than a Raw) keeps the C symbol's import wired up.
+    // A DEFAULTED C++ `operator==` → an idiomatic Kotlin `equals` override. The body
+    // narrows `other` to the wrapper type, then delegates the actual comparison to the
+    // generated `_op_eq` C function over the two backing pointers. Sound only because a
+    // defaulted `==` is memberwise over ALL members (so the paired field-fold hashCode
+    // agrees). Using the extensionMethod Call (rather than a Raw) keeps the C symbol's
+    // import wired up.
     private fun KotlinCodeBuilder.generateEquals(cls: ResolvedClass, method: ResolvedMethod) {
         val typeName = cls.type.kotlinType.plainName
         override {
@@ -2401,6 +2410,41 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
                         )
                     )
                 }
+            }
+        }
+    }
+
+    // A HAND-WRITTEN C++ `operator==` (not `= default`) can't be statically proven
+    // memberwise, so binding it to Kotlin `equals` would risk the equals/hashCode
+    // contract (a custom `==` may ignore fields the field-fold hashCode folds). Instead:
+    //  * `equals` is an IDENTITY comparison on the backing pointer (paired in
+    //    onGenerateMethods with a `ptr.hashCode()` hashCode — always contract-sound), and
+    //  * the C++ comparison stays reachable as `valueEquals(other): Boolean`, delegating
+    //    to the same `_op_eq` C wrapper the delegating `equals` would have used.
+    private fun KotlinCodeBuilder.generateValueEquals(cls: ResolvedClass, method: ResolvedMethod) {
+        val typeName = cls.type.kotlinType.plainName
+        override {
+            function {
+                name = "equals"
+                retType = type(ResolvedKotlinType("kotlin.Boolean", false))
+                define("other", nullable(fullyQualifiedType("kotlin.Any")))
+                body {
+                    +Return(Raw("other is $typeName && ptr == (other as $typeName).ptr"))
+                }
+            }
+        }
+        function {
+            name = "valueEquals"
+            retType = type(ResolvedKotlinType("kotlin.Boolean", false))
+            define("other", cls.type.kotlinType.copy(isNullable = false))
+            body {
+                +Return(
+                    Call(
+                        extensionMethod(pkg, method.uniqueCName!!),
+                        ptr,
+                        Raw("other.ptr")
+                    )
+                )
             }
         }
     }
@@ -2441,18 +2485,26 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         }
     }
 
-    // Always paired with `equals` so the equals/hashCode contract holds: equal
-    // objects (same `operator==`) must hash equal. Best-effort and allowed to be
-    // poorly-distributed — it folds the public fields' hashCodes (the same state
-    // `operator==` compares), or returns a fixed constant when the class exposes
-    // no usable fields.
-    private fun KotlinCodeBuilder.generateHashCode(cls: ResolvedClass) {
+    // Always paired with `equals` so the equals/hashCode contract holds: equal objects
+    // must hash equal. The shape depends on how the class's `operator==` bound to Kotlin
+    // equality:
+    //  * DEFAULTED `==` → `equals` is the memberwise C++ comparison, so a field-fold
+    //    hashCode is sound (equal objects have all members equal → same fold; private-only
+    //    differences only cause allowed collisions). Best-effort/poorly-distributed: it
+    //    folds the public fields' hashCodes, or a fixed constant when there are no fields.
+    //  * HAND-WRITTEN `==` → `equals` is identity on the backing pointer, so the hashCode
+    //    must match that: `ptr.hashCode()`.
+    private fun KotlinCodeBuilder.generateHashCode(cls: ResolvedClass, isDefaulted: Boolean) {
         val fields = cls.children.filterIsInstance<ResolvedField>()
         override {
             function {
                 name = "hashCode"
                 retType = type(ResolvedKotlinType("kotlin.Int", false))
                 body {
+                    if (!isDefaulted) {
+                        +Return(Raw("ptr.hashCode()"))
+                        return@body
+                    }
                     if (fields.isEmpty()) {
                         +Return(Raw("0"))
                         return@body

--- a/krapper_gen/src/nativeTest/kotlin/FullKotlinTests.kt
+++ b/krapper_gen/src/nativeTest/kotlin/FullKotlinTests.kt
@@ -529,10 +529,22 @@ class FullKotlinTests {
             "    return retValue\n" +
             "}"
 
-    // C++ operator== now maps to an idiomatic Kotlin `equals` override (so `a == b`
-    // works) rather than an `infix fun eq`. The body narrows `other` and delegates
-    // to the generated `_op_eq` C function over the two backing pointers.
+    // A HAND-WRITTEN C++ `operator==` (isDefaulted=false, TestClass's default) can't be
+    // proven memberwise, so binding it to Kotlin `equals` would risk the equals/hashCode
+    // contract. It instead gets an IDENTITY `equals` (backing-pointer equality) plus a
+    // `valueEquals` exposing the C++ comparison (delegating to the `_op_eq` C wrapper).
     private val testlibTestclassEqCmp =
+        "override fun equals(other: Any?): Boolean {\n" +
+            "    return other is TestClass && ptr == (other as TestClass).ptr\n" +
+            "}\n" +
+            "fun valueEquals(other: TestClass): Boolean {\n" +
+            "    return TestLib_TestClass_op_eq(ptr, other.ptr)\n" +
+            "}"
+
+    // A DEFAULTED C++ `operator==` (`= default`) IS memberwise over all members, so it
+    // keeps the idiomatic delegating `equals` override (so `a == b` runs the C++ `==`),
+    // whose paired field-fold hashCode is then contract-sound.
+    private val testlibTestclassEqDefaulted =
         "override fun equals(other: Any?): Boolean {\n" +
             "    return other is TestClass && " +
             "TestLib_TestClass_op_eq(ptr, (other as TestClass).ptr)\n" +
@@ -1101,6 +1113,24 @@ class FullKotlinTests {
         target = TestData.testClass.operatorEq,
         expected = testlibTestclassEqCmp
     )
+
+    @Test
+    fun testTestClass_op_eq_defaulted() {
+        // Flip the shared operatorEq to DEFAULTED for this one assertion, then restore it, so
+        // the flag can't leak into the hand-written-`==` case above regardless of test order.
+        // (Reusing the singleton keeps it resolvable — it's the one registered in TestData.tu.)
+        val op = TestData.testClass.operatorEq
+        try {
+            op.isDefaulted = true
+            runTest(
+                cls = TestData.testClass.cls,
+                target = op,
+                expected = testlibTestclassEqDefaulted
+            )
+        } finally {
+            op.isDefaulted = false
+        }
+    }
 
     @Test
     fun testTestClass_op_neq() = runTest(

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelIo.kt
@@ -135,6 +135,7 @@ data class MethodDto(
     val methodType: MethodType = MethodType.METHOD,
     val isVirtual: Boolean = false,
     val isConst: Boolean = false,
+    val isDefaulted: Boolean = false,
     val returnsPairSecond: Boolean = false,
     val returnViaMemberCall: String? = null,
     val rangeElementType: String? = null,
@@ -405,6 +406,7 @@ private class ModelEncoder(private val shared: Set<ElementIdentity>) {
                 element.methodType,
                 element.isVirtual,
                 element.isConst,
+                element.isDefaulted,
                 element.returnsPairSecond,
                 element.returnViaMemberCall,
                 element.rangeElementType,
@@ -515,6 +517,7 @@ private class ModelDecoder {
             is MethodDto -> WrappedMethod(dto.name, type(dto.returnType), dto.methodType).also {
                 it.isVirtual = dto.isVirtual
                 it.isConst = dto.isConst
+                it.isDefaulted = dto.isDefaulted
                 it.returnsPairSecond = dto.returnsPairSecond
                 it.returnViaMemberCall = dto.returnViaMemberCall
                 it.rangeElementType = dto.rangeElementType

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/ModelSerializer.kt
@@ -33,6 +33,7 @@ data class SerializedElement(
     val methodType: String? = null,
     val isConst: Boolean? = null,
     val isVirtual: Boolean? = null,
+    val isDefaulted: Boolean? = null,
     val isAbstract: Boolean? = null,
     // Base-specifier payload (WrappedBase).
     val isPublic: Boolean? = null,
@@ -137,6 +138,7 @@ fun WrappedElement.serialized(): SerializedElement {
             methodType = methodType.name,
             isConst = isConst,
             isVirtual = isVirtual,
+            isDefaulted = isDefaulted.takeIf { it },
             children = kids
         )
 

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedMethod.kt
@@ -101,6 +101,15 @@ open class WrappedMethod(
     // A settable var so copy()/clone() preserve it, like isVirtual.
     var isConst: Boolean = false
 
+    // True for a C++20 `= default`-ed method (`CXXMethodDecl::isDefaulted()`). Only
+    // meaningful here for a defaulted `operator==`, which the compiler guarantees is a
+    // memberwise comparison over ALL members. KotlinWriter gates the equals/hashCode
+    // contract on it: a defaulted `==` keeps the delegating `equals` + field-fold
+    // `hashCode` (provably sound); a hand-written `==` — not statically classifiable as
+    // memberwise — falls back to an identity contract keyed on the backing pointer.
+    // A settable var so copy()/clone() preserve it, like isVirtual/isConst.
+    var isDefaulted: Boolean = false
+
     // Set by rewritePairSecondReturns (Parsing.kt): the C++ method returns
     // `std::pair<iterator, bool>`; its return is rewritten to `bool` and CppWriter emits
     // `.second` on the call. Threaded through copy()/clone()/resolve, like isVirtual.
@@ -132,6 +141,7 @@ open class WrappedMethod(
         it.parent = parent
         it.isVirtual = isVirtual
         it.isConst = isConst
+        it.isDefaulted = isDefaulted
         it.returnsPairSecond = returnsPairSecond
         it.returnViaMemberCall = returnViaMemberCall
         it.rangeElementType = rangeElementType
@@ -142,6 +152,7 @@ open class WrappedMethod(
         it.addAllChildren(children)
         it.isVirtual = isVirtual
         it.isConst = isConst
+        it.isDefaulted = isDefaulted
         it.returnsPairSecond = returnsPairSecond
         it.returnViaMemberCall = returnViaMemberCall
         it.rangeElementType = rangeElementType

--- a/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
+++ b/krapper_model/src/nativeTest/kotlin/com/monkopedia/krapper/generator/model/ModelIoTest.kt
@@ -58,6 +58,7 @@ class ModelIoTest {
         )
         method.isVirtual = true
         method.isConst = true
+        method.isDefaulted = true
         method.returnsPairSecond = true
         method.returnViaMemberCall = ".str()"
         method.rangeElementType = "clang::Decl"
@@ -162,6 +163,7 @@ class ModelIoTest {
         assertEquals("const std::string&", method.returnType.toString())
         assertTrue(method.isVirtual)
         assertTrue(method.isConst)
+        assertTrue(method.isDefaulted)
         assertTrue(method.returnsPairSecond)
         assertEquals(".str()", method.returnViaMemberCall)
         assertEquals("clang::Decl", method.rangeElementType)

--- a/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
@@ -543,7 +543,11 @@ private class ModelBuilder(private val memScope: MemScope) {
         return WrappedMethod(name, returnType, methodType).also {
             it.isConst = isConst
             it.isVirtual = method.isVirtual()
-            it.isDefaulted = method.isDefaulted()
+            // Use isExplicitlyDefaulted (user wrote `= default`), NOT isDefaulted: the latter
+            // also covers compiler-implicit defaulting, which never applies to a user-declared
+            // operator==. Only an explicit `= default`-ed operator== should take the delegating
+            // equals + field-fold hashCode path; hand-written == stays on the identity path.
+            it.isDefaulted = method.isExplicitlyDefaulted()
             it.rangeElementType = range?.second
             it.addArgs(method.asFunctionDecl())
         }

--- a/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
@@ -543,6 +543,7 @@ private class ModelBuilder(private val memScope: MemScope) {
         return WrappedMethod(name, returnType, methodType).also {
             it.isConst = isConst
             it.isVirtual = method.isVirtual()
+            it.isDefaulted = method.isDefaulted()
             it.rangeElementType = range?.second
             it.addArgs(method.asFunctionDecl())
         }


### PR DESCRIPTION
## The contract bug this fixes

Today, whenever a bound C++ class has `operator==`, the generator ALWAYS emits a Kotlin `equals(other)` that delegates to the C++ `operator==` (via the `_op_eq` C wrapper) **plus** a `hashCode()` that folds the public fields.

That is a latent **equals/hashCode contract bug** when `operator==` is *hand-written*: a custom `==` may compare only a subset of state (e.g. an `id`), so two objects that are `==`-equal can differ in some public field. The field-fold `hashCode` then gives them **different** hashes -> violates Kotlin's contract (equal objects must hash equal).

## The rule (defaulted vs custom)

The only reliably AST-detectable "structure member comparison" is a **C++20 defaulted** `operator==` (`bool operator==(const T&) const = default;`), which the compiler guarantees is memberwise over ALL members. A hand-written body can't be statically classified as memberwise, so it conservatively takes the "otherwise" (identity) path.

- **`==` is DEFAULTED** (`CXXMethodDecl::isDefaulted()`): keep today's behavior — delegating `equals` + field-fold `hashCode`. Now provably sound (all members equal ⇒ same fold; private-only differences only cause allowed collisions).
- **`==` is NOT defaulted** (custom): switch to an **identity contract** keyed on the backing C++ pointer, so the contract holds regardless of what the custom `==` does:
  - `equals(other)` -> `other is T && ptr == (other as T).ptr`
  - `hashCode()` -> `ptr.hashCode()`
  - the C++ comparison stays reachable as **`valueEquals(other: T): Boolean`**, delegating to the same `_op_eq` wrapper the old `equals` used.

## `valueEquals`

So the semantic C++ comparison is never lost when we drop it off Kotlin `==`/`equals` — it moves to `valueEquals`. Only the *binding to Kotlin equality* changes.

## Plumbing

A new `isDefaulted` method flag through the single cpp front-end path:
`krapper_parse` `ModelBuilder` (`it.isDefaulted = method.isDefaulted()`) -> `WrappedMethod` -> `ModelIo`/`ModelSerializer` -> `ResolvedMethod` (via `ModelResolution`) -> `KotlinWriter` (`generateOperator`/`generateEquals`/new `generateValueEquals`/`generateHashCode`).

**Surprise (good one): no slice-header change was needed.** `CXXMethodDecl::isDefaulted()` is already bound on the generated krapper_parse surface (alongside `isConst()`/`isVirtual()`/`isStatic()`), so `ModelBuilder` just consumes the already-generated accessor. The krapper_parse self-host re-sync stayed clean and `isDefaulted()` is present in the regenerated bindings.

## Tests

- **featuregen**: added a defaulted `operator== = default` struct (`VecEq`) exercising the delegating-equals + field-fold-hashCode path, and updated the existing hand-written cases (`Vec2`, `Widget`) to the new identity-`equals` + `valueEquals` + `ptr.hashCode()` behavior (`OpRelationalTest`, `UcStaticOpTest`). The featuregen operator fixtures previously covered ONLY the hand-written case (no defaulted-vs-custom distinction existed) — this adds the missing defaulted case.
- **krapper_gen**: updated `FullKotlinTests.testTestClass_op_eq` to assert the new identity+`valueEquals` output and added `testTestClass_op_eq_defaulted` asserting the delegating equals under `isDefaulted=true`.
- **krapper_model**: extended `ModelIoTest` to set + assert `isDefaulted` round-trips.

## Gate results

- **featuregen behavioral suite: 189/0** (was 188; +1 for the new defaulted-`==` test; sync re-run after the generator change, cpp front-end).
- **`:krapper_gen:nativeTest`: green** (289 tests).
- **krapper_parse self-host re-sync: clean** (`isDefaulted()` present in regenerated bindings; 124 files).
- **`assemble` + ktlint on all touched source sets: green.** (Pre-existing `:feature-tests:ktlintKotlinScriptCheck` violations in `feature-tests/build.gradle.kts` exist on clean `main` too — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)