### PR TITLE
perf: index the base-bind type resolution (O(n²) full-TU scan → O(1) lookup)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -423,15 +423,71 @@ class ParsedResolver(val tu: WrappedTU) : Resolver {
     private val classMap = mutableMapOf<String, Pair<ResolvedClass, WrappedClass>?>()
     private val templateMap = mutableMapOf<String, WrappedTemplate>()
 
+    // ---- Type-string index over the TU (issue #10 / PR #160 base-bind hotspot) ----
+    //
+    // `resolve`/`resolveTemplate` used to locate a class/template by re-walking the ENTIRE
+    // ~73k-node TU with `filterRecursive` on every distinct type — O(distinct-types × tree-size),
+    // measured at ~1.27 B node visits / ~309 s by the #160 profiler. These indices replace that
+    // with an O(1) map lookup keyed by the SAME strings `filterRecursive` compared against:
+    //   * classIndex:    `WrappedClass.type.toString()` -> the WrappedClass node(s) with that type
+    //   * templateIndex: `WrappedTemplate.qualified`     -> the WrappedTemplate node(s) with it
+    //
+    // BYTE-IDENTICAL contract — the index must return EXACTLY what `filterRecursive{…}.singleOrNull()`
+    // returned. Two invariants make that hold:
+    //
+    //  1. Match semantics preserved AT QUERY TIME. `filterRecursive` returned ALL matches and the
+    //     callers took `singleOrNull()` (the node iff exactly one match; null for 0 or 2+). So the
+    //     index stores a LIST per key (grouped, pre-order — same order filterRecursive produced) and
+    //     the query applies `singleOrNull()` itself. Crucially the `isNotEmpty()` predicate the class
+    //     scan ANDs in is evaluated at QUERY time on the (small) candidate list, NOT frozen at build
+    //     time: `isNotEmpty()` reflects the class's live children, and although the resolve loop can
+    //     mutate a class's children (modifyMethodsIfNeeded adds a default ctor + sizeOf/alignOf;
+    //     dropConstOverloadDuplicates / hasHiddenDelete remove members), evaluating it lazily makes
+    //     the index observe the exact same value the live `filterRecursive` scan would have. (In
+    //     practice the synthetic additions are excluded by `calculateNotEmpty`, so emptiness is
+    //     stable, but querying live keeps us correct without relying on that.)
+    //
+    //  2. The indexed node SET is FIXED for the resolver's lifetime, so a one-time build is complete.
+    //     No WrappedClass or WrappedTemplate is ever ADDED to `tu` during resolution: INCLUDE_MISSING
+    //     materializations (`typedAs`) build a DETACHED WrappedClass stored only in classMap/tracker
+    //     (never `tu.addChild`-ed), and the only in-tree mutations are non-Class/non-Template members
+    //     (ctor/sizeOf/alignOf) and the pre-resolution rewrites that all run BEFORE the first query.
+    //     The key strings (`type`/`qualified`) derive from the parent chain, which is likewise stable
+    //     once resolution starts (the forcing first-seen reorder runs during loadForcingModel, before
+    //     resolve). So building once (lazily, on first query) captures every node any scan could match.
+    //
+    // Built lazily on first use (after findClasses / the pre-resolution rewrites have run) in ONE
+    // `forEachRecursive` pass: ~1.27 B node visits collapse to a single ~73k-node walk.
+    private var indexBuilt = false
+    private val classIndex = mutableMapOf<String, MutableList<WrappedClass>>()
+    private val templateIndex = mutableMapOf<String, MutableList<WrappedTemplate>>()
+
+    private fun ensureIndex() {
+        if (indexBuilt) return
+        var walkedNodes = 0
+        tu.forEachRecursive { element ->
+            if (BaseBindProfiler.enabled) walkedNodes++
+            when (element) {
+                is WrappedClass ->
+                    classIndex.getOrPut(element.type.toString()) { mutableListOf() }.add(element)
+
+                is WrappedTemplate ->
+                    templateIndex.getOrPut(element.qualified) { mutableListOf() }.add(element)
+
+                else -> {}
+            }
+        }
+        // One build pass instead of one whole-TU walk per distinct type — the whole point of #10.
+        BaseBindProfiler.recordTreeWalk(walkedNodes)
+        indexBuilt = true
+    }
+
     override fun resolveTemplate(type: WrappedType, context: ResolveContext): WrappedTemplate =
         templateMap.getOrPut(type.toString()) {
-            var walkedNodes = 0
-            val templateCandidates = tu.filterRecursive {
-                if (BaseBindProfiler.enabled) walkedNodes++
-                ((it as? WrappedTemplate)?.qualified == type.toString())
-            }
-            BaseBindProfiler.recordTreeWalk(walkedNodes)
-            templateCandidates.singleOrNull() as? WrappedTemplate
+            ensureIndex()
+            // Mirror `filterRecursive { qualified == key }.singleOrNull()`: the single template
+            // with this qualified name, or fail (0 or 2+ candidates -> singleOrNull() == null).
+            templateIndex[type.toString()]?.singleOrNull()
                 ?: error("Can't resolve template $type (${type::class.simpleName})")
         }
 
@@ -458,13 +514,13 @@ class ParsedResolver(val tu: WrappedTU) : Resolver {
         key: String,
         context: ResolveContext
     ): Pair<ResolvedClass, WrappedClass>? {
-        var walkedNodes = 0
-        val existingClass = tu.filterRecursive {
-            if (BaseBindProfiler.enabled) walkedNodes++
-            (it as? WrappedClass)?.type?.toString() == key &&
-                it.isNotEmpty()
-        }.singleOrNull() as? WrappedClass
-        BaseBindProfiler.recordTreeWalk(walkedNodes)
+        ensureIndex()
+        // Mirror `filterRecursive { type.toString() == key && it.isNotEmpty() }.singleOrNull()`:
+        // among the classes indexed under this type-string, keep the non-empty ones (evaluated
+        // LIVE, not at index-build time — see the invariant note above) and take singleOrNull().
+        val existingClass = classIndex[key]
+            ?.filter { it.isNotEmpty() }
+            ?.singleOrNull()
         existingClass?.let { cls ->
             return cls.resolve(context)?.let { it to cls }
         }


### PR DESCRIPTION
## Root cause (issue #10, profiled by PR #160)

The base resolve (`filterAndResolve` → `resolveAll`) was the broad-scale wall. PR #160's `BaseBindProfiler` (flag `diag.baseBindTiming`) root-caused it: `ParsedResolver.resolve` / `resolveTemplate` located a class/template by calling `filterRecursive` — which walks the **entire ~73k-node TU with no index/short-circuit** — on **every distinct type**. Over a broad run that is O(distinct-types × TU-size): the #160 profiler measured **17,371 whole-TU walks × ~73k nodes = 1,269,915,444 node visits** (~1.27 B), taking **~250–309 s** to resolve 1597 classes.

## The fix — index the resolution

`ParsedResolver` now builds a lazy type-string index in ONE `forEachRecursive` pass and does an O(1) map lookup instead of a per-type full-TU scan:

- `classIndex: Map<WrappedClass.type.toString(), List<WrappedClass>>`
- `templateIndex: Map<WrappedTemplate.qualified, List<WrappedTemplate>>`

keyed on the SAME strings `filterRecursive` compared. `~1.27 B node visits → one ~72 k-node build pass.`

### Replicating `filterRecursive`'s match semantics exactly (byte-identical)

`filterRecursive` returned **ALL** matches; both call sites took `.singleOrNull()` (the node iff exactly one match; `null` for 0 or 2+). So the index stores a **list** per key (grouped in pre-order — the same order `filterRecursive` produced) and the query applies `singleOrNull()` itself. For the class path, the `isNotEmpty()` predicate that the original ANDed in is evaluated **at query time on the small candidate list, NOT frozen at index-build time** — so it observes the class's live children exactly as the live scan would (the resolve loop mutates class children via `modifyMethodsIfNeeded` / `dropConstOverloadDuplicates` / `hasHiddenDelete`; in practice the synthetic additions are excluded by `calculateNotEmpty`, but querying live keeps us correct without relying on that).

### The growing tree (INCLUDE_MISSING materializations)

The one-time build is complete because **no `WrappedClass` or `WrappedTemplate` is ever added to the TU during resolution.** The ~9 k `INCLUDE_MISSING` materializations (`typedAs`) build a **detached** `WrappedClass` stored only in `classMap`/the tracker — never `tu.addChild`-ed. The only in-tree mutations are non-Class/non-Template members (default ctor + `sizeOf`/`alignOf`), which neither match the class/template filter nor (per `calculateNotEmpty`) flip `isNotEmpty()`. The key strings derive from the parent chain, which is stable once resolution starts (the forcing first-seen reorder runs in `loadForcingModel`, before any query). So the indexed node SET is fixed for the resolver's lifetime → build once, on first query.

## Byte-identical proof (method + result)

Built the release `krapper_gen.kexe` on clean `main` (602e5d0) and on this branch, ran BOTH over identical committed model inputs, diffed the generated trees. `.def` is excluded (it embeds the `-o` output-dir path — the documented artifact); `.a` is a compiled binary that also embeds the path.

- **Scenario 1 — INCLUDE_MISSING forcing** (`bag.h` fixture, `--only Bag --only Item --instantiate std::vector<Item*>` + `--forcingModel`): file sets identical; all `.h`/`.cc`/`.kt` content identical; **source sha256 identical** (`026d19c9…`); only `.def` delta is the `-o` path.
- **Scenario 2 — IGNORE_MISSING allowlist** (full 13 MB Clang-slice `base_model.json`, the 18-class clangwalk allowlist, 3 `std::vector<clang::…*>` forcings): file sets identical; all content identical; **source sha256 identical** (`68316e9c…`); only `.def` delta is the `-o` path.
- **Broad DefaultFilter + INCLUDE_MISSING** (below): the emitted `clangwalk.cc` and `clangwalk.h` are **byte-identical between main and branch** as well.

## Profiler before/after (`diag.baseBindTiming`, full Clang-slice base model, DefaultFilter + INCLUDE_MISSING)

| metric | main (before) | branch (after) |
|---|---|---|
| tree walks | 17,371 | **1** |
| nodes visited | 1,269,915,444 | **71,882** |
| total base-bind | ~249,547 ms | **4,258 ms** |
| avg / type | 156.25 ms | **2.66 ms** |
| resolved classes | 1597 | 1597 (identical) |
| includeMaterializations | 8938 | 8938 (identical) |

~**59× wall-clock** (250 s → 4.3 s), ~**17,700× fewer node visits**. `resolved` + `includeMaterializations` are identical on both → the index changes nothing about what resolves. (The `1,269,915,444` node-visit count matches PR #160 to the byte.)

## Does the broad force now reach codegen? (the original #10 acceptance metric)

Yes. With the base-bind collapsed to ~4.3 s, the broad force (DefaultFilter + INCLUDE_MISSING over the full Clang slice) now progresses all the way to codegen and the C++ compile — which was never measurable before because the base-bind alone took ~250–309 s. Compiling the generated `clangwalk.cc` (clang++ 22, `-ferror-limit=0`) yields **1531 broad-surface C++ errors**, bucketed:

- 597 — cannot initialize a parameter with an rvalue (value/move marshalling)
- 556 — no matching function for call (overload/signature mismatch)
- 73 — no matching constructor
- 40 + 27 — class template requires template arguments (unspecialized args) / argument deduction not allowed
- 35 — invalid operands to binary expression
- 27 — cannot form pointer to deduced class-template specialization
- ~50 — deleted / implicitly-deleted ctor / copy-assign families
- tail — undeclared identifiers, abstract-class allocation, const placement-new, address-of-temporary, …

This is the first time issue #10's broad-surface error count has been measurable; it's the follow-up work surface, not a regression from this PR.

## Gates

- `:krapper_gen:ktlintCheck` — green.
- `:krapper_gen:nativeTest` — green.
- The pre-existing `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` exit-134 is environmental (published tool); inertness is instead proven by the two byte-identical diffs + the byte-identical broad `.cc`/`.h`, and both binaries hit the identical downstream exit-134.

Progresses #10. See PR #160 and `docs/design/broad-forcing-resolve.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
