### PR TITLE
fix(plugin): don't hard-crash IDE import when :krapper_parse is LLVM-gated out

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -74,10 +74,21 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             // ANY module flipped to cpp now self-wires the front-end build generically.
             // resolveKrapperParse covers BOTH the sibling layout (featuregen/cppfixture) and
             // the included-build layout (the standalone v8 example, where krapper_parse lives in
-            // the kplusplus build pulled in via includeBuild) — its link task is null when
-            // clang isn't enabled, in which case the doLast fails fast with the -PenableClang
-            // guidance.
-            if (target.findProperty("kpp.frontend.${target.name}") == "cpp") {
+            // the kplusplus build pulled in via includeBuild).
+            //
+            // The dependsOn is gated on `clangEnabled` — the SAME -PenableClang/-PllvmConfig
+            // signal that gates :krapper_parse into the build (settings.gradle.kts). This is
+            // load-bearing for the included-build layout: `IncludedBuild.task(":krapper_parse:…")`
+            // returns a LAZY reference that does NOT validate the project exists, so when the
+            // module is on the cpp front-end but clang is NOT enabled (e.g. an IntelliJ Gradle
+            // sync, which passes no -PenableClang), resolveKrapperParse hands back a dangling
+            // task ref into the included :kplusplus build — where :krapper_parse was never
+            // include()d — and Gradle hard-fails at graph resolution ("Project with path
+            // ':krapper_parse' not found in build ':kplusplus'"), aborting the ENTIRE IDE import.
+            // Skipping the dependsOn when clang is off keeps CONFIGURATION clean; the LLVM
+            // requirement is deferred to EXECUTION, where the doLast fails fast with the
+            // -PenableClang guidance (runKrapperParseSync / the missing-binary check below).
+            if (target.findProperty("kpp.frontend.${target.name}") == "cpp" && clangEnabled(target)) {
                 resolveKrapperParse(target).first?.let { ct -> it.dependsOn(ct) }
             }
             val krappedDir = krappedDirFor(target)
@@ -666,6 +677,22 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         } catch (_: Exception) {
             null
         }
+    }
+
+    /**
+     * Whether the LLVM/Clang-gated modules (:krapper_parse et al.) are enabled for this build.
+     * Mirrors the gate in the root `settings.gradle.kts` EXACTLY: `-PenableClang` (any value but
+     * "false") OR `-PllvmConfig=<path>` (its mere presence opts in). Gradle propagates `-P`
+     * project properties across the composite, so this reads true in the consumer build (v8)
+     * precisely when :krapper_parse was actually include()d into the pulled-in kplusplus build.
+     * Used to skip the :krapper_parse dependsOn when the module is null — otherwise the lazy,
+     * non-validating included-build task ref dangles and hard-fails graph resolution during an
+     * IDE sync (see the dependsOn site).
+     */
+    private fun clangEnabled(target: Project): Boolean {
+        val enableClang = target.findProperty("enableClang")
+        val llvmConfig = target.findProperty("llvmConfig")
+        return (enableClang != null && enableClang != "false") || llvmConfig != null
     }
 
     /**


### PR DESCRIPTION
## Root cause
A cpp-front-end module (`kpp.frontend.<module>=cpp`, e.g. `samples/v8`) wires its `:kplusplusSync` onto `:krapper_parse`'s link task. But `:krapper_parse` is **LLVM-gated**: the root `settings.gradle.kts` only `include()`s it under `-PenableClang`/`-PllvmConfig`.

In the **composite/included-build layout** (v8 pulls kplusplus in via `includeBuild("../../")`), `IncludedBuild.task(":krapper_parse:...")` returns a **lazy reference that does not validate the project exists**. So an IntelliJ Gradle sync — which passes no `-PenableClang` — got a dangling task ref into the included `:kplusplus` build where `:krapper_parse` was never included, and Gradle hard-failed at **graph resolution / model-fetch time**:

```
Could not determine the dependencies of task ':kplusplusSync'.
> Project with path ':krapper_parse' not found in build ':kplusplus'.
```

That aborts the **entire IDE import**, not just the one task. The pre-existing `isDirectory` guard in `resolveKrapperParse` doesn't fire here: the `krapper_parse/` directory exists on disk in the root build regardless of whether the project was `include()`d, so the guard passes and the dangling ref is still returned.

## The fix (guard Option B)
Gate the `:krapper_parse` `dependsOn` on the **same `-PenableClang`/`-PllvmConfig` signal that gates `:krapper_parse` into the build** — a new `clangEnabled()` helper that mirrors `settings.gradle.kts` exactly (`-P` properties propagate across the composite, so the consumer build sees the flag precisely when `:krapper_parse` was actually `include()`d). When clang is off, skip the `dependsOn` so **configuration succeeds** (the IDE loads the model). The LLVM requirement is **deferred to execution**, where `runKrapperParseSync` fails fast with the existing actionable "build with `-PenableClang`" message if the `krapper_parse` binary is genuinely absent.

Chose Option B over Option A (null-out the dangling ref) because the property gate uses the *exact* condition that governs inclusion — the two can never disagree — and it sidesteps fragile "does this lazy task ref dangle?" detection.

## Before / after (config-only, from `samples/v8`, no `-PenableClang`)
Before (on `main`): `./gradlew :kplusplusSync --dry-run` → **BUILD FAILED**, `Project with path ':krapper_parse' not found in build ':kplusplus'`.

After: `:kplusplusSync --dry-run`, `tasks`, and `help` all **BUILD SUCCESSFUL** — `:krapper_parse` correctly absent from the graph. This is the IDE-import-equivalent.

## Non-regression (WITH the flag — unchanged)
- v8 `:kplusplusSync --dry-run -PenableClang`: `:kplusplus:krapper_parse:linkReleaseExecutableKlinker` is in the graph — real dependency still wired.
- sibling featuregen cpp path `:featuregen:kplusplusSync --dry-run -PenableClang -Pkpp.frontend.featuregen=cpp`: `:krapper_parse:linkReleaseExecutableKlinker` in the graph — unchanged.

## Deferred requirement intact
Running `:kplusplusSync` without LLVM and without a prebuilt binary now fails at **execution** (not config) with the actionable message: `kplusplusSync[v8]: -Pkpp.frontend.v8=cpp but the krapper_parse binary was not found at ... — build with -PenableClang (or -PllvmConfig=<path>) ...`. Deferred, not lost.

## Validation
- `:kplusplus-compiler-gradle:compileKotlin` green.
- `:krapper_gen:nativeTest` green (sibling cpp modules unaffected).

Files touched: `compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)