### PR TITLE
release(prep): 0.3.3 — ksrpc 1.1.4 + Kotlin 2.4.10 + coroutines 1.11.0

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.monkopedia.kplusplus"
-    version = "0.3.2"
+    version = "0.3.3"
 }
 
 // Aggregate publish for the two consumer-facing JVM artifacts that live in this

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.2"
+version = "0.3.3"
 
 dependencies {
     implementation(kotlin("stdlib"))

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -928,7 +928,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         const val PLUGIN_ID = "com.monkopedia.kplusplus.compiler"
         const val PLUGIN_GROUP = "com.monkopedia.kplusplus"
         const val PLUGIN_NAME = "kplusplus-compiler-plugin"
-        const val PLUGIN_VERSION = "0.3.2"
+        const val PLUGIN_VERSION = "0.3.3"
         const val MIN_KOTLIN_VERSION = "2.3.20"
 
         // The C++ standard the cpp front-end parses (and krapper_gen compiles the wrapper)

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.2"
+version = "0.3.3"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.monkopedia.kplusplus"
-version = "0.3.2"
+version = "0.3.3"
 
 // Sign only when a key is present (CI); otherwise local publishToMavenLocal fails with "no
 // configured signatory". See compiler/gradle/build.gradle.kts for the full rationale.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.2
+version=0.3.3
 group=com.monkopedia.kplusplus
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "2.4.0"
-coroutines = "1.10.2"
+kotlin = "2.4.10"
+coroutines = "1.11.0"
 serialization = "1.10.0"
-ksrpc = "1.1.1"
+ksrpc = "1.1.4"
 clikt = "5.1.0"
 guava = "33.5.0-jre"
 ktlint-gradle = "14.0.1"

--- a/krapper_gen/build.gradle.kts
+++ b/krapper_gen/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
             all {
                 @OptIn(KotlinNativeCacheApi::class)
                 disableNativeCache(
-                    version = DisableCacheInKotlinVersion.`2_4_0`,
+                    version = DisableCacheInKotlinVersion.`2_4_10`,
                     reason = "clikt 5.1.0 duplicate-symbol with cached native libs",
                 )
             }


### PR DESCRIPTION
Fleet release-train Round 2. Preps kplusplus **0.3.3** on the now-live upstream ksrpc **1.1.4**. **PREP ONLY — not published; awaiting Jason's cut authorization.**

## Bumps (`gradle/libs.versions.toml`)
- **ksrpc 1.1.1 → 1.1.4** — shared `ksrpc` version ref covers ksrpc-core / -jni / -sockets + the ksrpc Gradle plugin.
- **Kotlin 2.4.0 → 2.4.10** and **coroutines 1.10.2 → 1.11.0** — to align with ksrpc 1.1.4.
- klinker left at 0.2.0; serialization / clikt / guava / etc. untouched (no prior-prep pattern moves them together).

## Version fields 0.3.2 → 0.3.3 (exact PR #143 pattern)
Bumped the **publish-side** fields only — the same set PR #143 bumped:
- `gradle.properties` `version`
- `compiler/build.gradle.kts`, `compiler/gradle/build.gradle.kts`, `compiler/native/build.gradle.kts`, `compiler/plugin/build.gradle.kts` (the 4 compiler modules)
- `PLUGIN_VERSION` in `KPlusPlusCompilerGradlePlugin.kt`

**Deliberately NOT bumped** (the "one release behind" self-host bootstrap): `settings.gradle.kts` pluginManagement and `samples/minimal` both **stay at 0.3.2**. The 0.3.3 build CONSUMES the prior published release's bundled tool (0.3.3 isn't published during its own build) — the sync run below confirms it pulled `krapper_parse` from `.gradle/kplusplus/tools/0.3.2/`. These flip to 0.3.3 only after 0.3.3 actually ships. This mirrors #143 exactly (which likewise did not touch those two).

## One required build-behavior fix from the Kotlin bump
`krapper_gen/build.gradle.kts`: `disableNativeCache` threshold **`2_4_0` → `2_4_10`**. `DisableCacheInKotlinVersion` is a version THRESHOLD (major/minor/patch + `compareTo`), not a static flag — the clikt 5.1.0 duplicate-symbol native-cache workaround only applies while the running Kotlin version is `<=` the given threshold. Bumping to 2.4.10 (> 2.4.0) silently re-enabled the cache and the `clikt`/`clikt-mordant` `selfAndAncestors` duplicate-symbol link error resurfaced at `:krapper_gen:linkDebugTestNative`. KGP ships a matching `2_4_10` threshold constant; bumped to it → golden tests green again. (No other module uses `disableNativeCache`.)

## Verification (JAVA 21, `-PenableClang`, LLVM 22)
- **ksrpc 1.1.4 RESOLVES from Maven Central** — dependency tree shows ksrpc-core / -api / -jni / -sockets / -compiler-plugin all at 1.1.4, no unresolved-dependency error.
- **`:krapper_model:nativeTest`** — BUILD SUCCESSFUL (green).
- **`:krapper_gen:nativeTest`** (the golden tests) — **300 tests, 0 failures / 0 errors / 0 skipped** (after the cache-threshold fix).
- **`:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp`** — **195 tests, 0 failures / 0 errors / 0 skipped**. No exit-134 this cut — the version bump shifted the published-tool path favorably; the full cpp-front-end binding + link ran clean.
- **`:krapper_parse:kplusplusSync`** (self-host sync) — BUILD SUCCESSFUL; cpp front-end regenerated **124 Kotlin files** via the bundled **0.3.2** tool (confirms the consumed-one-behind wiring).
- **`:krapper_gen:ktlintCheck` + `:krapper_model:ktlintCheck`** — green (the modules touched by this PR).

## Flags for the reviewer
- **apiCheck: NOT CONFIGURED in this repo.** There is no binary-compatibility-validator plugin, no `.api` dumps, and no `api/`/`apiCheck` task (task list confirms only `check`). So I could NOT run apiCheck and am NOT claiming ABI-clean via it — there simply is no ABI gate here. The public surface is a K/N binding generator; nothing in this PR changes it. If an ABI gate is expected, it needs to be added separately (out of scope for a deps/version prep).
- **Pre-existing ktlint failure (NOT from this PR):** `:krapper_parse:ktlintKotlinScriptCheck` fails on style violations in `krapper_parse/build.gradle.kts` (trailing-comma / chain-method-continuation / multiline-expression-wrapping). That file is **byte-identical to main** on this branch (`git diff main -- krapper_parse/build.gradle.kts` is empty) — this is the known pre-existing cppfrontend/krapper_parse ktlint debt, unrelated to the bump. Left as-is (out of scope); flagging so it's not mistaken for regression.

## Included since 0.3.2
base-bind perf (#162), IDE-import (#161), flag system (#158), profiler (#160), and the #10 broad-surface codegen cluster (#163–#166).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
