### PR TITLE
diag: base-bind profiling instrumentation (off-by-default)

### DIFF
--- a/docs/experimental-flags.md
+++ b/docs/experimental-flags.md
@@ -59,6 +59,27 @@ zero-overhead-when-off timing helper wired into `resolveForcing` (per-pass wall-
 counts, and a per-request total). This is the instrumentation the upcoming cross-request
 memoization experiment needs.
 
+## `diag.baseBindTiming` — base-resolve profiler
+
+`diag.baseBindTiming` profiles the **base resolve** (`filterAndResolve` / `resolveAll` — the pass
+that runs *before* any forcing), gating
+[`BaseBindProfiler`](../krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/BaseBindProfiler.kt).
+It exists to answer the issue-#10 question of whether the base-bind cost at broad Clang/LLVM scale
+is uniform-breadth (O(n)) or a hotspot/superlinear (O(n²)) — and because that run can time out, it
+emits **streaming** progress so a partial run still yields a profile:
+
+- every 100 resolved types (or 3 s), a `basebind: resolved=… elapsed=… inst=…/s cum=…/s walks=…
+  nodes=…` line — a decaying instantaneous rate is the O(n²) fingerprint;
+- a running **top-N slowest types** (names the pathological types, if any);
+- **tree-walk counters** — every `ParsedResolver.resolve`/`resolveTemplate` does a full-TU
+  `filterRecursive` walk, so `walks`/`nodes` expose the O(distinct-types × tree-size) cost directly;
+- INCLUDE_MISSING on-demand materialization + re-entry counts.
+
+`BaseBindProfiler.report()` (after `resolveAll` returns) dumps the final distribution. **Inert +
+byte-identical when off** (every method early-returns; the profiler is measurement-only and never
+changes what gets bound). Run it e.g. with
+`krapper_gen … --referencePolicy INCLUDE_MISSING -X diag.baseBindTiming`.
+
 ## Candidates to migrate later (NOT done here — kept out of scope)
 
 These pre-existing ad-hoc toggles could later move into the registry for consistency:

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/BaseBindProfiler.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/BaseBindProfiler.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator
+
+import com.monkopedia.krapper.generator.Utils.printerrln
+import kotlin.time.TimeSource
+
+/**
+ * Process-scoped, off-by-default profiler for the BASE resolve (`filterAndResolve` / `resolveAll`
+ * — the pass that runs BEFORE any forcing). Gated by the `diag.baseBindTiming` experimental flag
+ * ([ExperimentalFlags.DIAG_BASE_BIND_TIMING]); when the flag is OFF, every method here is an inert
+ * early-return, so a normal run is byte-identical to one with no profiler wired in at all
+ * (measurement only — the profiler never changes what gets bound).
+ *
+ * It answers the issue-#10 question the base bind poses: is the ~240 s base-resolve cost
+ *   (a) UNIFORM-BREADTH — ~N classes each costing ~constant time, a steady classes/sec rate; the
+ *       lever is bounding the surface; or
+ *   (b) a HOTSPOT / SUPERLINEAR — a decaying rate (O(n²)) or a few pathological heavily-templated
+ *       types dominating; the lever is fixing that hotspot.
+ *
+ * To be useful even when the run TIMES OUT before completing, it emits STREAMING progress:
+ *  - every [PROGRESS_EVERY] resolved types (or [PROGRESS_INTERVAL_MS] wall-clock, whichever first)
+ *    it logs cumulative count, elapsed, instantaneous rate (classes/sec over the last window) and
+ *    cumulative rate — a decaying instantaneous rate is the O(n²) fingerprint;
+ *  - it keeps a running TOP-N slowest types by resolve time (so the pathological types are named);
+ *  - it counts full-TU tree walks (`ParsedResolver.resolve`/`resolveTemplate`'s `filterRecursive`)
+ *    and the nodes visited, which is the concrete O(distinct-types × tree-size) suspect;
+ *  - it counts INCLUDE_MISSING on-demand materializations and re-entries, to spot repeated work.
+ *
+ * [report] dumps the final distribution (top-N, walk counters, per-bucket rate curve).
+ */
+object BaseBindProfiler {
+    val enabled: Boolean
+        get() = ExperimentalFlags.isEnabled(ExperimentalFlags.DIAG_BASE_BIND_TIMING)
+
+    private const val PROGRESS_EVERY = 100
+    private const val PROGRESS_INTERVAL_MS = 3_000L
+    private const val TOP_N = 25
+
+    // ---- run-scoped state (reset per generation run) ----
+    private var startMark = TimeSource.Monotonic.markNow()
+    private var lastLogMark = startMark
+    private var lastLogCount = 0
+
+    // Count of times ParsedResolver.resolve produced a NEW resolution (a class actually resolved,
+    // not a memo hit) — this is the true "classes resolved" the rate is computed over.
+    private var resolvedCount = 0
+
+    // filterRecursive (full-TU walk) instrumentation — the O(n²) suspect.
+    private var treeWalks = 0
+    private var treeNodesVisited = 0L
+
+    // INCLUDE_MISSING on-demand materialization counters.
+    private var includeMaterializations = 0
+    private var includeReentries = 0
+
+    // Per-type resolve time, kept only for the top-N slowest (bounded memory): (typeString, ms),
+    // held sorted descending, capped at TOP_N.
+    private val slowest = ArrayList<Pair<String, Double>>()
+
+    // Coarse rate curve: (cumulativeCount, cumulativeElapsedMs) samples at each progress log.
+    private val rateCurve = ArrayList<Pair<Int, Double>>()
+
+    /** Reset run-scoped state at the start of each generation run (called from the init block). */
+    fun reset() {
+        if (!enabled) return
+        startMark = TimeSource.Monotonic.markNow()
+        lastLogMark = startMark
+        lastLogCount = 0
+        resolvedCount = 0
+        treeWalks = 0
+        treeNodesVisited = 0L
+        includeMaterializations = 0
+        includeReentries = 0
+        slowest.clear()
+        rateCurve.clear()
+    }
+
+    /** Announce the base resolve is starting over [totalFiltered] initially-filtered classes. */
+    fun begin(totalFiltered: Int) {
+        if (!enabled) return
+        startMark = TimeSource.Monotonic.markNow()
+        lastLogMark = startMark
+        lastLogCount = 0
+        printerrln(
+            "basebind: START — $totalFiltered filtered classes " +
+                "(transitive INCLUDE_MISSING expansion may resolve far more)"
+        )
+    }
+
+    /**
+     * Record that resolving [typeString] took [ms] and produced a genuinely-new resolution. This is
+     * the per-type distribution sample AND the tick that drives streaming progress. Call ONLY for a
+     * real resolution (not a memo hit), so the rate reflects work actually done.
+     */
+    fun recordResolved(typeString: String, ms: Double) {
+        if (!enabled) return
+        resolvedCount++
+        offerSlowest(typeString, ms)
+        maybeLogProgress()
+    }
+
+    /** One full-TU `filterRecursive` walk visiting [nodes] elements (the O(n²) suspect). */
+    fun recordTreeWalk(nodes: Int) {
+        if (!enabled) return
+        treeWalks++
+        treeNodesVisited += nodes
+    }
+
+    /** An INCLUDE_MISSING on-demand materialization of a referenced-but-unbound type. */
+    fun recordInclude(reentry: Boolean) {
+        if (!enabled) return
+        if (reentry) includeReentries++ else includeMaterializations++
+    }
+
+    private fun offerSlowest(typeString: String, ms: Double) {
+        if (slowest.size < TOP_N) {
+            slowest.add(typeString to ms)
+            slowest.sortByDescending { it.second }
+        } else if (ms > slowest.last().second) {
+            slowest[slowest.size - 1] = typeString to ms
+            slowest.sortByDescending { it.second }
+        }
+    }
+
+    private fun maybeLogProgress() {
+        val sinceLog = lastLogMark.elapsedNow().inWholeMilliseconds
+        if (resolvedCount - lastLogCount < PROGRESS_EVERY && sinceLog < PROGRESS_INTERVAL_MS) return
+        val totalMs = startMark.elapsedNow().inWholeMicroseconds / 1000.0
+        val windowCount = resolvedCount - lastLogCount
+        val windowMs = if (sinceLog > 0) sinceLog.toDouble() else 1.0
+        val instRate = windowCount * 1000.0 / windowMs
+        val cumRate = if (totalMs > 0) resolvedCount * 1000.0 / totalMs else 0.0
+        rateCurve.add(resolvedCount to totalMs)
+        printerrln(
+            "basebind: resolved=$resolvedCount elapsed=${fmt(totalMs)}ms " +
+                "inst=${fmt(instRate)}/s cum=${fmt(cumRate)}/s " +
+                "walks=$treeWalks nodes=$treeNodesVisited " +
+                "incl=$includeMaterializations reentry=$includeReentries"
+        )
+        lastLogMark = TimeSource.Monotonic.markNow()
+        lastLogCount = resolvedCount
+    }
+
+    /** Final distribution dump (call after resolveAll returns, or from a shutdown path). */
+    fun report() {
+        if (!enabled) return
+        val totalMs = startMark.elapsedNow().inWholeMicroseconds / 1000.0
+        val cumRate = if (totalMs > 0) resolvedCount * 1000.0 / totalMs else 0.0
+        printerrln("basebind: ===== REPORT =====")
+        printerrln(
+            "basebind: resolved=$resolvedCount total=${fmt(totalMs)}ms avgRate=${fmt(cumRate)}/s " +
+                "avgPerType=${fmt(if (resolvedCount > 0) totalMs / resolvedCount else 0.0)}ms"
+        )
+        printerrln(
+            "basebind: treeWalks=$treeWalks nodesVisited=$treeNodesVisited " +
+                "avgNodesPerWalk=${fmt(
+                    if (treeWalks > 0) treeNodesVisited.toDouble() / treeWalks else 0.0
+                )}"
+        )
+        printerrln(
+            "basebind: includeMaterializations=$includeMaterializations reentries=$includeReentries"
+        )
+        val topSum = slowest.sumOf { it.second }
+        // NB: no literal '%' — printerrln passes the string straight to fprintf as a FORMAT
+        // string, so a '%' would be interpreted as a conversion. Report the fraction as "pct".
+        printerrln(
+            "basebind: top-$TOP_N slowest sum=${fmt(topSum)}ms " +
+                "(${fmt(if (totalMs > 0) topSum * 100 / totalMs else 0.0)} pct of total):"
+        )
+        slowest.forEachIndexed { i, (name, ms) ->
+            printerrln("basebind:   #${i + 1} ${fmt(ms)}ms  $name")
+        }
+        printerrln("basebind: rate curve (count @ elapsedMs):")
+        rateCurve.forEach { (count, ms) -> printerrln("basebind:   $count @ ${fmt(ms)}ms") }
+        printerrln("basebind: ==================")
+    }
+
+    private fun fmt(v: Double): String {
+        val scaled = (v * 100).toLong()
+        return "${scaled / 100}.${(scaled % 100).toString().padStart(2, '0')}"
+    }
+}

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/ExperimentalFlags.kt
@@ -86,9 +86,23 @@ object ExperimentalFlags {
         description = "Log per-phase wall-clock timings (ms) + counts to stderr."
     )
 
+    // Profile the BASE resolve (filterAndResolve / resolveAll — the pass that runs BEFORE any
+    // forcing). Emits STREAMING progress (cumulative classes resolved, elapsed, classes/sec) so a
+    // run that times out still yields a profile, plus a per-type resolve-time distribution: a
+    // running top-N of the slowest types and the full-tree-walk (`filterRecursive`) counters that
+    // reveal whether the cost is uniform-breadth O(n) or a superlinear O(n²) tree-walk hotspot. Off
+    // by default and byte-identical when off (measurement only — never changes what gets bound).
+    val DIAG_BASE_BIND_TIMING = ExperimentalFlag.BoolFlag(
+        "diag.baseBindTiming",
+        default = false,
+        description = "Profile the base resolve: streaming classes/sec progress + per-type " +
+            "slowest-N distribution + tree-walk counters (O(n) vs O(n²) diagnosis)."
+    )
+
     /** Every declared flag. Add new flags here. */
     val all: List<ExperimentalFlag<*>> = listOf(
-        DIAG_TIMING
+        DIAG_TIMING,
+        DIAG_BASE_BIND_TIMING
     )
 
     private val byName: Map<String, ExperimentalFlag<*>> = all.associateBy { it.name }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/IndexedServiceImpl.kt
@@ -104,6 +104,9 @@ class IndexedServiceImpl(private val config: KrapperConfig, private val request:
         // (e.g. in writeTo) would be too late.
         DropLedger.reset()
         GenerationContext.reset(config.rootPackage, config.noRtti)
+        // Process-scoped base-resolve profiler (off by default, byte-identical when off). Reset per
+        // run so a partial/timed-out run's counters don't leak into a later in-process run.
+        BaseBindProfiler.reset()
     }
 
     override suspend fun filterAndResolve(filter: FilterDefinition) {

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -425,9 +425,12 @@ class ParsedResolver(val tu: WrappedTU) : Resolver {
 
     override fun resolveTemplate(type: WrappedType, context: ResolveContext): WrappedTemplate =
         templateMap.getOrPut(type.toString()) {
+            var walkedNodes = 0
             val templateCandidates = tu.filterRecursive {
+                if (BaseBindProfiler.enabled) walkedNodes++
                 ((it as? WrappedTemplate)?.qualified == type.toString())
             }
+            BaseBindProfiler.recordTreeWalk(walkedNodes)
             templateCandidates.singleOrNull() as? WrappedTemplate
                 ?: error("Can't resolve template $type (${type::class.simpleName})")
         }
@@ -436,27 +439,47 @@ class ParsedResolver(val tu: WrappedTU) : Resolver {
         type: WrappedType,
         context: ResolveContext
     ): Pair<ResolvedClass, WrappedClass>? {
-        return classMap.getOrPut(type.toString()) {
-            val existingClass = tu.filterRecursive {
-                (it as? WrappedClass)?.type?.toString() == type.toString() &&
-                    it.isNotEmpty()
-            }.singleOrNull() as? WrappedClass
-            existingClass?.let { cls ->
-                return@getOrPut cls.resolve(context)?.let { it to cls }
+        val key = type.toString()
+        // When the profiler is OFF this is exactly the original `classMap.getOrPut(key) { ... }`.
+        // When ON, a memo HIT returns early (no timing — no work done); only a genuine MISS is
+        // timed + recorded, so the rate reflects real per-type resolve work, not memo lookups.
+        if (!BaseBindProfiler.enabled) {
+            return classMap.getOrPut(key) { computeResolve(type, key, context) }
+        }
+        classMap[key]?.let { return it }
+        val resolveMark = kotlin.time.TimeSource.Monotonic.markNow()
+        val result = classMap.getOrPut(key) { computeResolve(type, key, context) }
+        BaseBindProfiler.recordResolved(key, resolveMark.elapsedNow().inWholeMicroseconds / 1000.0)
+        return result
+    }
+
+    private suspend fun computeResolve(
+        type: WrappedType,
+        key: String,
+        context: ResolveContext
+    ): Pair<ResolvedClass, WrappedClass>? {
+        var walkedNodes = 0
+        val existingClass = tu.filterRecursive {
+            if (BaseBindProfiler.enabled) walkedNodes++
+            (it as? WrappedClass)?.type?.toString() == key &&
+                it.isNotEmpty()
+        }.singleOrNull() as? WrappedClass
+        BaseBindProfiler.recordTreeWalk(walkedNodes)
+        existingClass?.let { cls ->
+            return cls.resolve(context)?.let { it to cls }
+        }
+        return when (type) {
+            is WrappedTemplateType -> {
+                val template = resolveTemplate(type.baseType, context)
+                template.typedAs(type, context)
             }
-            when (type) {
-                is WrappedTemplateType -> {
-                    val template = resolveTemplate(type.baseType, context)
-                    template.typedAs(type, context)
-                }
 
-                is WrappedTemplateRef -> {
-                    throw IllegalArgumentException("Can't resolve $type since it is templated")
-                }
+            is WrappedTemplateRef -> {
+                throw IllegalArgumentException("Can't resolve $type since it is templated")
+            }
 
-                else -> {
-                    error("Can't resolve $type (${type::class.simpleName})")
-                }
+            else -> {
+                error("Can't resolve $type (${type::class.simpleName})")
             }
         }
     }

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Resolver.kt
@@ -132,6 +132,7 @@ suspend fun List<WrappedElement>.resolveAll(
         )
         .withClasses(classes)
         .withPolicy(policy)
+    BaseBindProfiler.begin(classes.size)
     classes.forEach {
         if (resolveContext.resolve(it.type) == null) {
             DropLedger.record(
@@ -142,6 +143,7 @@ suspend fun List<WrappedElement>.resolveAll(
             Log.w("Warning: can't resolve filtered class ${it.type}")
         }
     }
+    BaseBindProfiler.report()
     val methods = filterIsInstance<WrappedMethod>().mapNotNull { method ->
         (method.parent as? WrappedNamespace)?.let { nm ->
             method.resolve(resolveContext + nm)
@@ -743,8 +745,10 @@ private fun typeMapper(policy: ReferencePolicy): TypeMapping {
                         // class isn't deduped and resolution descends until the native
                         // stack overflows.
                         if (context.tracker.otherResolved.contains(it.toString())) {
+                            BaseBindProfiler.recordInclude(reentry = true)
                             return@operateOn ElementUnchanged
                         }
+                        BaseBindProfiler.recordInclude(reentry = false)
                         context.tracker.otherResolved.add(it.toString())
                         try {
                             // Reference expansion: keep the legacy hard-fail when a


### PR DESCRIPTION
## What

Adds a `diag.baseBindTiming` experimental flag + `BaseBindProfiler` that profiles the **base resolve** (`filterAndResolve` / `resolveAll` — the pass that runs *before* any forcing). Instrumentation only; no fix. This answers the open issue-#10 question: is the base-bind cost **uniform-breadth O(n)** or a **hotspot/superlinear O(n²)**?

## Where it is wired

- `ExperimentalFlags.kt` — the `diag.baseBindTiming` bool flag (off by default).
- `BaseBindProfiler.kt` (new) — process-scoped, gated, streaming profiler.
- `Resolver.kt` — `resolveAll` calls `begin()`/`report()`; the INCLUDE_MISSING `typeMapper` branch records on-demand materializations/re-entries.
- `Parsing.kt` — `ParsedResolver.resolve`/`resolveTemplate` time each genuine (non-memoized) resolution and count the full-TU `filterRecursive` walk + nodes visited. `resolve` refactored to extract `computeResolve` (the original `getOrPut` body); the OFF path is the exact original `classMap.getOrPut(key) { computeResolve(...) }`.
- `IndexedServiceImpl.kt` — `BaseBindProfiler.reset()` in the per-run init block (no cross-run leak).

Because the broad run can time out, the profiler **streams**: every 100 resolved types / 3 s it logs cumulative count, elapsed, instantaneous + cumulative classes/sec; keeps a running top-N slowest types; and reports the tree-walk counters.

## Byte-identical when off

Every profiler method early-returns when the flag is unset; the resolve path with the flag off is the exact original `getOrPut`. Measurement-only — it never changes what gets bound. Verified with release binaries over the `samples/minimal` fixture: generated output is **byte-identical** flag-off vs a pristine-main binary, and flag-on vs flag-off (the only delta is the `-o` output-dir path baked into the `.def`, an artifact of writing to two different dirs).

## Gates

- `:krapper_gen:ktlintCheck` — green.
- `:krapper_gen:nativeTest` (incl. DeterminismTest) — green.
- `:krapper_gen:compileKotlinNative` — green.
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` — **fails with exit 134 (SIGABRT) in `kplusplusSync`, but this is PRE-EXISTING and environmental: it reproduces identically on pristine `main` HEAD with all of this PR's changes stashed.** Not a regression from this instrumentation.

## PROFILE RESULTS (the deliverable)

Reproduced the broad base-bind by running the release binary directly over the full Clang slice base model (`clangwalk/build/krapped-cpp/cpp-models/base_model.json`, 13 MB), `--referencePolicy INCLUDE_MISSING` + DefaultFilter (Scenario A, worst case), `-X diag.baseBindTiming`.

**Headline: the base bind COMPLETES (it no longer hangs indefinitely) — `resolveAll` returned at ~308.6 s having resolved 1597 classes.** So the "~240 s timeout" is really "~309 s of genuine work that finishes."

```
basebind: START — 2228 filtered classes
basebind: ===== REPORT =====
basebind: resolved=1597 total=308591.20ms avgRate=5.17/s avgPerType=193.23ms
basebind: treeWalks=17371 nodesVisited=1269915444 avgNodesPerWalk=73105.48
basebind: includeMaterializations=8938 reentries=0
basebind: top-25 slowest sum=91088.70ms (29.5 pct of total)
```

### Verdict: BOTH, but dominated by (a)-uniform-breadth with a specific O(n²) mechanism — plus ONE (b) pathological outlier

**1. The cost is a full-TU tree walk done ~11× per class.** `ParsedResolver.resolve`/`resolveTemplate` resolve each distinct type by calling `filterRecursive` — which walks the **entire ~73k-node TU with no short-circuit**, every time. Over the run: **17,371 walks × ~73,105 nodes = 1.27 BILLION node visits.** That is `O(distinct-types × tree-size)` — the concrete superlinear mechanism. avgPerType ≈ 193 ms is almost entirely these ~11 whole-tree scans per class.

**2. The rate is otherwise ~constant (~5 classes/s), i.e. uniform-breadth.** The rate curve is near-linear: 500 @ ~95 s, 1000 @ ~193 s, 1585 @ ~308 s. No runaway decay → the per-class cost is a roughly-fixed ~11 whole-tree walks, so total scales ~O(classes × tree-size). The top-25 slowest types account for only ~30 pct of total; the other ~70 pct is spread uniformly across the 1597 classes. This is breadth, not a single villain.

**3. One genuine outlier.** `clang::ObjCProtocolQualifiers<clang::ObjCObjectType>` alone took **43.3 s** (14 pct of the whole run) — a single template resolution cascading into a deep chain of full-TU walks. The rest of the top-25 are 1.7–2.6 s each (`llvm::ArrayRef<...>`, `llvm::MutableArrayRef<...>`, `std::map<...>`, `std::vector<...>` template specializations — each triggering its own tree walk per template arg).

`includeMaterializations=8938, reentries=0` — the INCLUDE_MISSING transitive expansion pulls in ~9k referenced types (2228 filtered → 1597 resolved + transitive), and the cycle-guard never re-enters, so there is **no redundant re-resolution of the same type** (`classMap`/`templateMap` memoize correctly). The waste is not re-resolution; it is that *each* first resolution re-scans the whole tree.

### Recommended lever (NOT implemented here)

**Fix the O(n²) tree-walk hotspot — build an index once, not a full-TU `filterRecursive` per type.** `ParsedResolver` should pre-build a `Map<type-string, WrappedClass>` and `Map<qualified, WrappedTemplate>` from a **single** `forEachRecursive` pass over the TU, then have `resolve`/`resolveTemplate` do an O(1) map lookup instead of an O(tree) `filterRecursive` scan. That converts the base bind from `O(distinct-types × tree-size)` to `O(tree-size + distinct-types)` — collapsing ~1.27 B node visits to ~73 k, and should take the ~309 s base bind to seconds. It is a pure-speedup, output-preserving change (same class/template selected — `singleOrNull()` semantics preserved by keying on the same strings), independent of and complementary to the forcing-loop levers in `docs/design/broad-forcing-resolve.md`.

Secondary: the `ObjCProtocolQualifiers` 43 s outlier is worth a separate look once the index lands (it may be a template-arg resolution fan-out that the index also mostly fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)