### PR TITLE
krapper_gen: skip methods whose signature references an inaccessible (protected/private) nested type (#123)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -290,6 +290,7 @@ A multi-namespace probe (`NsSingleTest`/`NsNestedTest`/`NsNestedClassTest`/
 | NS-nested-class | `Outer::Inner` | `package outer`, class `Inner`, `import outer.Inner`; `Outer` stays `root.Outer` | 🟢 | the outer class name becomes a package segment — so two `Outer::Inner` separate naturally (the review's "collide in root" prediction was wrong) |
 | NS-collision | `acolor::Tag` / `bflavor::Tag` | distinct packages + distinct C prefixes | 🟢 | no link/runtime clash; same-file Kotlin use needs an import alias (`import bflavor.Tag as FlavorTag`) |
 | NS-anon | anonymous `namespace { Hidden }` | (skipped — not bound) | 🟢 | members are now skipped (TU-internal linkage, not referenceable across a C ABI) instead of emitting an invalid empty `package ` line — `WrappedElement.map` returns null for an empty-spelling namespace |
+| TI-inaccessible | public method over a `protected`/`private` nested type — `int use(HiddenMode)` / `HiddenTag make()` | (method skipped — not bound) | 🟢 | a nested tag type declared `protected`/`private` can't be named from the free-function wrapper (the LLVM-22 repro: `ASTContext::getPredefinedSugarType(clang::Type::PredefinedSugarKind)`, param is a protected enum). `TypeBuilder` resolves such a leaf to `UNRESOLVABLE`, so the method drops through the same `notifyFailed` path as any unbindable type; sibling methods over accessible types still bind. Replaces a manual per-symbol `removeMethod` fixup. `TiInaccessibleTypeTest` (#123) |
 
 ## Inheritance & virtual dispatch
 

--- a/featuregen/src/cppMain/include/strings_feature.h
+++ b/featuregen/src/cppMain/include/strings_feature.h
@@ -871,4 +871,29 @@ struct RefHolder {
     int note;
 };
 
+// T-inaccessible (#123): a public method whose SIGNATURE references a protected/private
+// nested type can't be bound — the generated wrapper is a free function, so it can't name
+// the type to cast to it (the LLVM-22 repro: `clang::ASTContext::getPredefinedSugarType`
+// takes the protected enum `clang::Type::PredefinedSugarKind`). Skip-not-crash: the
+// generator DROPS such a method (its signature type resolves to UNRESOLVABLE), while
+// sibling methods with accessible signatures still bind. Two inaccessible kinds are
+// covered — a protected nested ENUM and a private nested STRUCT — plus a method over the
+// accessible top-level `Color` enum as a control that must still bind.
+struct AccessProbe {
+protected:
+    enum HiddenMode { HM_A = 1, HM_B = 2 };   // protected nested enum
+private:
+    struct HiddenTag { int t; };              // private nested struct
+public:
+    AccessProbe() {}
+    // DROPPED: param is the protected enum (can't be named from the wrapper).
+    int useHiddenEnum(HiddenMode m) const { return (int)m; }
+    // DROPPED: return type is the private nested struct.
+    HiddenTag makeHiddenTag() const { return HiddenTag{7}; }
+    // BOUND: param is the accessible top-level `Color` enum (control for the drop).
+    int useColor(Color c) const { return (int)c; }
+    // BOUND: a plain int accessor sibling, always bindable.
+    int plain() const { return 99; }
+};
+
 #endif

--- a/featuregen/src/nativeTest/kotlin/TiInaccessibleTypeTest.kt
+++ b/featuregen/src/nativeTest/kotlin/TiInaccessibleTypeTest.kt
@@ -1,0 +1,37 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.memScoped
+import root.AccessProbe
+import root.Color
+
+// T-inaccessible (#123): a public method whose signature references a protected/private
+// nested type is un-nameable from the generated free-function wrapper, so binding it
+// would emit a cast to an inaccessible type (the LLVM-22 repro:
+// `clang::ASTContext::getPredefinedSugarType(clang::Type::PredefinedSugarKind)`, whose
+// param is the PROTECTED enum `clang::Type::PredefinedSugarKind`). Skip-not-crash: the
+// generator DROPS such a method (its signature type resolves to UNRESOLVABLE in
+// TypeBuilder, dropping the method through the same notifyFailed path as any other
+// unbindable type), while sibling methods with accessible signatures still bind.
+//
+// Coverage is structural: this file COMPILING + a successful sync proves the two
+// inaccessible-signature methods (`useHiddenEnum` over a protected enum, `makeHiddenTag`
+// returning a private struct) were NOT emitted — before the fix the wrapper compile
+// failed on the inaccessible cast. Referencing `p.useHiddenEnum(...)` / `p.makeHiddenTag()`
+// here would not compile (they are absent). The asserts exercise the surviving siblings —
+// a plain-int method and a method over the accessible top-level `Color` enum — to prove
+// AccessProbe is still usable and that only the inaccessible-signature methods dropped.
+class TiInaccessibleTypeTest {
+    // The plain-int sibling always binds: proves the class itself survived.
+    @Test fun plain_sibling_method_binds() = memScoped {
+        val p = with(AccessProbe) { AccessProbe() }
+        assertEquals(99, p.plain())
+    }
+
+    // A method over an ACCESSIBLE enum stays bound (control for the drop): the top-level
+    // `Color` enum is nameable, so useColor(Color) is emitted and round-trips through C++.
+    @Test fun accessible_enum_signature_method_binds() = memScoped {
+        val p = with(AccessProbe) { AccessProbe() }
+        assertEquals(1, p.useColor(Color.Green))
+        assertEquals(2, p.useColor(Color.Blue))
+    }
+}

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -225,12 +225,17 @@ kplusplus {
         removeMethod("llvm_APSInt_op_decrement")
         // #122 (self-hosting spike): LLVM-22 added clang::ASTContext::getPredefinedSugarType,
         // whose parameter is the PROTECTED enum clang::Type::PredefinedSugarKind. ASTContext
-        // is in the allowlist, so krapper_gen binds the method and emits a cast to the
-        // protected enum — `clang::Type::PredefinedSugarKind KD_cast = ...` — which the
-        // wrapper compile rejects ("protected member of 'clang::Type'"). The bridge doesn't
-        // need it (nothing here calls getPredefinedSugarType); remove it by uniqueCName until
-        // krapper_gen learns to skip methods over inaccessible types. The committed seed
-        // predates this LLVM surface, so it never carried the method.
+        // is in the allowlist, so a wrapper cast to the protected enum —
+        // `clang::Type::PredefinedSugarKind KD_cast = ...` — is rejected ("protected member
+        // of 'clang::Type'").
+        //
+        // #123 makes this durable: TypeBuilder now resolves a protected/private nested tag
+        // type to UNRESOLVABLE, so a NEWLY built krapper_parse auto-drops this method (and
+        // any future inaccessible-signature method) with no per-symbol fixup. This fixup is
+        // retained ONLY as a bootstrap crutch: :krapper_parse:kplusplusSync self-generates
+        // krapper_parse's own bindings with the PINNED stage-0 tool binary, which predates
+        // the #123 fix — without the removeMethod that stale tool re-emits the broken cast
+        // and the sync aborts. Drop this line once the stage-0 tool is bumped past #123.
         removeMethod("clang_ASTContext_get_predefined_sugar_type")
     }
     // Materialize the range returns the walk iterates. Brick 3 walks members through

--- a/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import clang.AccessSpecifier
 import clang.CXXRecordDecl
 import clang.Decl
 import clang.EnumDecl
@@ -81,6 +82,19 @@ private fun WrappedType.maybeConst(isConst: Boolean): WrappedType =
 // Kotlin form is the platform-correct `platform.posix.<name>`, preserved by NAME instead
 // of being collapsed to their underlying integer.
 private val C_ALIAS_TYPEDEFS = setOf("size_t", "ssize_t", "ptrdiff_t", "intptr_t", "wchar_t")
+
+// #123: a nested tag type (enum/record) declared `protected`/`private` cannot be NAMED
+// from the wrapper's free-function context, so any signature that references it — e.g.
+// `clang::ASTContext::getPredefinedSugarType(clang::Type::PredefinedSugarKind)`, whose
+// param is the protected enum `clang::Type::PredefinedSugarKind` — would emit a cast to
+// that inaccessible type and fail to compile. Treat such a leaf as UNRESOLVABLE so the
+// resolver drops the whole method through its existing "couldn't resolve type" path
+// (ModelResolution's notifyFailed, DropPhase.RESOLVE), the same as any other unbindable
+// type — rather than requiring a manual per-symbol removeMethod fixup on every LLVM bump.
+// AS_none (top-level, non-member tags) and AS_public members stay bindable; the check
+// mirrors ModelBuilder's private/protected member filter (Decl::getAccess()).
+private fun Decl.isAccessibleTagType(): Boolean =
+    getAccess() != AccessSpecifier.AS_private && getAccess() != AccessSpecifier.AS_protected
 
 /**
  * Decode [type]'s structure into a WrappedType, mirroring the libclang front-end's
@@ -265,6 +279,8 @@ fun buildWrappedType(type: QualType): WrappedType {
         // template-element match — see clang_slice.h).
         val qualified = qualifiedName(record.asNamedDecl())
             ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
+        // #123: an inaccessible nested record can't be named from the wrapper — drop it.
+        if (!record.asDecl().isAccessibleTagType()) return UNRESOLVABLE
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {
@@ -283,6 +299,9 @@ fun buildWrappedType(type: QualType): WrappedType {
         val enumDecl = canonTy.getAsTagDecl()
             ?.let { Decl(it.ptr) }
             ?.asEnumDecl() ?: return UNRESOLVABLE
+        // #123: a protected/private nested enum (e.g. clang::Type::PredefinedSugarKind)
+        // can't be named from the wrapper — drop any method whose signature references it.
+        if (!enumDecl.asDecl().isAccessibleTagType()) return UNRESOLVABLE
         return buildEnumType(enumDecl).maybeConst(isConst)
     }
     // Builtin (and any remaining) leaf: createForType's `else -> WrappedType(spelling)`,


### PR DESCRIPTION
Fixes #123.

## Problem

A public method whose parameter/return type is a **protected or private nested tag type** (enum/record) can't be bound: the generated wrapper is a free function, so it can't name the inaccessible type to cast to it. The LLVM-22 repro is `clang::ASTContext::getPredefinedSugarType`, whose param is the protected enum `clang::Type::PredefinedSugarKind` — the wrapper compile rejects the emitted cast (`'PredefinedSugarKind' is a protected member of 'clang::Type'`). Until now the only fix was a manual, per-symbol, LLVM-version-specific `removeMethod` fixup that recurs on every LLVM bump.

## Detection + where it hooks into the drop machinery

The signal is the referenced type's clang access specifier. `krapper_parse`'s `TypeBuilder.buildWrappedType` decodes a `QualType` to a `WrappedType` and has the `Decl` in hand at both tag-type leaves (record and enum). New helper `Decl.isAccessibleTagType()` returns false for `AS_protected`/`AS_private` — exactly the accessor + values `ModelBuilder` already uses to filter private/protected members (`Decl::getAccess()`). When a leaf is inaccessible, the builder returns `UNRESOLVABLE`.

That's the whole hook: an `UNRESOLVABLE` signature type flows into the resolver's **existing** "couldn't resolve type" path — `ModelResolution.resolvePlainMethod`/`resolveArgument` → `ResolveContext.notifyFailed` → the method is dropped and recorded in the `DropLedger` as a `DropPhase.RESOLVE` drop, identically to any other unbindable type. No new drop seam was needed. `AS_none` (top-level, non-member tags) and `AS_public` members are untouched, so accessible-signature siblings still bind.

## The `removeMethod` fixup

The durable fix makes the `clang_ASTContext_get_predefined_sugar_type` fixup unnecessary for a **newly built** parser — but it is **retained** as a bootstrap crutch, because `:krapper_parse:kplusplusSync` self-generates krapper_parse's own bindings with the **pinned stage-0 tool binary**, which predates this fix. Removing the fixup makes that stale tool re-emit the broken cast and the self-sync aborts (exit 134, reproduced). The comment now notes the fixup can be dropped once the stage-0 tool is bumped past #123.

## Tests

featuregen `AccessProbe` fixture (`strings_feature.h`): a protected nested enum param (`useHiddenEnum`) and a private nested struct return (`makeHiddenTag`) both **drop**; a method over the accessible top-level `Color` enum (`useColor`) and a plain-int method (`plain`) still **bind**. Verified in the generated C header — only `AccessProbe_new/_use_color/_plain/_size_of/_align_of` are emitted. `TiInaccessibleTypeTest` asserts the surviving siblings behave. Added the `TI-inaccessible` row to `docs/features.md`.

## Observed gates (JAVA_HOME=21, -PenableClang, LLVM 22)

- `:featuregen:kplusplusSync` (cpp front-end, rebuilt krapper_parse): green — 119 Kotlin files.
- `:featuregen:nativeTest`: **191 tests, 0 failures, 0 errors** (includes `TiInaccessibleTypeTest`, 2 cases).
- `:krapper_gen:nativeTest`: green.
- `:krapper_parse:kplusplusSync` (self-host re-sync): green — 124 Kotlin files (with the retained bootstrap fixup).
- ktlint: no new violations on the touched files (`TypeBuilder.kt` clean; pre-existing `build.gradle.kts` script violations are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)