### PR TITLE
build: self-host on 0.3.3 — consumed tool bump flips bindings to context parameters

### DIFF
--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
     // The kplusplus compiler subplugin, resolved from its published mavenLocal marker
     // (R2, #128) — no includeBuild. Everything kplusplus-specific lives in the narrow
     // `kplusplus { ... }` block at the bottom of this file.
-    id("com.monkopedia.kplusplus.compiler") version "0.3.2"
+    id("com.monkopedia.kplusplus.compiler") version "0.3.3"
     id("com.monkopedia.klinker.plugin") version "0.2.0"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     // so their dev loop is still immediate; PLUGIN development happens in an example (samples/*)
     // that includeBuilds compiler. Bump this version on each release.
     plugins {
-        id("com.monkopedia.kplusplus.compiler") version "0.3.2"
+        id("com.monkopedia.kplusplus.compiler") version "0.3.3"
     }
 }
 


### PR DESCRIPTION
## What

Self-host "one release behind": bump the **consumed** kplusplus plugin `0.3.2 → 0.3.3` in the flat build's `pluginManagement`. The flat build consumes the PUBLISHED plugin (which bundles the `krapper_gen`/`krapper_parse` tool binaries), so this bump swaps the tool that regenerates the repo's own cpp-frontend bindings.

## Why this is an API-shape flip, not a trivial version bump

`v0.3.2` (the previously-consumed release) **predates PR #146** (`feat(codegen): migrate carried MemScope field to Kotlin context parameters`) — verified: `git merge-base --is-ancestor d6b36c0 v0.3.2` → NOT in v0.3.2. `0.3.3` bundles the #146 tool. So:

- **0.3.2 tool** emits the OLD `MemScope`-**receiver** shape (`fun MemScope.foo()`).
- **0.3.3 tool** emits the NEW **context-parameter** shape (`context(scope: MemScope) fun foo()`).

This bump therefore regenerates `:krapper_parse` / `:featuregen` / `:cppfixture` bindings into the context-parameter shape — the repo now self-hosts on context params.

### Before / after (same call site, `clang::ValueDecl::getType`, a by-value allocating accessor)

```kotlin
// 0.3.2 tool (pre-#146) — MemScope receiver:
inline fun MemScope.getType(): QualType { ... }

// 0.3.3 tool (this PR, regenerated) — context parameter:
inline context(scope: MemScope) fun getType(): QualType { ... }
```

Non-allocating members (`isWeak()`, `setType()`) carry no scope at all — the `allocatesScope` gating from #146 is honored. This mirrors the codegen flip #146 made in `KotlinWriter.kt` (e.g. `fun <T> MemScope.${facade.base}()` → `context(scope: MemScope) fun <T> ${facade.base}()`).

## Consuming-code fallout

**None.** PR #146 landed BOTH the codegen change AND the consuming-code migration (`ModelBuilder.kt`/`TypeBuilder.kt` now thread the ambient scope via `context(scope: MemScope)`) in the same commit on `main`. Main's hand-written consumers were already written against context params; this bump simply aligns the consumed tool with what main already expects. `:krapper_parse:compileKotlinNative` compiles clean against the regenerated context-param bindings (warnings only, no errors).

## Verification (all under `-PenableClang`, LLVM 22)

- **0.3.3 plugin + bundled tool resolve and are used** — the extracted tool runs from `~/.gradle/kplusplus/tools/**0.3.3**/krapper_parse` (0.3.3, not 0.3.2). Portal/Central fall-through resolved it (mavenLocal only had ≤0.3.2).
- `:krapper_parse:kplusplusSync` — green, 124 Kotlin files regenerated with context params; module compiles clean.
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` — **195 tests, 0 failures** (76 suites, `--rerun-tasks`).
- `:cppfixture:nativeTest -Pkpp.frontend.cppfixture=cpp` — **2 tests, 0 failures** (generic cpp-path consumer, regenerated).
- `:krapper_gen:nativeTest` — **300/0**; `:krapper_model:nativeTest` — **2/0** (LLVM-free hand-written modules, unaffected as expected).
- `:krapper_gen:ktlintCheck` — green.

### Note on `:krapper_parse:ktlintCheck`

Pre-existing failure, NOT a regression from this PR. The violations are (a) in generated `build/krapped-cpp/**` + `build/gen/klinker/**` artifacts ktlint scans, and (b) hand-written violations already present in `KrapperParse.kt`/`ModelBuilder.kt`/`TypeBuilder.kt` at the committed HEAD (unchanged by this PR — this branch touches only two `.gradle.kts` version pins, no Kotlin source). This is the known "krapper_parse has pre-existing ktlint violations, ungated cleanup item." Left as a separate cleanup.

## Files touched (2 lines)

- `settings.gradle.kts` — pluginManagement consumed pin `0.3.2 → 0.3.3`.
- `samples/minimal/build.gradle.kts` — consumed pin `0.3.2 → 0.3.3`.

Correctly LEFT unchanged: `gradle.properties` / `compiler/**` `version = "0.3.3"` (publish-side, already 0.3.3), and the `samples/v8` + `clangwalk` / `featuregen` / `cppfixture` plugin-id applications with no version (they consume the in-tree/includeBuilt compiler, not the published pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
