### PR TITLE
experimental flag system + flag-gated resolve timing

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -443,7 +443,14 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             "kplusplusSync[$moduleName]: krapper_gen (cpp model) over ${requested.size} " +
                 "instantiation(s) from $headerPath -> $krappedDir"
         )
-        val exit = ProcessBuilder(args).inheritIO().start().waitFor()
+        // Experimental / diagnostic flag passthrough: `-Pkpp.x=diag.timing` (comma-separated
+        // for several) is forwarded verbatim to krapper_gen via its KRAPPER_X env var, so an
+        // experiment can be driven through the build without touching source. Off by default.
+        val procBuilder = ProcessBuilder(args).inheritIO()
+        (target.findProperty("kpp.x") as? String)?.takeIf { it.isNotBlank() }?.let {
+            procBuilder.environment()["KRAPPER_X"] = it
+        }
+        val exit = procBuilder.start().waitFor()
         if (exit != 0) {
             throw GradleException(
                 "kplusplusSync[$moduleName]: krapper_gen (--parsedModel) failed: exit $exit"

--- a/docs/experimental-flags.md
+++ b/docs/experimental-flags.md
@@ -1,0 +1,69 @@
+# Experimental / diagnostic flags
+
+krapper_gen is effectively a compiler, so it accretes *experiments* (new resolve strategies,
+caches, alternate codegen) and *diagnostics* (timing, dumps) that we want gated behind a switch
+rather than shipped on by default. Rather than let each grow its own ad-hoc mechanism, they share
+one home: the **experimental flag registry**.
+
+## Declaring a flag (the single source of truth)
+
+Every flag is declared once in
+[`ExperimentalFlags`](../krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt)
+with a namespaced name, a type (`BoolFlag` / `StringFlag` / `IntFlag`), a default, and a one-line
+description, then added to the `all` list:
+
+```kotlin
+val DIAG_TIMING = ExperimentalFlag.BoolFlag(
+    "diag.timing",
+    default = false,
+    description = "Log per-phase wall-clock timings (ms) + counts to stderr."
+)
+
+val all: List<ExperimentalFlag<*>> = listOf(DIAG_TIMING)
+```
+
+Read it anywhere via the typed accessor:
+
+```kotlin
+if (ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING)) { ... }
+val mode = ExperimentalFlags.get(SomeStringFlag)   // returns the flag's default when unset
+```
+
+Names are dotted by area, e.g. `diag.timing`, `forcing.crossRequestMemo`.
+
+## Setting a flag
+
+Resolved **once** at tool startup, with precedence **CLI `-X` > env `KRAPPER_X` > default**:
+
+- **Env:** `KRAPPER_X` holds a comma-separated list of `name` (bool → on) or `name=value` entries.
+  `export KRAPPER_X=diag.timing,forcing.memo=lru`
+- **CLI:** repeatable `-X name[=value]` / `--experimental name[=value]` merges over (and overrides)
+  the env. `krapper_gen ... -X diag.timing -X forcing.memo=lru`
+- **Gradle:** `-Pkpp.x=<value>` is forwarded to krapper_gen as `KRAPPER_X` by the compiler plugin's
+  `kplusplusSync` (`./gradlew :featuregen:kplusplusSync -Pkpp.frontend.featuregen=cpp -Pkpp.x=diag.timing`).
+
+**Inert when unset.** With no flag set, every read returns the declared default, so behavior and
+generated output are byte-identical to a build with no flag machinery.
+
+Discoverability:
+
+- Unknown names **warn** to stderr (typo visibility), never crash.
+- Active (non-default) flags are logged to stderr at startup for reproducibility.
+- `krapper_gen --list-experimental` prints every declared flag with its default + description.
+
+## First consumer: `diag.timing`
+
+`diag.timing` gates
+[`Diag.timed`](../krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Diag.kt), a
+zero-overhead-when-off timing helper wired into `resolveForcing` (per-pass wall-clock + class
+counts, and a per-request total). This is the instrumentation the upcoming cross-request
+memoization experiment needs.
+
+## Candidates to migrate later (NOT done here — kept out of scope)
+
+These pre-existing ad-hoc toggles could later move into the registry for consistency:
+
+- `KRAPPER_ROUNDTRIP_MODEL` env / `--roundTripModel` CLI (model round-trip oracle)
+- `--dumpParsedModel` CLI (parse-only dump)
+- `KRAPPER_DEBUG_RESOLVE` env (resolve debug filter, `Resolver.kt`)
+- `-Pkpp.frontend.<module>` build property (front-end selection)

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/App.kt
@@ -184,8 +184,27 @@ class KrapperGen : CliktCommand() {
             "by uniqueCName, strip a stale `const ` prefix from matching return types, etc.). " +
             "Applied during writeTo()."
     )
+    val experimental by option(
+        "-X",
+        "--experimental",
+        help = "Set an experimental / diagnostic flag as `name` (bool → on) or `name=value`. " +
+            "Repeatable. Merges over (and overrides) the KRAPPER_X env var. Unknown names warn " +
+            "to stderr. See --list-experimental for the declared flags."
+    ).multiple()
+    val listExperimental by option(
+        "--list-experimental",
+        help = "Print every declared experimental / diagnostic flag with its default and " +
+            "description, then exit."
+    ).flag()
 
     override fun run() {
+        // Resolve experimental / diagnostic flags ONCE, before any work: CLI -X overrides the
+        // KRAPPER_X env var overrides each flag's declared default. Inert when nothing is set.
+        ExperimentalFlags.init(cli = experimental)
+        if (listExperimental) {
+            print(ExperimentalFlags.listing())
+            return
+        }
         if (serviceMode) {
             return runService()
         }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Diag.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Diag.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.Utils.printerrln
+import kotlin.time.TimeSource
+
+/**
+ * Flag-gated diagnostics. Every helper here is a ZERO-OVERHEAD passthrough unless the
+ * `diag.timing` experimental flag is on (see [ExperimentalFlags.DIAG_TIMING]): with the flag
+ * off, [timed] just runs its block and [line] does nothing, so an ordinary run is byte-identical
+ * to one with no diagnostics wired in at all.
+ *
+ * When on, measurements use [TimeSource.Monotonic] (wall-clock, available in Kotlin/Native — the
+ * tool is a real native binary) and are logged to stderr, keeping stdout — the machine-readable
+ * generated-output channel — untouched.
+ */
+object Diag {
+    val timingEnabled: Boolean get() = ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING)
+
+    /**
+     * Run [block], and — only when `diag.timing` is on — log `<phase>: <ms> ms` to stderr with
+     * the elapsed wall-clock. Returns the block's result. Off-flag path adds no measurement.
+     */
+    inline fun <T> timed(phase: String, block: () -> T): T {
+        if (!timingEnabled) return block()
+        val mark = TimeSource.Monotonic.markNow()
+        val result = block()
+        line("$phase: ${mark.elapsedNow().inWholeMicroseconds / 1000.0} ms")
+        return result
+    }
+
+    /** Emit a diagnostic [message] to stderr only when `diag.timing` is on. */
+    fun line(message: String) {
+        if (timingEnabled) printerrln("diag: $message")
+    }
+}

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.Utils.printerrln
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+/**
+ * A single experimental / diagnostic toggle for the krapper_gen tool.
+ *
+ * krapper_gen is effectively a compiler, so it accretes experiments (new resolve strategies,
+ * caches, alternate codegen) and diagnostics (timing, dumps) we want gated behind a switch
+ * rather than shipped on-by-default. Historically each of those grew its own ad-hoc mechanism
+ * (an env var here, a `-P` gradle property there, a one-off CLI flag). This gives them ONE
+ * home: a flag is DECLARED once in [ExperimentalFlags] (name + type + default + description),
+ * parsed ONCE at startup from the environment and the CLI, and read through a typed accessor.
+ *
+ * A flag's [name] is namespaced with a dotted prefix by area, e.g. `diag.timing`,
+ * `forcing.crossRequestMemo`. The [default] is what every read returns when the flag is unset,
+ * so an untouched tool run is byte-for-byte identical to one with no flag machinery at all.
+ */
+sealed class ExperimentalFlag<T>(val name: String, val default: T, val description: String) {
+    /** Parse a raw string [value] (from `name=value`) into [T]; null = malformed, keep default. */
+    abstract fun parse(value: String): T?
+
+    class BoolFlag(name: String, default: Boolean, description: String) :
+        ExperimentalFlag<Boolean>(name, default, description) {
+        // A bare `name` (no `=value`) means "turn it on"; parse() only runs for an explicit
+        // `name=value`, where we accept the usual truthy/falsy spellings.
+        override fun parse(value: String): Boolean? = when (value.trim().lowercase()) {
+            "", "true", "1", "on", "yes" -> true
+            "false", "0", "off", "no" -> false
+            else -> null
+        }
+    }
+
+    class StringFlag(name: String, default: String, description: String) :
+        ExperimentalFlag<String>(name, default, description) {
+        override fun parse(value: String): String = value
+    }
+
+    class IntFlag(name: String, default: Int, description: String) :
+        ExperimentalFlag<Int>(name, default, description) {
+        override fun parse(value: String): Int? = value.trim().toIntOrNull()
+    }
+}
+
+/**
+ * The central registry: the single source of truth for every experimental / diagnostic flag.
+ *
+ * Declaring a new flag is a one-liner here — add an [ExperimentalFlag] to [all] and read it via
+ * [ExperimentalFlags.get] (or the flag's own convenience accessor). Values are resolved ONCE by
+ * [ExperimentalFlags.init] at tool startup with the precedence:
+ *
+ *     CLI `-X name[=value]`  overrides  env `KRAPPER_X`  overrides  the declared default.
+ *
+ * Off-by-default and inert: before [init] runs, and for any flag left unset, [get] returns the
+ * declared [ExperimentalFlag.default], so the tool behaves and emits byte-identically to a build
+ * with no flag machinery. Unknown flag names are WARNed to stderr (typo visibility), never fatal.
+ */
+object ExperimentalFlags {
+    /** Env var holding a comma-separated `name` / `name=value` list. */
+    const val ENV_VAR = "KRAPPER_X"
+
+    // ---- Declared flags (the single source of truth). ----
+
+    // Emit per-phase wall-clock timings (and bound-class counts) to stderr. The first consumer
+    // of the flag system: gates Diag.timed. Feeds the upcoming cross-request memo experiment.
+    val DIAG_TIMING = ExperimentalFlag.BoolFlag(
+        "diag.timing",
+        default = false,
+        description = "Log per-phase wall-clock timings (ms) + counts to stderr."
+    )
+
+    /** Every declared flag. Add new flags here. */
+    val all: List<ExperimentalFlag<*>> = listOf(
+        DIAG_TIMING
+    )
+
+    private val byName: Map<String, ExperimentalFlag<*>> = all.associateBy { it.name }
+
+    // Resolved raw string values keyed by flag name; only NON-default entries live here, so an
+    // empty map == everything at its default == fully inert. Replaced wholesale by init().
+    private var resolved: Map<String, String> = emptyMap()
+
+    /**
+     * Parse [env] (the `KRAPPER_X` string) and [cli] (the repeatable `-X` option values), apply
+     * precedence (CLI over env over default), warn on unknown names, and install the result.
+     * Idempotent; safe to call once at startup. Env-independent core is [parse] for testability.
+     */
+    fun init(env: String? = getenv(ENV_VAR)?.toKString(), cli: List<String> = emptyList()) {
+        val (values, warnings) = parse(env, cli)
+        resolved = values
+        for (w in warnings) {
+            printerrln("kplusplus warn: $w")
+        }
+        logActive()
+    }
+
+    /**
+     * Pure resolver (no I/O): returns the resolved NON-default values plus a list of warnings for
+     * unknown / malformed entries. CLI entries are applied after env entries, so they win.
+     */
+    fun parse(env: String?, cli: List<String>): Pair<Map<String, String>, List<String>> {
+        val values = mutableMapOf<String, String>()
+        val warnings = mutableListOf<String>()
+        fun apply(entry: String, source: String) {
+            val trimmed = entry.trim()
+            if (trimmed.isEmpty()) return
+            val eq = trimmed.indexOf('=')
+            val name = (if (eq < 0) trimmed else trimmed.substring(0, eq)).trim()
+            val rawValue = if (eq < 0) "" else trimmed.substring(eq + 1)
+            val flag = byName[name]
+            if (flag == null) {
+                warnings += "unknown experimental flag '$name' (from $source); ignoring. " +
+                    "Known flags: ${byName.keys.sorted().joinToString(", ")}"
+                return
+            }
+            if (flag.parse(rawValue) == null) {
+                warnings += "malformed value '$rawValue' for experimental flag '$name' " +
+                    "(from $source); ignoring."
+                return
+            }
+            // Store the canonical raw string; typed reads re-parse through the flag.
+            values[name] = rawValue
+        }
+        env?.split(',')?.forEach { apply(it, "$ENV_VAR env") }
+        cli.forEach { apply(it, "-X") }
+        return values to warnings
+    }
+
+    /** Typed read: the resolved value if set (and valid), else the declared default. */
+    fun <T> get(flag: ExperimentalFlag<T>): T {
+        val raw = resolved[flag.name] ?: return flag.default
+        return (flag.parse(raw) ?: flag.default)
+    }
+
+    /** Convenience for the common boolean case. */
+    fun isEnabled(flag: ExperimentalFlag.BoolFlag): Boolean = get(flag)
+
+    /** Human-readable list of the active (non-default) flags, for the startup log. */
+    fun activeSummary(): String = activeFlags().joinToString(", ") { "${it.name}=${get(it)}" }
+
+    private fun activeFlags(): List<ExperimentalFlag<*>> = all.filter { it.name in resolved }
+
+    /** Full listing of every declared flag with default + description (for --list-experimental). */
+    fun listing(): String = buildString {
+        appendLine("Experimental / diagnostic flags (set via $ENV_VAR env or repeatable -X):")
+        for (flag in all.sortedBy { it.name }) {
+            val type = when (flag) {
+                is ExperimentalFlag.BoolFlag -> "bool"
+                is ExperimentalFlag.StringFlag -> "string"
+                is ExperimentalFlag.IntFlag -> "int"
+            }
+            appendLine("  ${flag.name} [$type, default=${flag.default}] — ${flag.description}")
+        }
+    }
+
+    private fun logActive() {
+        if (resolved.isEmpty()) return
+        printerrln("kplusplus: active experimental flags: ${activeSummary()}")
+    }
+
+    /** Test-only reset so unit tests don't leak resolved state into each other. */
+    internal fun resetForTest(values: Map<String, String> = emptyMap()) {
+        resolved = values
+    }
+}

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -53,6 +53,7 @@ import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedEnumEntry
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedFunctionPointer
 import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
 import com.monkopedia.krapper.generator.resolvedmodel.type.nullable
+import kotlin.time.TimeSource
 
 interface Resolver {
     suspend fun resolve(
@@ -203,6 +204,10 @@ suspend fun List<WrappedElement>.resolveForcing(
     forcedContainerKeys: MutableSet<String> = mutableSetOf(),
     forcingTargets: Set<String> = emptySet()
 ): List<ResolvedElement> {
+    // Gated wall-clock for the whole 3-pass forcing of THIS instantiation request; the mark is
+    // only read when `diag.timing` is on (see the total emitted before the return). Feeds the
+    // upcoming cross-request memoization experiment — the per-pass lines below split it up.
+    val requestMark = if (Diag.timingEnabled) TimeSource.Monotonic.markNow() else null
     val classes = filterIsInstance<WrappedClass>()
     // The `KrapperForce_*` struct's `value` member type IS the forced container
     // specialization (e.g. `std::vector<clang::Decl*>`); resolving it is what
@@ -265,14 +270,16 @@ suspend fun List<WrappedElement>.resolveForcing(
     //     here instead would silently drop those cross-instantiation methods.
     // The shared-tracker invariant still prevents the explosion: see pass 2.
     val pass1 = baseContext.withPolicyKeepingNamer(policy)
-    boundClasses.forEach {
-        if (pass1.resolve(it.type) == null) {
-            DropLedger.record(
-                it.type.toString(),
-                "Filtered class did not resolve",
-                DropPhase.RESOLVE
-            )
-            Log.w("Warning: can't resolve filtered class ${it.type}")
+    Diag.timed("forcing pass 1 (bind ${boundClasses.size} bound class(es))") {
+        boundClasses.forEach {
+            if (pass1.resolve(it.type) == null) {
+                DropLedger.record(
+                    it.type.toString(),
+                    "Filtered class did not resolve",
+                    DropPhase.RESOLVE
+                )
+                Log.w("Warning: can't resolve filtered class ${it.type}")
+            }
         }
     }
 
@@ -285,14 +292,16 @@ suspend fun List<WrappedElement>.resolveForcing(
     // as resolved and does NOT re-expand it — only the std container machinery is
     // pulled in. Result: the container specialization is now bound, bounded.
     val pass2 = baseContext.withPolicyKeepingNamer(ReferencePolicy.INCLUDE_MISSING)
-    forcingStructs.forEach {
-        if (pass2.resolve(it.type) == null) {
-            DropLedger.record(
-                it.type.toString(),
-                "Forcing struct did not resolve",
-                DropPhase.RESOLVE
-            )
-            Log.w("Warning: can't resolve forcing struct ${it.type}")
+    Diag.timed("forcing pass 2 (force ${forcingStructs.size} container(s))") {
+        forcingStructs.forEach {
+            if (pass2.resolve(it.type) == null) {
+                DropLedger.record(
+                    it.type.toString(),
+                    "Forcing struct did not resolve",
+                    DropPhase.RESOLVE
+                )
+                Log.w("Warning: can't resolve forcing struct ${it.type}")
+            }
         }
     }
 
@@ -386,8 +395,10 @@ suspend fun List<WrappedElement>.resolveForcing(
     // shape and seeds the shared tracker so pass 2's container force stays bounded — skipping a
     // class there could shift its first resolution into pass 2's INCLUDE_MISSING and change output.
     val containerConsumers = boundClasses.filter { it.referencesAnyContainer(containerMatchKeys) }
-    containerConsumers.forEach {
-        pass3.resolve(it.type)
+    Diag.timed("forcing pass 3 (recover ${containerConsumers.size} consumer(s))") {
+        containerConsumers.forEach {
+            pass3.resolve(it.type)
+        }
     }
 
     // Re-resolve any namespace-scoped static methods in the scoped set (parity with
@@ -410,6 +421,13 @@ suspend fun List<WrappedElement>.resolveForcing(
         (element as? ResolvedClass)?.type?.toString()?.takeIf { it !in alreadyBoundKeys }
     }
     forcedContainerKeys.addAll(newClassKeys)
+    requestMark?.let {
+        Diag.line(
+            "forcing request total: ${it.elapsedNow().inWholeMicroseconds / 1000.0} ms " +
+                "(${boundClasses.size} bound, ${containerConsumers.size} consumer(s), " +
+                "${newClassKeys.size} new, ${resolved.size} resolved)"
+        )
+    }
     Log.i(
         "Forcing introduced ${newClassKeys.size} new class(es) " +
             "(re-resolved ${resolved.size} total)"

--- a/krapper_gen/src/nativeTest/kotlin/ExperimentalFlagsTest.kt
+++ b/krapper_gen/src/nativeTest/kotlin/ExperimentalFlagsTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExperimentalFlagsTest {
+    @AfterTest
+    fun tearDown() {
+        // Never leak resolved flag state into other tests (or other flag tests).
+        ExperimentalFlags.resetForTest()
+    }
+
+    private fun resolve(env: String?, cli: List<String>): Map<String, String> {
+        val (values, _) = ExperimentalFlags.parse(env, cli)
+        ExperimentalFlags.resetForTest(values)
+        return values
+    }
+
+    @Test
+    fun defaultIsInertWhenNothingSet() {
+        resolve(null, emptyList())
+        assertFalse(ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING))
+        assertEquals("", ExperimentalFlags.activeSummary())
+    }
+
+    @Test
+    fun envBareNameTurnsBoolOn() {
+        resolve("diag.timing", emptyList())
+        assertTrue(ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING))
+    }
+
+    @Test
+    fun envExplicitFalseKeepsBoolOff() {
+        resolve("diag.timing=false", emptyList())
+        assertFalse(ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING))
+    }
+
+    @Test
+    fun envCommaSeparatedListParses() {
+        val (_, warnings) = ExperimentalFlags.parse("diag.timing , ", emptyList())
+        assertTrue(warnings.isEmpty(), "trailing empty entry should be ignored: $warnings")
+        resolve("diag.timing", emptyList())
+        assertTrue(ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING))
+    }
+
+    @Test
+    fun cliOverridesEnv() {
+        // env turns it on, CLI turns it back off -> CLI wins.
+        resolve("diag.timing", listOf("diag.timing=off"))
+        assertFalse(ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_TIMING))
+    }
+
+    @Test
+    fun unknownFlagWarnsButDoesNotCrash() {
+        val (values, warnings) = ExperimentalFlags.parse("diag.timeing", emptyList())
+        assertTrue(values.isEmpty(), "unknown flag must not resolve to a value")
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("unknown experimental flag 'diag.timeing'"))
+    }
+
+    @Test
+    fun malformedIntValueWarns() {
+        // Use the same warn path via a malformed bool value.
+        val (values, warnings) = ExperimentalFlags.parse("diag.timing=maybe", emptyList())
+        assertTrue(values.isEmpty())
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("malformed value 'maybe'"))
+    }
+
+    @Test
+    fun activeSummaryListsOnlyNonDefault() {
+        resolve("diag.timing", emptyList())
+        assertEquals("diag.timing=true", ExperimentalFlags.activeSummary())
+    }
+
+    @Test
+    fun listingCoversEveryDeclaredFlag() {
+        val listing = ExperimentalFlags.listing()
+        for (flag in ExperimentalFlags.all) {
+            assertTrue(listing.contains(flag.name), "listing missing ${flag.name}")
+        }
+    }
+}


### PR DESCRIPTION
## What

krapper_gen is effectively a compiler, so it keeps accreting **experiments** (resolve strategies, caches, alternate codegen) and **diagnostics** (timing, dumps) we want gated behind a switch. Today those are scattered (`KRAPPER_ROUNDTRIP_MODEL` env, `-Pkpp.frontend.<module>`, one-off `--dumpParsedModel`/`--roundTripModel`). This gives experimental + diagnostic toggles **one consistent home** — a small registry, not a framework — architected to extend.

First consumer: a flag-gated timing helper wired into the forcing resolver, the instrumentation the upcoming cross-request memoization experiment needs.

## The flag system

**Declaration (single source of truth)** — `ExperimentalFlags.kt`. Each flag is declared once with a namespaced name, a type (`BoolFlag`/`StringFlag`/`IntFlag`), a default, and a one-line description, then added to `all`:

```kotlin
val DIAG_TIMING = ExperimentalFlag.BoolFlag(
    "diag.timing", default = false,
    description = "Log per-phase wall-clock timings (ms) + counts to stderr."
)
val all = listOf(DIAG_TIMING)
```

Read via a typed accessor anywhere: `ExperimentalFlags.isEnabled(DIAG_TIMING)` / `get(flag)` (returns the declared default when unset).

**Parsed once at startup** with precedence **CLI `-X` > env `KRAPPER_X` > default**:
- Env: `KRAPPER_X` = comma list of `name` (bool → on) or `name=value`, e.g. `KRAPPER_X=diag.timing,forcing.memo=lru`.
- CLI: repeatable `-X name[=value]` / `--experimental` merges over (and overrides) the env.
- Gradle: `-Pkpp.x=<value>` forwarded to krapper_gen as `KRAPPER_X` through one hook in `kplusplusSync`.

**Robust + discoverable:** unknown names **WARN** to stderr (typo visibility), never crash; active (non-default) flags logged to stderr at startup; `--list-experimental` dumps every declared flag.

**Off-by-default and inert:** with nothing set, every read returns the declared default → behavior and generated output byte-identical to today.

Not migrating the existing scattered toggles here (kept the diff tight); `docs/experimental-flags.md` lists the migration candidates.

## First consumer: `Diag.timed`

`Diag.timed(phase) { ... }` measures wall-clock via `kotlin.time.TimeSource.Monotonic` and logs `<phase>: <ms>` to stderr **only** when `diag.timing` is on; off = a plain passthrough (zero measurement). Wired into `resolveForcing`: pass 1, pass 2, pass 3, and a per-request total with bound/consumer/new/resolved counts.

## Demonstrated timing (real run, all 17 featuregen forcing requests)

```
kplusplus: active experimental flags: diag.timing=true
diag: forcing pass 1 (bind 75 bound class(es)): 797.199 ms
diag: forcing pass 2 (force 1 container(s)): 9.812 ms
diag: forcing pass 3 (recover 0 consumer(s)): 0.001 ms
diag: forcing request total: 862.777 ms (75 bound, 0 consumer(s), 2 new, 22 resolved)
... (17 requests total)
diag: forcing request total: 1397.635 ms (75 bound, 1 consumer(s), 2 new, 27 resolved)
```

(Debug-binary numbers, so absolute ms are inflated; the shape is the point — **pass 1 re-binds the same 75 classes on every one of the 17 requests**, ~750–920 ms each, which is exactly the redundancy the cross-request memo experiment targets.) The identical run with the flag OFF logs **zero** diag lines.

## Byte-identical proof (registry inert when unused)

- **On vs off (same generator, direct invocation over all 17 featuregen forcing models):** every generated `.h`/`.cc`/`.kt`/`.def` byte-identical; flag-OFF emits 0 diag lines. (The only apparent `.def` delta was the `-o` output-dir token, because the two runs used different output dirs — not a flag effect.)
- ****Clean main vs this branch (flags default):** regenerated featuregen's full cpp binding tree on both and diffed. Every generated `.kt`/`.h`/`.cc` byte-identical. The lone `.def` delta was purely the worktree-root path prefix in its `-I`/`libraryPaths` (the two builds ran in different directories); identical after normalizing that prefix. The registry is inert when unused.**

## Gates

- `:krapper_gen:nativeTest` green; new `ExperimentalFlagsTest` **9/9** (env parse, CLI-over-env precedence, unknown-flag warn, malformed-value warn, default inertness, active summary, listing).
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` green: **195/0**.
- `:krapper_gen:ktlintCheck` green on the new files.

## Files

- `krapper_gen/.../ExperimentalFlags.kt` (registry), `Diag.kt` (timing helper)
- `krapper_gen/.../App.kt` (`-X`/`--experimental`/`--list-experimental` + startup init)
- `krapper_gen/.../Resolver.kt` (`Diag.timed` in `resolveForcing`)
- `compiler/gradle/.../KPlusPlusCompilerGradlePlugin.kt` (`-Pkpp.x` → `KRAPPER_X` hook)
- `krapper_gen/src/nativeTest/.../ExperimentalFlagsTest.kt`
- `docs/experimental-flags.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
