### PR TITLE
experiment: forcing cross-request memo prototype (behind flag) + measurement

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
@@ -86,9 +86,26 @@ object ExperimentalFlags {
         description = "Log per-phase wall-clock timings (ms) + counts to stderr."
     )
 
+    // EXPERIMENTAL (off by default): memoize the value-resolved form of pass-1's safely-
+    // memoizable bound classes across successive forcing requests, so the second and later
+    // --instantiate requests don't re-resolve the whole bound set from scratch. Guarded to the
+    // four safety conditions from docs/design/broad-forcing-resolve.md §(b.5): value-based
+    // (cached ResolvedClass, never a re-run against a mutated WrappedClass), restricted to the
+    // whole-run non-consumer + non-consumer-referencing subset, DISABLED under INCLUDE_MISSING
+    // (featuregen's policy — the memo buys nothing there and its on-demand materialization
+    // side effects make a memo hit unsafe), and process-reset per run. With the flag OFF this
+    // is byte-identical to today (the memo is never populated or consulted).
+    val FORCING_CROSS_REQUEST_MEMO = ExperimentalFlag.BoolFlag(
+        "forcing.crossRequestMemo",
+        default = false,
+        description = "EXPERIMENTAL: memoize pass-1's non-consumer bound-class resolutions " +
+            "across forcing requests (IGNORE_MISSING only). Off = byte-identical to today."
+    )
+
     /** Every declared flag. Add new flags here. */
     val all: List<ExperimentalFlag<*>> = listOf(
-        DIAG_TIMING
+        DIAG_TIMING,
+        FORCING_CROSS_REQUEST_MEMO
     )
 
     private val byName: Map<String, ExperimentalFlag<*>> = all.associateBy { it.name }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -104,6 +104,10 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         // (e.g. in writeTo) would be too late.
         DropLedger.reset()
         GenerationContext.reset(config.rootPackage, config.noRtti)
+        // Process-scoped, experimental (off by default), MUST be reset per run so it can't leak
+        // resolved state across in-process runs (the class of bug #11a fixed for elementLookup;
+        // guarded by DeterminismTest.twoInProcessRunsAreByteIdentical).
+        ForcingPass1Memo.reset()
     }
 
     override suspend fun filterAndResolve(filter: FilterDefinition) {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -55,6 +55,65 @@ import com.monkopedia.krapper.generator.resolvedmodel.type.ResolvedKotlinType
 import com.monkopedia.krapper.generator.resolvedmodel.type.nullable
 import kotlin.time.TimeSource
 
+/**
+ * EXPERIMENTAL, process-scoped, off by default (gated by
+ * [ExperimentalFlags.FORCING_CROSS_REQUEST_MEMO]).
+ *
+ * Cross-request memo for `resolveForcing`'s PASS 1. Each instantiation request re-decodes a fresh
+ * forcing TU and builds a fresh `ResolveTracker`, so pass 1 re-resolves the SAME base-bound class
+ * set from scratch on every request — O(bound × requests). For the classes that are provably
+ * request-INVARIANT (see the four conditions below), that re-resolution reproduces the same
+ * [ResolvedClass] value each time, so it can be memoized across requests.
+ *
+ * SAFETY (docs/design/broad-forcing-resolve.md §b.5 — all four are enforced at the call site):
+ *  1. VALUE-BASED: the stored value is the finished [ResolvedClass] taken out of the tracker after
+ *     resolution, never a re-run of `WrappedClass.resolve` against a (mutated) cached model element.
+ *     On a hit we inject the cached value straight into the fresh request's tracker.
+ *  2. NON-CONSUMER + NON-CONSUMER-REFERENCING subset only: a container consumer's method set changes
+ *     per forced container (request-dependent), and a class that references a consumer inherits that
+ *     dependence, so both are excluded — only opaque leaves are memoized.
+ *  3. IGNORE_MISSING ONLY: under INCLUDE_MISSING a first resolution can materialize siblings into the
+ *     shared tracker as a side effect; a memo hit would skip that pull and diverge elsewhere. The
+ *     memo is disabled under INCLUDE_MISSING (featuregen's policy — it also buys nothing there).
+ *  4. PROCESS-RESET per run: [reset] is called from `IndexedServiceImpl`'s init block alongside
+ *     `DropLedger`/`GenerationContext`, so it never leaks across in-process runs (guarded by
+ *     DeterminismTest.twoInProcessRunsAreByteIdentical).
+ *
+ * Instrumented with hit/miss/store counters, surfaced through `diag.timing`.
+ */
+object ForcingPass1Memo {
+    private val cache = mutableMapOf<String, ResolvedClass>()
+    var hits: Int = 0
+        private set
+    var misses: Int = 0
+        private set
+
+    /** True only when the experiment flag is on; every method below is inert otherwise. */
+    val enabled: Boolean
+        get() = ExperimentalFlags.isEnabled(ExperimentalFlags.FORCING_CROSS_REQUEST_MEMO)
+
+    /** The memoized value for [key], or null on a miss. Records the hit/miss counters. */
+    fun get(key: String): ResolvedClass? {
+        val hit = cache[key]
+        if (hit != null) hits++ else misses++
+        return hit
+    }
+
+    /** Store the finished resolved value for [key] (first-write-wins; later requests reproduce it). */
+    fun put(key: String, resolved: ResolvedClass) {
+        cache.getOrPut(key) { resolved }
+    }
+
+    fun summary(): String = "ForcingPass1Memo: ${cache.size} cached, $hits hit(s), $misses miss(es)"
+
+    /** Reset the process-scoped state at the start of each generation run. */
+    fun reset() {
+        cache.clear()
+        hits = 0
+        misses = 0
+    }
+}
+
 interface Resolver {
     suspend fun resolve(
         type: WrappedType,
@@ -270,8 +329,39 @@ suspend fun List<WrappedElement>.resolveForcing(
     //     here instead would silently drop those cross-instantiation methods.
     // The shared-tracker invariant still prevents the explosion: see pass 2.
     val pass1 = baseContext.withPolicyKeepingNamer(policy)
+
+    // EXPERIMENTAL cross-request memo (docs/design/broad-forcing-resolve.md §b; flag
+    // `forcing.crossRequestMemo`, OFF by default → this whole block is inert and pass 1 runs
+    // exactly as before). Under the four safety conditions, the MEMOIZABLE SUBSET of the bound
+    // classes resolves to a request-INVARIANT ResolvedClass, so we can serve requests 2..N from a
+    // process-scoped cache instead of re-resolving from scratch.
+    //
+    // The subset = non-consumers (over this request's cumulative `containerMatchKeys`) that also
+    // reference NO container consumer (condition 2 — a consumer's shape is request-dependent, and a
+    // class referencing one inherits that). Both exclusions are cheap structural type-string scans.
+    // Enabled only under IGNORE_MISSING (condition 3): under INCLUDE_MISSING a first resolution can
+    // side-effect-materialize siblings into the shared tracker, which a memo hit would skip.
+    val memoActive = ForcingPass1Memo.enabled && policy == ReferencePolicy.IGNORE_MISSING
+    val memoizable: Set<String> = if (memoActive) {
+        val consumers = boundClasses.filter { it.referencesAnyContainer(containerMatchKeys) }
+        val consumerKeys = consumers.mapTo(HashSet()) { it.type.toString() }
+        boundClasses
+            .filter { it.type.toString() !in consumerKeys }
+            .filterNot { it.referencesAnyClass(consumerKeys) }
+            .mapTo(HashSet()) { it.type.toString() }
+    } else {
+        emptySet()
+    }
     Diag.timed("forcing pass 1 (bind ${boundClasses.size} bound class(es))") {
         boundClasses.forEach {
+            val key = it.type.toString()
+            // On a memoizable-subset HIT, inject the cached finished ResolvedClass straight into
+            // this fresh request's tracker (value-based reuse, condition 1) and skip the resolve.
+            val cached = if (memoActive && key in memoizable) ForcingPass1Memo.get(key) else null
+            if (cached != null) {
+                baseContext.tracker.resolvedClasses[key] = cached
+                return@forEach
+            }
             if (pass1.resolve(it.type) == null) {
                 DropLedger.record(
                     it.type.toString(),
@@ -279,9 +369,13 @@ suspend fun List<WrappedElement>.resolveForcing(
                     DropPhase.RESOLVE
                 )
                 Log.w("Warning: can't resolve filtered class ${it.type}")
+            } else if (memoActive && key in memoizable) {
+                // MISS that just resolved: store the finished value for later requests.
+                baseContext.tracker.resolvedClasses[key]?.let { ForcingPass1Memo.put(key, it) }
             }
         }
     }
+    if (memoActive) Diag.line(ForcingPass1Memo.summary())
 
     // ---- Pass 2: INCLUDE_MISSING — bind the forcing struct (the container). ----
     // Same tracker. The struct's `value` member (`std::vector<clang::Decl*>`) is
@@ -459,6 +553,32 @@ private fun WrappedClass.referencesAnyContainer(containerKeys: Set<String>): Boo
                     child.args.any { it.type.mentionsContainer() }
 
             is WrappedField -> child.type.mentionsContainer()
+
+            else -> false
+        }
+    }
+}
+
+/**
+ * True when any member of this bound class references one of the [classKeys] (exact rendered
+ * type-string match) in its return type, an argument type, or a field type. Used by the
+ * cross-request pass-1 memo (`forcing.crossRequestMemo`) to enforce condition 2 of §b.5: a class
+ * that references a container CONSUMER inherits that consumer's request-dependence and so must NOT
+ * be memoized. Purely structural (no resolution, order-independent). An empty [classKeys] set
+ * (no consumers this request) yields false — nothing to exclude on.
+ */
+private fun WrappedClass.referencesAnyClass(classKeys: Set<String>): Boolean {
+    if (classKeys.isEmpty()) return false
+    fun WrappedType.mentionsClass(): Boolean {
+        val rendered = toString()
+        return classKeys.any { rendered.contains(it) }
+    }
+    return children.any { child ->
+        when (child) {
+            is WrappedMethod ->
+                child.returnType.mentionsClass() || child.args.any { it.type.mentionsClass() }
+
+            is WrappedField -> child.type.mentionsClass()
 
             else -> false
         }


### PR DESCRIPTION
## What

Prototype of the Option-(b) **cross-request pass-1 memo** for `resolveForcing`, behind a new
OFF-by-default experimental flag, plus a measured report. Design reference:
`docs/design/broad-forcing-resolve.md` §b (b.1–b.10).

**Do not merge on the ON path** — this is a measurement. The prototype earns a merge only for its
OFF-inertness (proven below); the ON path is experimental and its benefit is not realizable on any
scenario we can byte-check (see honesty caveat).

## Change

- **New flag** `forcing.crossRequestMemo` (`BoolFlag`, default false) in `ExperimentalFlags`.
- **`ForcingPass1Memo`** (process-scoped) consulted in `resolveForcing` pass 1, strictly per the
  four-condition safe key (§b.5):
  1. **value-based** — caches the finished `ResolvedClass`, injected into the fresh request's
     tracker on a hit (never re-runs `resolve` against a mutated `WrappedClass`);
  2. **non-consumer + non-consumer-referencing subset only** — excludes container consumers
     (request-dependent method set) and classes referencing one (`referencesAnyContainer` +
     new `referencesAnyClass`, structural type-string scans);
  3. **IGNORE_MISSING only** — disabled under INCLUDE_MISSING (side-effecting on-demand
     materialization would make a hit unsafe);
  4. **process-reset per run** — reset in `IndexedServiceImpl` init alongside
     `DropLedger`/`GenerationContext`.
- Instrumented with hit/miss counters surfaced via `diag.timing`.

## Which policy featuregen uses (empirically determined)

The compiler plugin passes `-r INCLUDE_MISSING` by default
(`KPlusPlusCompilerGradlePlugin.kt:390`) and featuregen sets no `referencePolicy` override →
**featuregen pass-1 runs under INCLUDE_MISSING**, where the memo is disabled by condition 3. So
featuregen **cannot exercise the memo path at all** — exactly the gate-blindness the design warns
of (§b.10). The memo is active only on the **IGNORE_MISSING** path (clangwalk / broad #10).

## Scenario measured: clangwalk (IGNORE_MISSING, 3 instantiation requests)

The one completing, byte-checkable, IGNORE_MISSING multi-request scenario. Ran `krapper_gen`
directly on clangwalk's cached cpp-models, OFF vs ON.

| | value |
|---|---|
| bound classes (pass 1) | **17** |
| memoizable subset | **1** class |
| container consumers | 3–5 (the Decl hierarchy: `decls()/methods()/bases()`) |
| memo hits | req1: 0 hit / 1 miss; req2: 1 hit; req3: 2 hits |
| pass-1 time OFF | 56.6 / 54.2 / 131.6 ms |
| pass-1 time ON | 56.8 / 52.6 / 50.4 ms |
| pass-1 speedup | **none measurable** (Δ within run-to-run noise; memo saves resolving 1 of 17) |
| **output byte-identical OFF vs ON** | **YES** (same output dir → whole-tree sha256 identical) |

So on the scenario we CAN byte-check, the memo is **verifiably correct but its benefit is
negligible** — clangwalk binds 17 classes, not the ~3221 the memo targets, and only 1 is a safe
opaque leaf.

## The broad scenario does not complete (so can't be byte-checked)

`only(18)` under INCLUDE_MISSING (design Scenario B) **timed out at 240s in the BASE resolve**
(churning `llvm::MapVector` rewrites) — it never reached forcing at all. The broad blow-up is the
**base-bind**, which runs *before* pass 1 and is INCLUDE_MISSING (memo disabled there anyway). This
confirms §b.7's caveat: the memo makes *forcing* cheap but does nothing for the base-bind wall,
which is the actual gate.

## Honest verdict

This is the **measurable-XOR-verifiable bind** the design predicted (§b.10):
- The scenario where the memo is **verifiable** (clangwalk, IGNORE_MISSING, completes) has too few
  bound classes for the memo to help measurably.
- The scenario where the memo would **help** (~3221 bound) either doesn't complete (INCLUDE_MISSING
  base stall, memo disabled) or would need a purpose-built completing IGNORE_MISSING force over
  hundreds of classes — which I could not construct reliably from the available model, and which
  would still be un-byte-checkable against a non-completing baseline.

**Recommendation:** the OFF path is provably inert (byte-identical + gates green) and safe to keep
behind the flag as scaffolding, but **Option (b) does not demonstrate a measurable win on any
scenario we can also byte-verify.** Its correctness on the path that matters rests on the predicate
argument, not a machine check — the same gate-blindness that bit #156's pass-1 attempt. The
offline-measurement framing (§b.10 alternative) looks like the better cost/risk trade unless/until
a completing mid-size IGNORE_MISSING force exists to measure against.

## Gates (OFF-inertness — the merge-relevant claim)

- Output **byte-identical OFF vs ON** on clangwalk (real IGNORE_MISSING scenario, memo active).
- `:krapper_gen:nativeTest` green (includes `DeterminismTest.twoInProcessRunsAreByteIdentical`).
- `:krapper_gen:ktlintCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
