### PR TITLE
featuregen: pin nested-enum C++ qualification (#10 broad-binding cluster)

### DIFF
--- a/featuregen/src/cppMain/include/strings_feature.h
+++ b/featuregen/src/cppMain/include/strings_feature.h
@@ -39,6 +39,33 @@ struct EnumFeature {
 // shape as MEMBER operators so a Kotlin binding is generated + behaviourally tested.
 enum Flag { FlagNone = 0, FlagA = 1, FlagB = 2, FlagC = 4 };
 
+// EN-nested (#10 broad-binding correctness): an enum nested inside a NAMESPACE
+// (`ensig::Signal`) or a CLASS (`Machine::State`), passed to / returned from a wrapped
+// static method. The generated C++ RAW_CAST (`(ensig::Signal)x`) and ENUM_RETURN
+// (`(unsigned int)(...)`) must spell the enum with its full enclosing scope; a bare
+// `(Signal)x` at the wrapper's file scope is an undeclared identifier and won't compile.
+// This is the exact shape the "use of undeclared identifier" cluster (#10) was thought
+// to hit; it pins the qualification so a regression can't silently reintroduce it. The
+// featuregen surface had only TOP-LEVEL enums (Color/Flag/Direction), which never
+// exercise the enclosing-scope qualifier.
+namespace ensig {
+    enum Signal { SigLow = 0, SigHigh = 1, SigFloat = 2 };
+    struct Bus {
+        static Signal invert(Signal s) {
+            return s == SigLow ? SigHigh : (s == SigHigh ? SigLow : SigFloat);
+        }
+        static int level(Signal s) { return static_cast<int>(s); }
+    };
+}
+
+struct Machine {
+    enum State { Idle = 0, Running = 1, Halted = 2 };
+    static State advance(State s) {
+        return static_cast<State>((static_cast<int>(s) + 1) % 3);
+    }
+    static int stateInt(State s) { return static_cast<int>(s); }
+};
+
 struct ByteFlags {
     Flag bits;
     ByteFlags() : bits(FlagNone) {}

--- a/featuregen/src/nativeTest/kotlin/EnNestedTest.kt
+++ b/featuregen/src/nativeTest/kotlin/EnNestedTest.kt
@@ -1,0 +1,33 @@
+import ensig.Bus
+import ensig.Signal
+import machine.State
+import root.Machine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// EN-nested (#10 broad-binding correctness): a nested enum (in a namespace `ensig::Signal`
+// or a class `Machine::State`) round-trips through a wrapped static method. The point of
+// the fixture is the GENERATED C++: the RAW_CAST / ENUM_RETURN must spell the enum with
+// its enclosing scope (`ensig::Signal` / `Machine::State`), never a bare `Signal`/`State`
+// that would be an undeclared identifier at the wrapper's file scope. If that regressed,
+// featuregen sync would fail to COMPILE the wrapper — so a green build already proves the
+// qualification; these assertions additionally prove the round-trip is behaviourally sound.
+class EnNestedTest {
+    @Test fun namespace_nested_enum_round_trips() {
+        // invert: SigLow <-> SigHigh, SigFloat fixed. arg + return are both ensig::Signal.
+        assertEquals(Signal.SigHigh, Bus.invert(Signal.SigLow))
+        assertEquals(Signal.SigLow, Bus.invert(Signal.SigHigh))
+        assertEquals(Signal.SigFloat, Bus.invert(Signal.SigFloat))
+        // level: nested-enum arg -> int (ENUM arg cast, plain int return).
+        assertEquals(0, Bus.level(Signal.SigLow))
+        assertEquals(2, Bus.level(Signal.SigFloat))
+    }
+
+    @Test fun class_nested_enum_round_trips() {
+        // advance cycles Idle -> Running -> Halted -> Idle; arg + return are Machine::State.
+        assertEquals(State.Running, Machine.advance(State.Idle))
+        assertEquals(State.Halted, Machine.advance(State.Running))
+        assertEquals(State.Idle, Machine.advance(State.Halted))
+        assertEquals(2, Machine.stateInt(State.Halted))
+    }
+}


### PR DESCRIPTION
## Summary

Progresses #10 (broad-binding correctness — the "284-error / bare-enum-qualification thesis"). This chunk targets the FIRST cluster: the ~179× "use of undeclared identifier" hypothesized as ONE systematic bug — the generator emitting a bare enum-constant / static-member reference where the enclosing-scope qualifier is dropped in the generated C++.

## Key finding: the bare-enum thesis does NOT reproduce on the current generator

I root-caused the enum/static-member emission paths and confirmed, with new fixtures, that the current generator already emits nested enums **fully qualified** on both sides:

- **Enum-typed arg cast (RAW_CAST):** `ensig::Signal s_cast = (ensig::Signal)s;`  (not bare `(Signal)s`)
- **Enum return (ENUM_RETURN):** `return (unsigned int)(ensig::Bus::invert(s_cast));`
- **Static call:** `ensig::Bus::invert(...)`, `Machine::advance(...)` (`MethodType.STATIC` uses `cls.type.toString()`)

Why the cluster no longer bites, verified by inspection:
- `WrappedEnumType.cppName` is populated from `qualifiedName(enumDecl)` (`printQualifiedName`, inline-namespace-preserving) — the enclosing scope is always present. `toString()`/the RAW_CAST target both render it.
- Enum-constant **defaults** never reach the generated C++: the C++ wrapper takes every parameter explicitly (fixed arity); `KotlinWriter.renderKotlinDefault` maps only simple literals and returns null for enum/named-constant defaults (param stays mandatory). So a captured default spelling like `RED` is never emitted into C++.
- **Static data members** (e.g. `FlagProbe::state`) are not bound as fields at all — no `thiz->member` / bare-member emission path exists.

The 179× cluster was measured 2026-06-06; it appears to have been resolved by the intervening qualification/correctness work (T-typename, inline-namespace names, nested-class handling, referenceTypedefElement, etc.). Since there is no reproducible bare-enum bug in the current generator, this PR lands the **regression guard** that pins the qualification the #10 thesis worried about, rather than a no-op generator edit.

## Fix site / change

No generator code change was warranted (the paths are already correct). The change is a **coverage gap closure**:
- `featuregen/src/cppMain/include/strings_feature.h` — new `EN-nested` fixtures: an enum nested in a **namespace** (`ensig::Signal` + `ensig::Bus` static methods) and in a **class** (`Machine::State` + `Machine` static methods). featuregen previously had only TOP-LEVEL enums (Color/Flag/Direction), which never exercise the enclosing-scope qualifier — the exact thing the thesis was about.
- `featuregen/src/nativeTest/kotlin/EnNestedTest.kt` — round-trips both nested enums arg→return. A green build already proves the generated C++ wrapper **compiles** with the qualified spelling; the assertions additionally prove behavioural soundness.

## Observed gate counts

- `:featuregen:nativeTest -PenableClang -Pkpp.frontend.featuregen=cpp` — **195/0** (includes the 2 new EnNestedTest tests; both green; the wrapper compiles the nested-enum casts).
- `:krapper_gen:nativeTest` — **291/0**.

(Note: the default `:featuregen:kplusplusSync` — using the published 0.3.2 tool binary — aborts with exit 134 on **clean main** as well, independent of this change; the in-tree `-Pkpp.frontend.featuregen=cpp` path is the one exercised here.)

## Part B — broad-surface before/after (honest note: infeasible in this environment)

The broad force (~1269 classes via `--referencePolicy INCLUDE_MISSING` over `clang_slice.h`) does **not complete** in this environment. Driving it through `:clangwalk:kplusplusSync -Pkpp.frontend.clangwalk=cpp` with INCLUDE_MISSING + no `only()`, the krapper_gen step produces **no generated C++** (empty output, stale seed left in place) — matching the documented 1269-class INCLUDE_MISSING explosion / SEGV (`docs/campaigns/self-hosting.md`: "forcing `vector<clang::Decl*>` … SEGVs (INCLUDE_MISSING pulls the whole LLVM world)"). I could therefore not produce a full before/after error count and did not fabricate one.

What I can report with confidence: the enum cluster the count was dominated by does not reproduce on the isolated shapes (proven by the new fixtures + green compile). The remaining #10 categories (incomplete-type, deleted-ctor residuals, fn-ptr, the 9 std-typedef handler qualification cases, and confirming/remeasuring the broad count once a scoped-force harness that survives this env exists) stay as documented follow-up on #10.

## Surprise

The "one systematic bug" framing did not hold: the enum-type qualification path was already correct, enum-constant defaults never reach C++, and static data members aren't bound as fields — three distinct reasons the bare-enum thesis doesn't reproduce, rather than a single latent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
