### PR TITLE
fix(codegen): only emit the LLVM dyn_cast down-cast when well-formed for the base (broad-surface cluster, #10)

### DIFF
--- a/docs/campaigns/broad-error-measure.sh
+++ b/docs/campaigns/broad-error-measure.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Broad-surface codegen error measurement harness (issue #10).
+#
+# Forces the FULL transitive Clang slice under DefaultFilter + INCLUDE_MISSING (the broadest
+# case krapper_gen can be asked to bind), then compiles the generated C++ with clang++ and
+# buckets the errors. This is the "measure" half of the #10 measure-fix-remeasure loop that
+# PR #162 first made reachable (base-bind collapsed 250s -> 4.3s).
+#
+# Prerequisites (run once, on an LLVM box):
+#   export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+#   export GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx12g -XX:MaxMetaspaceSize=512m"
+#   ./gradlew :krapper_gen:linkReleaseExecutableNative -PenableClang
+#   ./gradlew :clangwalk:kplusplusSync -PenableClang   # produces the clang-slice base_model
+#
+# Usage:  docs/campaigns/broad-error-measure.sh
+# Output: prints the total error count + a per-family bucket table.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEXE="$REPO/krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe"
+CM="$REPO/clangwalk/build/krapped-cpp/cpp-models"
+HDR="$REPO/krapper_parse/include/clang_slice.h"
+OUT="${1:-/tmp/kpp10-broad-measure}"
+
+[ -x "$KEXE" ] || { echo "missing $KEXE — build it first (see header)"; exit 1; }
+[ -f "$CM/base_model.json" ] || { echo "missing $CM/base_model.json — run :clangwalk:kplusplusSync"; exit 1; }
+
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+# DefaultFilter (no --only) + INCLUDE_MISSING = the broad transitive surface. The generator
+# runs its OWN final compile and exits 134 on the remaining errors, but the .cc/.h are fully
+# written before that, which is all we need. So the non-zero exit here is EXPECTED.
+"$KEXE" \
+  --header "$HDR" \
+  --parsedModel "$CM/base_model.json" \
+  --referencePolicy INCLUDE_MISSING \
+  --compiler clang++ --std c++17 -o "$OUT" \
+  --instantiate "std::vector<clang::Decl*>" \
+  --instantiate "std::vector<clang::CXXMethodDecl*>" \
+  --instantiate "std::vector<clang::CXXBaseSpecifier*>" \
+  --forcingModel "std::vector<clang::Decl*>=$CM/KrapperForce_std_vector_clang_DeclPtr.json" \
+  --forcingModel "std::vector<clang::CXXMethodDecl*>=$CM/KrapperForce_std_vector_clang_CXXMethodDeclPtr.json" \
+  --forcingModel "std::vector<clang::CXXBaseSpecifier*>=$CM/KrapperForce_std_vector_clang_CXXBaseSpecifierPtr.json" \
+  > "$OUT/gen.log" 2>&1 || true
+
+[ -f "$OUT/clang_slice.h.cc" ] || { echo "generation produced no .cc — see $OUT/gen.log"; exit 1; }
+
+# Standalone compile with all errors surfaced (-ferror-limit=0).
+clang++ -std=c++17 -fsyntax-only -ferror-limit=0 \
+  -I"$OUT" -I"$REPO/krapper_parse/include" -I/usr/include \
+  "$OUT/clang_slice.h.cc" 2> "$OUT/errors.txt" || true
+
+E="$OUT/errors.txt"
+count() { grep -c "$1" "$E" || true; }
+echo "=== broad-surface C++ error buckets ($OUT/errors.txt) ==="
+printf '%-42s %s\n' "TOTAL"                     "$(count 'error:')"
+printf '%-42s %s\n' "rvalue-param-init"         "$(count "cannot initialize a parameter of type .* with an rvalue")"
+printf '%-42s %s\n' "no-matching-function"      "$(count 'no matching function for call')"
+printf '%-42s %s\n' "no-matching-constructor"   "$(count 'no matching constructor')"
+printf '%-42s %s\n' "requires-template-args"    "$(count 'requires template arguments')"
+printf '%-42s %s\n' "deduction-not-allowed"     "$(count 'argument deduction not allowed')"
+printf '%-42s %s\n' "invalid-binary-operands"   "$(count 'invalid operands to binary')"
+printf '%-42s %s\n' "pointer-to-deduced"        "$(count 'cannot form pointer to deduced')"
+printf '%-42s %s\n' "deleted-ctor"              "$(count 'implicitly-deleted\|call to deleted')"

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/CastTargets.kt
@@ -109,14 +109,64 @@ data class DownCastTarget(
     }
 }
 
-// True when [cls] declares a static `classof` member — the LLVM-style-RTTI signal. LLVM's
-// `dyn_cast<T>` routes the runtime check through `T::classof(const Base*)` (a discriminator
+// The static `classof` member(s) of [cls] — the LLVM-style-RTTI signal. LLVM's
+// `dyn_cast<T>` routes the runtime check through `T::classof(const Root *)` (a discriminator
 // /Kind-enum check), so such a type is castable WITHOUT C++ RTTI and, being compiled
 // `-fno-rtti`, can NOT use `dynamic_cast`. `classof` survives resolution as a STATIC method
 // (confirmed against the real Clang AST: `clang::TypeDecl::classof` et al. bind cleanly).
-private fun hasLlvmClassof(cls: ResolvedClass): Boolean =
+private fun classofMethods(cls: ResolvedClass): List<ResolvedMethod> =
     cls.children.filterIsInstance<ResolvedMethod>()
-        .any { it.methodType == MethodType.STATIC && it.name == "classof" }
+        .filter { it.methodType == MethodType.STATIC && it.name == "classof" }
+
+// True when [cls] declares a static `classof` — i.e. it participates in LLVM-style RTTI.
+private fun hasLlvmClassof(cls: ResolvedClass): Boolean = classofMethods(cls).isNotEmpty()
+
+// The LLVM-RTTI ROOT type-string(s) that [derived]'s `classof` accepts, e.g. for
+// `InheritableAttr::classof(const Attr *)` -> "clang::Attr". `dyn_cast<derived>(b)` lowers
+// to `derived::classof(const Root *)`, so the operand pointer must convert to `Root *`. We
+// read those Root types straight off the bound `classof` signature(s) (the first parameter,
+// stripped of `const`/`&`/`*`/whitespace) rather than guessing them, so the convertibility
+// gate below is exact for whatever hierarchy the model actually carries.
+private fun classofRootTypeStrings(derived: ResolvedClass): Set<String> =
+    classofMethods(derived).mapNotNullTo(mutableSetOf()) {
+        it.args.firstOrNull()?.type?.typeString?.stripToTypeName()
+    }
+
+// Strip a parameter type spelling (`const clang::Attr *`) down to the bare class type name
+// (`clang::Attr`) so it can be compared to a ResolvedClass's `type.toString()`.
+private fun String.stripToTypeName(): String =
+    replace("const", " ").replace("*", " ").replace("&", " ").replace(Regex("\\s+"), "").trim()
+
+// True when `llvm::dyn_cast<derived>(base *)` is well-formed. LLVM's cast machinery accepts
+// the operand in two ways, and we admit exactly those:
+//
+//  1. [base] is (or transitively derives from) a `classof` Root of [derived] — the plain
+//     case: `base *` up-converts to the `classof(const Root *)` parameter. This is what
+//     lets `dyn_cast<InheritableAttr>(Attr *)` work even though `Attr` itself declares no
+//     `classof` (its subclasses' `classof` takes `const Attr *`, so `Attr` IS the Root).
+//
+//  2. [base] itself declares a `classof` — it is an LLVM-RTTI node in its own right, so
+//     LLVM provides the cross-hierarchy bridge (e.g. `Decl`<->`DeclContext` via
+//     `castFromDeclContext`). This lets `dyn_cast<TagDecl>(DeclContext *)` work even though
+//     `DeclContext` is a PARALLEL base of `TagDecl`, not on the `Decl` Root chain.
+//
+// A mixin/utility ancestor satisfies NEITHER and is correctly rejected: `AttributeCommonInfo`
+// (a base OF the Root `Attr`, with no `classof` of its own), the intrusive
+// `llvm::FoldingSetBase::Node`, the CRTP `Redeclarable<T>`/`Mergeable<T>` bases of `Decl`.
+// Feeding one to `classof(const Root *)` is the "cannot initialize a parameter of type
+// 'const Root *' with an rvalue of type 'const Base *'" broad-surface compile error.
+private fun dynCastFromBaseIsWellFormed(
+    base: ResolvedClass,
+    derived: ResolvedClass,
+    lookup: (String) -> ResolvedClass?
+): Boolean {
+    if (hasLlvmClassof(base)) return true
+    val roots = classofRootTypeStrings(derived)
+    if (roots.isEmpty()) return false
+    if (base.type.toString() in roots) return true
+    // `base *` -> `Root *` is valid when Root is a (transitive, public) base of base.
+    return castTargetsFor(base, lookup).any { it.base.type.toString() in roots }
+}
 
 // True when [cls] itself declares a virtual member (method or destructor) — i.e. it has
 // its own vtable. `dynamic_cast<D*>(b)` requires the OPERAND type (the base) to be
@@ -151,7 +201,16 @@ fun downCastTargetsFor(
             it.base.type.toString() == baseTypeStr
         }
         if (!reachesBase) continue
-        val useLlvmDynCast = hasLlvmClassof(derived)
+        // Use the LLVM `classof` down-cast only when the derived declares a `classof` (the
+        // Kind-check to run) AND `llvm::dyn_cast<derived>(base *)` is actually well-formed —
+        // see `dynCastFromBaseIsWellFormed`. That guards the broad-surface break where a
+        // mixin/utility ancestor (e.g. `AttributeCommonInfo` above the Root `Attr`, the
+        // intrusive `FoldingSetBase::Node`, the CRTP `Redeclarable<T>`/`Mergeable<T>` bases
+        // of `Decl`) was fed to a `classof(const Root *)` it can't convert to. A valid base
+        // (the Root, a node between Root and derived, or an LLVM-RTTI node with its own
+        // `classof` such as `DeclContext`) still takes this RTTI-free path unchanged.
+        val useLlvmDynCast = hasLlvmClassof(derived) &&
+            dynCastFromBaseIsWellFormed(base, derived, lookup)
         // A `-fno-rtti` target library (config.noRtti) exports no `typeinfo` symbols, so the
         // generic `dynamic_cast<D*>` path below would reference a `typeinfo for D` the library
         // doesn't provide and fail to LINK (e.g. v8's TracingController / ExternalStringResource


### PR DESCRIPTION
## The cluster (issue #10 broad surface)

PR #162 made the broad DefaultFilter + INCLUDE_MISSING force over the full Clang slice reach codegen for the first time; compiling the generated C++ yielded **1531 errors**, the largest bucket being **597 "cannot initialize a parameter … with an rvalue"**. This is that cluster.

## Root cause — ONE systematic codegen pattern

The generator emits a checked down-cast helper per (base, derived) pair. When the derived declares an LLVM `classof`, it uses the RTTI-free LLVM path:

```cpp
void* clang_AttributeCommonInfo_dyncast_clang_InheritableAttr(void* p) {
    return llvm::dyn_cast_or_null<clang::InheritableAttr>(reinterpret_cast<clang::AttributeCommonInfo*>(p));
}
```

`llvm::dyn_cast<Derived>` lowers to `Derived::classof(const Root*)` — for `InheritableAttr` the Root is `clang::Attr`. But the `base` here is `clang::AttributeCommonInfo`, which is a base **of** `Attr` (a mixin above the RTTI root), so `AttributeCommonInfo*` does **not** convert to `Attr*`. The compiler reports exactly:

```
error: cannot initialize a parameter of type 'const Attr *' with an rvalue of type 'const clang::AttributeCommonInfo *'
   64 |   static inline bool doit(const From &Val) { return To::classof(&Val); }
```

Every one of the 597 followed this shape — the `base` was a mixin/utility ancestor OUTSIDE the derived's LLVM-RTTI hierarchy:

| source (base) fed to `classof(const Root*)` | count |
|---|---|
| `clang::AttributeCommonInfo` (base of Root `Attr`) | 462 |
| `llvm::FoldingSetBase::Node` (intrusive list mixin) | 68 |
| `clang::Redeclarable<T>` / `clang::Mergeable<T>` (CRTP bases of `Decl`) | ~45 |
| `clang::KeywordHelpers`, `APIntStorage`, `RefCountedBase<T>`, `ObjCProtocolQualifiers<T>`, … | rest |

`downCastTargetsFor` reached these because it inverts `castTargetsFor`, whose BFS walks **every** public base — including the mixins — and it took the LLVM path whenever the *derived* had a `classof`, without checking the *base* was a legal operand for that `classof`.

## The fix (`codegen/CastTargets.kt`)

Take the LLVM `classof` down-cast path only when `llvm::dyn_cast<Derived>(Base*)` is actually well-formed. `dynCastFromBaseIsWellFormed(base, derived)` admits exactly the two operand shapes LLVM's cast machinery accepts:

1. **`base` is (or derives from) a `classof` Root of `derived`** — read straight off the bound `classof` signature's first parameter. This keeps `dyn_cast<InheritableAttr>(Attr*)` working even though `Attr` itself declares no `classof` (it IS the Root).
2. **`base` declares its own `classof`** — an LLVM-RTTI node with its own cross-hierarchy bridge, e.g. `Decl`↔`DeclContext` via `castFromDeclContext`. This keeps `dyn_cast<TagDecl>(DeclContext*)` working even though `DeclContext` is a parallel base, not on the `Decl` Root chain.

A mixin ancestor satisfies neither and is dropped (no safe checked down-cast from an off-hierarchy ancestor exists). The generic-`dynamic_cast` path is untouched.

## Broad before/after (harness: `docs/campaigns/broad-error-measure.sh`)

| bucket | before | after |
|---|---:|---:|
| **TOTAL** | **1531** | **935** |
| **rvalue-param-init** | **597** | **1** |
| no-matching-function | 556 | 556 |
| no-matching-constructor | 73 | 73 |
| requires-template-args | 67 | 67 |
| deduction-not-allowed | 27 | 27 |
| invalid-binary-operands | 35 | 35 |
| pointer-to-deduced | 27 | 27 |
| deleted-ctor | 55 | 55 |

−596 total; the cluster goes 597 → **1**. Every other bucket is untouched (the fix is surgical). The 1 residual is a *distinct, unrelated* cause — a most-vexing-parse (`clang::TemplateArgumentListInfo item();` parsed as a function declaration), not a base-pointer init — so the 597 base-pointer cluster is effectively cleared.

Confirmed on the fixed `.cc`: `Attr_dyncast_*` = 462 kept (valid), `DeclContext_dyncast_*` = 31 kept (valid bridge), `AttributeCommonInfo_dyncast_*` = 0 and `FoldingSetBase_Node_dyncast_*` = 0 (broken dropped). No cast-helper appears in the error output anymore.

## Behavior preservation

**Verified-correct, no regression on existing bindings:**

- **clangwalk 18-class clang-slice binding (IGNORE_MISSING, the shipped stage1 binding — the one that DOES carry LLVM-`classof` types):** regenerated with a clean-main baseline kexe vs this branch → **`.cc` and `.h` byte-identical**. The valid `Attr`/`DeclContext`/`Decl`-rooted casts it emits are unchanged; the fix only removes casts that never compiled.
- **featuregen:** its model carries **zero `classof` methods** (`grep -c '"classof"'` = 0 across base + all forcing models), so `hasLlvmClassof(derived)` is always false and this code path is **provably inert** — featuregen's `dynamic_cast` down-casts are untouched.

An intermediate cut of the fix over-tightened the gate (dropped valid `DeclContext→TagDecl` / degraded `Decl→NamedDecl` to `dynamic_cast`); the byte-identical clangwalk diff is what caught it, and the final two-way `dynCastFromBaseIsWellFormed` rule restores those.

## Gates

- `:krapper_gen:nativeTest` — green.
- `:krapper_gen:ktlintCheck` — green.
- Known non-gate: the featuregen `-Pkpp.frontend.featuregen=cpp` path drives the *published* tool, not this branch's kexe, so it can't exercise the fix; inertness is proven by the byte-identical clangwalk diff + the zero-classof featuregen argument instead.

## Repeatable harness

`docs/campaigns/broad-error-measure.sh` runs the broad force → clang++ compile → bucket table (reproduces TOTAL 935 / rvalue 1). Reuse for the next #10 cluster (the 556 no-matching-function bucket is now the largest).

Progresses #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
