### PR TITLE
fix(codegen): east-const nested const-qualified pointer so ArrayRef<T*> ctors match (broad-surface cluster, #10)

### DIFF
--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedModifiedType.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedModifiedType.kt
@@ -69,7 +69,34 @@ class WrappedModifiedType(val baseType: WrappedType, val modifier: String) : Wra
     override val unconst: WrappedType
         get() = WrappedModifiedType(baseType.unconst, modifier)
 
-    override fun toString(): String = "${baseType}$modifier"
+    // A pointer/reference/array applied on top of a base type. The base renders itself,
+    // then this level's `*`/`&`/`[]` is appended.
+    //
+    // One base shape needs care: a `const`-qualified POINTER (`WrappedPrefixedType(ptr,
+    // "const")`, i.e. a `T* const` — the top-level const TypeBuilder re-applies to a pointer
+    // via maybeConst). That base renders itself WEST as `const T*`; appending this level's
+    // `*` yields `const T**`, which C++ re-parses as the DIFFERENT type
+    // pointer-to-(pointer-to-const-T) — the pointee's const wrongly migrated one level in.
+    // The intended type is pointer-to-(`T* const`), which C++ can only spell EAST as
+    // `T* const*`. So when the base is exactly a const-qualified pointer, spell that base
+    // east before appending. (A bare top-level `const T*` return/param base is never wrapped
+    // by an outer modifier, so its idiomatic west spelling is untouched — see the clangwalk
+    // slice, unchanged.) Reached e.g. by ArrayRef<T*>'s `const T* data` ctor arg with
+    // T = `IdentifierInfo*`: `const T*` -> `IdentifierInfo* const*`, matching the ArrayRef
+    // `const T *` constructor instead of failing with "no matching constructor".
+    override fun toString(): String {
+        val base = baseType
+        val baseSpelling =
+            if (base is WrappedPrefixedType &&
+                base.modifier == "const" &&
+                base.baseType.isPointer
+            ) {
+                "${base.baseType} ${base.modifier}"
+            } else {
+                base.toString()
+            }
+        return "$baseSpelling$modifier"
+    }
 }
 
 class WrappedPrefixedType(val baseType: WrappedType, val modifier: String) : WrappedType() {


### PR DESCRIPTION
## The error pattern

The broad-surface force hits **73 "no matching constructor for initialization of X"** errors; **48 are `llvm::ArrayRef<T*>`** (plus a handful of iterator/lvalue siblings at the same sites). Sample:

```
error: no matching constructor for initialization of 'llvm::ArrayRef<clang::IdentifierInfo *>'
    return ::new (location) llvm::ArrayRef<clang::IdentifierInfo*>(data_cast, length);
note: candidate not viable: no known conversion from
      'const clang::IdentifierInfo **' to 'clang::IdentifierInfo *const *' for 1st argument
```

Offending generated C++:
```cpp
const clang::IdentifierInfo** data_cast = reinterpret_cast<const clang::IdentifierInfo**>(data);
```

## Root cause

`ArrayRef<T*>`'s constructor takes `const T *data`. With `T = clang::IdentifierInfo*`, the const qualifies the **pointer T**, so `const T*` must be spelled EAST: `clang::IdentifierInfo* const*`.

In the model that argument is `WrappedModifiedType(WrappedPrefixedType(ptr, "const"), "*")` — a pointer wrapping a `T* const` (the top-level const `TypeBuilder` re-applies via `maybeConst`). `WrappedPrefixedType` renders itself WEST as `const IdentifierInfo*`; the outer pointer appends `*` → `const IdentifierInfo**`, which C++ re-parses as the **different** type pointer-to-(pointer-to-const-IdentifierInfo). The pointee's const has silently migrated one level in, matching no constructor.

## Fix

One site — `WrappedModifiedType.toString()`: when the base is exactly a const-qualified pointer, spell that base EAST (`T* const`) before appending this level's `*`/`&`/`[]`. A bare top-level `const T*` return/param is never wrapped by an outer modifier, so its idiomatic west spelling is untouched.

## Broad before → after (`docs/campaigns/broad-error-measure.sh`)

| bucket | before | after |
|---|---|---|
| **TOTAL** | **394** | **337** (−57) |
| **no-matching-constructor** | **73** | **23** (−50) |
| no-matching-function | 15 | 15 |
| requires-template-args | 67 | 67 |
| deduction-not-allowed | 27 | 27 |
| invalid-binary-operands | 35 | 35 |
| pointer-to-deduced | 27 | 27 |
| deleted-ctor | 55 | 55 |

All 48 `ArrayRef<T*>` errors gone (+ the same sites' `cannot-init-param-lvalue` 5→0 and `no-matching-member-fn` 3→1). No error class regressed (verified by normalized message-class diff). Remaining 23 no-matching-ctor are a scattered tail of ~20 distinct types (1–2 each), no dominant pattern — next targets.

## Behavior preservation

- **clangwalk stage-0 slice BYTE-IDENTICAL**: regenerated the clang-slice binding same-environment with the main-built exe vs the branch-built exe — `clangwalk.cc`, `clangwalk.h`, all `src/*.kt`, and all forcing headers identical. (A broader `const T*` rewrite was rejected in-flight precisely because it churned the slice's C boundary; the fix was narrowed to the genuinely-wrong nested case, which the slice never exercises.)
- `:krapper_gen:nativeTest` green; `:krapper_gen:ktlintCheck` + `:krapper_model:ktlintCheck` green.
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` green, **195/0** (`--rerun-tasks`, in-tree tool).

Files touched: `krapper_model/.../model/type/WrappedModifiedType.kt` (one method).

Progresses #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
