### PR TITLE
fix(codegen): trim bare defaulted STL policy template args (broad-surface std::less cluster, #10)

### DIFF
--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedTemplateType.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/type/WrappedTemplateType.kt
@@ -15,8 +15,22 @@
  */
 package com.monkopedia.krapper.generator.model.type
 
-class WrappedTemplateType(val baseType: WrappedType, val templateArgs: List<WrappedType>) :
+class WrappedTemplateType(val baseType: WrappedType, rawTemplateArgs: List<WrappedType>) :
     WrappedType() {
+
+    // A defaulted STL policy argument (comparator / hasher / equality / allocator) can reach
+    // us as a BARE class-template reference — e.g. `std::map<K, V>`'s comparator surfaces as
+    // the argument-less `std::less` rather than `std::less<K>` — because the front-end lost
+    // the default argument's own template arguments. Emitting `std::map<K, V, std::less>`
+    // fails to compile ("use of class template 'std::less' requires template arguments").
+    // A bare policy name only ever appears in this defaulted-trailing position (an explicit
+    // policy carries its args), so dropping such trailing arguments falls back to the C++
+    // default — `std::map<K, V, std::less<K>>` — which is exactly the intended type. Trimming
+    // the args list here keeps the C++ spelling (toString) and the Kotlin name mangling (which
+    // both read templateArgs) consistent. (broad-surface #10)
+    val templateArgs: List<WrappedType> = rawTemplateArgs.dropLastWhile {
+        it is WrappedTypeReference && it.name in DEFAULTED_POLICY_TEMPLATES
+    }
     override val cType: WrappedType
         get() {
             baseType.cType
@@ -61,4 +75,17 @@ class WrappedTemplateType(val baseType: WrappedType, val templateArgs: List<Wrap
         get() = error("Cannot unconst non-const templated $this")
 
     override fun toString(): String = "$baseType<${templateArgs.joinToString(", ")}>"
+
+    companion object {
+        // STL policy class templates that appear as DEFAULTED trailing container arguments.
+        // When one reaches us bare (no `<...>`), it is a dropped default we trim so C++ can
+        // re-supply it. An explicitly-spelled policy always carries its own arguments and so
+        // is a WrappedTemplateType, never a bare WrappedTypeReference — it is never trimmed.
+        private val DEFAULTED_POLICY_TEMPLATES = setOf(
+            "std::less",
+            "std::allocator",
+            "std::hash",
+            "std::equal_to"
+        )
+    }
 }


### PR DESCRIPTION
## Cluster chosen + why

The broad-surface measure on `main` sits at **337**. The single largest **systematic** cluster is `std::less requires template arguments` — **42** of the 67 `requires-template-args` lines (the rest are unrelated `argument deduction not allowed` CTAD cases). All 42 are the SAME pattern from ONE root, unlike the scattered bespoke tails (deleted-ctor is ~20 distinct one-off types; no-matching-ctor is bespoke). Size × single-root made this the clear pick.

## Error pattern

The comparator of a `std::map` reaches codegen as a BARE class-template reference `std::less` (its own `<Key>` argument was dropped by the front-end), so the emitted C++ is:

```cpp
::new (location) std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::less>();
//                                                                                          ^^^^^^^^^ no <...>
```

```
error: use of class template 'std::less' requires template arguments
```

The base model records the map's comparator argument as `{"k":"t.ref","name":"std::less"}` — the default argument's own template args were lost at parse time.

## Root cause

A DEFAULTED STL policy argument (comparator / allocator / hasher / equality) can surface as an argument-less `WrappedTypeReference` instead of `std::less<Key>`. `std::map<K, V, std::less>` is ill-formed.

## Fix

`WrappedTemplateType` trims trailing template arguments that are a bare `WrappedTypeReference` naming a known defaulted STL policy template (`std::less`, `std::allocator`, `std::hash`, `std::equal_to`). A bare policy name can ONLY be a dropped default in the trailing position — an explicitly-spelled policy always carries its own args and so is a `WrappedTemplateType`, never trimmed. Dropping it falls back to the C++ default (`std::map<K, V>` ⇒ `std::map<K, V, std::less<K>>`), the intended type. Trimming the `templateArgs` list itself (not just `toString()`) keeps the C++ spelling AND the Kotlin name mangling — both read `templateArgs` — consistent.

## Broad before/after (by bucket)

| bucket | before | after |
|---|---|---|
| **TOTAL** | **337** | **295** |
| requires-template-args | 67 | 25 |
| deduction-not-allowed | 27 | 25 |
| pointer-to-deduced | 27 | 25 |
| no-matching-constructor | 23 | 24 |
| no-matching-function | 15 | 15 |
| invalid-binary-operands | 35 | 35 |
| deleted-ctor | 55 | 55 |
| rvalue-param-init | 1 | 1 |

Net **−42**, exactly the std::less lines. No bucket regressed. `no-matching-constructor` moved 23→24 because the map now spells correctly and compiles far enough to surface ONE milder pre-existing constructor-arg issue on that same `std::map<string,string>` type (`PrebuiltModuleFiles` marshaling) that was previously masked behind the hard parse error — a strict improvement, not a new fault.

## Behavior-preservation proof

- **clangwalk clang-slice byte-identical (same-env method):** ran the clean-`main`-built kexe AND the branch-built kexe over the SAME `base_model.json` with the clangwalk `--only`/IGNORE_MISSING config; the generated `.cc`/`.h`/`src/*.kt` (83 files) are **byte-identical** — the only diff is the tmp output path echoed into the `.def`'s `compilerOpts`/`libraryPaths`. The `std::less` map type is outside clangwalk's `--only` surface, so this is the ideal broad-surface-only pattern.
- `:krapper_gen:nativeTest` green; `:krapper_model:nativeTest` green.
- `:krapper_gen:ktlintCheck` + `:krapper_model:ktlintCheck` green.
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` green (`--rerun-tasks`, full regen + build + tests).

## One cause or several / next targets

ONE root cause. Next systematic targets on the remaining 295: `deleted-ctor` (55, but a bespoke tail — 11 `Error` + scattered), `invalid-binary-operands` (35 — STL `==` instantiated on element types lacking `operator==`, a container-method-instantiation family), `deduction-not-allowed` (25 — `BumpPtrAllocatorImpl`/`time_point` CTAD-context).

Progresses #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
