### PR TITLE
fix(codegen): global-scope ::new for placement-new into caller buffer (broad-surface no-matching-function cluster, #10)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/BasicSymbols.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/builders/BasicSymbols.kt
@@ -104,11 +104,20 @@ class New(private val s: Symbol, private val location: Symbol? = null) :
         get() = listOf(s)
 
     override fun build(builder: CodeStringBuilder) {
-        builder.append("new ")
         if (location != null) {
-            builder.append('(')
+            // Global-scope placement new: construct into the caller-provided buffer
+            // via ::operator new(size_t, void*). The leading `::` is load-bearing —
+            // classes that declare a class-scoped `operator new` (e.g. clang's
+            // Attr/Decl allocator news taking an ASTContext) HIDE the standard
+            // placement new, so an unqualified `new (buf) T(...)` would resolve to
+            // the allocator overload and fail to match. `::new` bypasses class-scope
+            // lookup and is identical to unqualified placement-new for every type
+            // that does not declare its own operator new.
+            builder.append("::new (")
             location.build(builder)
             builder.append(") ")
+        } else {
+            builder.append("new ")
         }
         s.build(builder)
     }

--- a/krapper_gen/src/nativeTest/kotlin/CppCodeTests.kt
+++ b/krapper_gen/src/nativeTest/kotlin/CppCodeTests.kt
@@ -50,7 +50,7 @@ class CppCodeTests {
     """.trimIndent()
     private val stdVectorStringNew = """
         void* std_vector_std_string_new(void* location) {
-            return new (location) std::vector<std::string>();
+            return ::new (location) std::vector<std::string>();
         }
     """.trimIndent()
     private val stdVectorStringDispose = """
@@ -68,7 +68,7 @@ class CppCodeTests {
     """.trimIndent()
     private val testlibOtherclassNew = """
         void* TestLib_OtherClass_new(void* location) {
-            return new (location) TestLib::OtherClass();
+            return ::new (location) TestLib::OtherClass();
         }
     """.trimIndent()
     private val testlibOtherclassDispose = """
@@ -123,23 +123,23 @@ class CppCodeTests {
     """.trimIndent()
     private val testlibTestclassNew = """
         void* TestLib_TestClass_new(void* location) {
-            return new (location) TestLib::TestClass();
+            return ::new (location) TestLib::TestClass();
         }
     """.trimIndent()
     private val testlibTestclass2New = """
         void* TestLib_TestClass_new__const_TestLib_TestClass_and(void* location, void* other) {
             const TestLib::TestClass* other_cast = reinterpret_cast<const TestLib::TestClass*>(other);
-            return new (location) TestLib::TestClass(*other_cast);
+            return ::new (location) TestLib::TestClass(*other_cast);
         }
     """.trimIndent()
     private val testlibTestclass3New = """
         void* TestLib_TestClass_new__int(void* location, int a) {
-            return new (location) TestLib::TestClass(a);
+            return ::new (location) TestLib::TestClass(a);
         }
     """.trimIndent()
     private val testlibTestclass4New = """
         void* TestLib_TestClass_new__int_double(void* location, int a, double b) {
-            return new (location) TestLib::TestClass(a, b);
+            return ::new (location) TestLib::TestClass(a, b);
         }
     """.trimIndent()
     private val testlibTestclassDispose = """
@@ -526,14 +526,14 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast - *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast - *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassMinusUnary = """
             void TestLib_TestClass_op_unary_minus(void* thiz, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator-());
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator-());
         }
     """.trimIndent()
     private val testlibTestclassPlus = """
@@ -541,14 +541,14 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast + *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast + *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassPlusUnary = """
             void TestLib_TestClass_op_unary_plus(void* thiz, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator+());
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator+());
         }
     """.trimIndent()
     private val testlibTestclassTimes = """
@@ -556,7 +556,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast * *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast * *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassDivide = """
@@ -564,7 +564,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast / *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast / *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassModulo = """
@@ -572,35 +572,35 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast % *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast % *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassPreInc = """
         void TestLib_TestClass_op_increment(void* thiz, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator++());
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator++());
         }
     """.trimIndent()
     private val testlibTestclassPostInc = """
          void TestLib_TestClass_op_post_increment(void* thiz, int dummy, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator++(dummy));
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator++(dummy));
         }
     """.trimIndent()
     private val testlibTestclassPreDec = """
         void TestLib_TestClass_op_decrement(void* thiz, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator--());
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator--());
         }
     """.trimIndent()
     private val testlibTestclassPostDec = """
         void TestLib_TestClass_op_post_decrement(void* thiz, int dummy, void* ret_value) {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator--(dummy));
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator--(dummy));
         }
     """.trimIndent()
     private val testlibTestclassEqCmp = """
@@ -608,7 +608,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast == *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast == *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassNeq = """
@@ -616,7 +616,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast != *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast != *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassLt = """
@@ -624,7 +624,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast < *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast < *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassGt = """
@@ -632,7 +632,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast > *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast > *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassLteq = """
@@ -640,7 +640,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast <= *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast <= *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassGteq = """
@@ -648,7 +648,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast >= *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast >= *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassBnot = """
@@ -662,7 +662,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c_cast = reinterpret_cast<TestLib::TestClass*>(c);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast && *c_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast && *c_cast);
         }
     """.trimIndent()
     private val testlibTestclassBor = """
@@ -670,7 +670,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast || *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast || *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassNot = """
@@ -684,7 +684,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c_cast = reinterpret_cast<TestLib::TestClass*>(c);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast & *c_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast & *c_cast);
         }
     """.trimIndent()
     private val testlibTestclassOr = """
@@ -692,7 +692,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast | *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast | *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassXor = """
@@ -700,7 +700,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast ^ *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast ^ *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassShl = """
@@ -708,7 +708,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast << *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast << *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassShr = """
@@ -716,7 +716,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             TestLib::TestClass* c2_cast = reinterpret_cast<TestLib::TestClass*>(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(*thiz_cast >> *c2_cast);
+            ::new (ret_value_cast) TestLib::TestClass(*thiz_cast >> *c2_cast);
         }
     """.trimIndent()
     private val testlibTestclassInd = """
@@ -724,7 +724,7 @@ class CppCodeTests {
             TestLib::TestClass* thiz_cast = reinterpret_cast<TestLib::TestClass*>(thiz);
             std::string c2_cast = std::string(c2);
             TestLib::TestClass* ret_value_cast = reinterpret_cast<TestLib::TestClass*>(ret_value);
-            new (ret_value_cast) TestLib::TestClass(thiz_cast->operator[](c2_cast));
+            ::new (ret_value_cast) TestLib::TestClass(thiz_cast->operator[](c2_cast));
         }
     """.trimIndent()
     private val testlibMypairTestlibOtherclassA = """


### PR DESCRIPTION
## The error pattern

The broad transitive Clang surface (`DefaultFilter + INCLUDE_MISSING`) was producing **556 "no matching function for call"** errors — of which **541 were `operator new`**:

```
/tmp/.../clang_slice.h.cc:45812:12: error: no matching function for call to 'operator new'
 45812 |     return new (location) clang::WarnUnusedResultAttr(*Ctx_cast, *CommonInfo_cast, Message_cast);
       |            ^   ~~~~~~~~~~
/usr/include/clang/AST/Attr.h:75:9: note: candidate function not viable: cannot convert argument of
     incomplete type 'void *' to 'ASTContext &' for 2nd argument
   75 |   void *operator new(size_t Bytes, ASTContext &C, ...
```

Same shape via `DeclBase.h` for `clang::Decl` subclasses (its allocator `operator new(size_t, const ASTContext&, GlobalDeclID, size_t)`).

Breakdown of the 556 by callee: **541 `operator new`**, 8 `_Construct`, 4 `__fill_a1`, 2 `swap`, 1 `kpp_to_elem_ptr`.

## Root cause

The constructor wrapper emits placement-new into a caller-provided buffer:

```cpp
return new (location) clang::WarnUnusedResultAttr(...);
```

`clang::Attr`/`clang::Decl` subclasses declare a **class-scoped `operator new`** (the ASTContext allocator new). A class-scoped `operator new` **hides** the standard placement `::operator new(size_t, void*)`, so name lookup for the unqualified `new (location) T(...)` finds only the allocator overload — which doesn't match `(size_t, void*)` — and fails. This is *one* systematic codegen pattern, not several.

## The fix

Emit **global-scope** placement new — `::new (location) T(...)` — at the two placement-into-buffer sites (constructor `DIRECT` allocation + `ARG_CAST` return-in-place). Both flow through the `New` symbol, so the fix is a one-line change in `New.build()`: when a `location` is present, prefix `::`. The leading `::` bypasses class-scope lookup and resolves to the standard `::operator new(size_t, void*)`. For any type that does *not* declare its own `operator new`, `::new (buf)` is **identical** to unqualified placement-new, so this is universally safe for construct-into-provided-buffer.

Files: `krapper_gen/.../builders/BasicSymbols.kt` (the fix) + `krapper_gen/src/nativeTest/kotlin/CppCodeTests.kt` (31 placement-new expectations updated to `::new`).

## Broad before/after (harness `docs/campaigns/broad-error-measure.sh`)

| bucket | before | after |
|---|---|---|
| **TOTAL** | **935** | **394** |
| **no-matching-function** | **556** | **15** |
| rvalue-param-init | 1 | 1 |
| no-matching-constructor | 73 | 73 |
| requires-template-args | 67 | 67 |
| deduction-not-allowed | 27 | 27 |
| invalid-binary-operands | 35 | 35 |
| pointer-to-deduced | 27 | 27 |
| deleted-ctor | 55 | 55 |

**−541 total.** Surgical: every other bucket is unchanged. The entire 541-error `operator new` sub-cluster is eliminated; the remaining 15 no-matching-function are a pre-existing tail (8 `_Construct`, 4 `__fill_a1`, 2 `swap`, 1 `kpp_to_elem_ptr` — std internal helpers) left as the next target.

## Behavior preservation

Regenerated the clangwalk clang-slice binding (`--frontend=cpp`) on clean `main` vs this branch:
- `clangwalk.h`, all `src/*.kt`, `.def`: **byte-identical**.
- `clangwalk.cc`: the ONLY diff is `new (X)` → `::new (X)` on all 164 placement sites; each `<` line maps to its `>` line by adding exactly `::` (verified mechanically — no other change). krapper_gen's own final compile of the regenerated `.cc` succeeds, so the existing binding still builds cleanly.

This is the "verified correctness improvement" case: additive `::` qualification, semantically identical on the existing surface (clang `QualType` etc. don't hide placement new). Gates: `:krapper_gen:nativeTest` green, `:krapper_gen:ktlintCheck` green, `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` green.

Progresses #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
