### PR TITLE
chore: clean up stale cppfrontend/retired-gate naming references

### DIFF
--- a/docs/design/broad-forcing-resolve.md
+++ b/docs/design/broad-forcing-resolve.md
@@ -201,9 +201,11 @@ byte-identical output on the existing gates.
 
 ## 4. Options
 
-Non-negotiable safety constraint: **byte-identical output on `:cppfrontend:featuregenParity`
-and the 17-instantiation unit gate** (this loop is load-bearing for ALL binding, not just
-the broad case).
+Non-negotiable safety constraint: **byte-identical output on the regenerate-and-diff gate**
+— regenerating featuregen's `build/krapped-cpp/` binding tree and diffing it against the
+unfiltered baseline (this loop is load-bearing for ALL binding, not just the broad case).
+(This gate replaces the retired `:cppfrontend:featuregenParity` + 17-instantiation-unit
+harness, removed in the Phase-E flip; see the "Stale gate names" note in §5.)
 
 ### Option (a) — bound the closure / rethink INCLUDE_MISSING semantics
 Make the base resolve only expand the requested surface + genuine binding-necessary
@@ -573,18 +575,18 @@ consequences:
   same gate-blindness that bit #156's pass-1 attempt. A valid alternative to accepting that
   residual risk is to run broad forcing as an **offline measurement**, not a per-build gate.
 
-- **Stale gate names (flip landed).** The safety constraint above and §5's verification plan
-  cite `:cppfrontend:featuregenParity` and "the 17-instantiation ALL unit" — **both no longer
-  exist** (the Phase-E flip removed the parity harness and that unit). The equivalent
-  machine-check used to validate PR #156 is **regenerating featuregen's `build/krapped-cpp/`
-  binding tree and diffing it** against the unfiltered baseline (byte-identical), which is
-  what was done for this change. Read the `:cppfrontend:featuregenParity` / 17-unit
-  references throughout this doc as "regenerate `build/krapped-cpp/` and diff".
+- **Retired gate names (flip landed).** Earlier drafts of this doc cited
+  `:cppfrontend:featuregenParity` and "the 17-instantiation ALL unit" as the safety gate;
+  **both no longer exist** (the Phase-E flip removed the parity harness and that unit, and
+  the `cppfrontend` module is now `krapper_parse`). The equivalent machine-check used to
+  validate PR #156 — now written throughout this doc — is **regenerating featuregen's
+  `build/krapped-cpp/` binding tree and diffing it** against the unfiltered baseline
+  (byte-identical), which is what was done for this change.
 
 ### Verification plan (how we prove no regression)
-1. **Byte-identical gates (blocking):** `:cppfrontend:featuregenParity` and the
-   17-instantiation ALL unit under `--frontend=cpp` must stay on their committed ratchet
-   ledger (zero regression). Because (c) only *skips re-resolving classes that recover
+1. **Byte-identical gate (blocking):** regenerating featuregen's `build/krapped-cpp/`
+   binding tree under `--frontend=cpp` and diffing it against the unfiltered baseline must
+   show zero regression. Because (c) only *skips re-resolving classes that recover
    nothing*, the featuregen output is unchanged by construction; the gate confirms it.
 2. **`krapper_gen :nativeTest` + featuregen sync** green (the standing determinism +
    codegen guards; per the memory discipline, re-run featuregen sync after the generator


### PR DESCRIPTION
Cleanup of stale/misleading naming left by two architecture changes: the `cppfrontend` module was renamed to `krapper_parse`, and the self-hosting flip deleted the libclang reducer and retired several gated tasks. Goal was to fix references that point at things that no longer exist **and are presented as current** — not to rewrite history, rename fixtures, or delete code for the sake of naming.

## Fixed (definitely stale)
- **`docs/design/broad-forcing-resolve.md`** — the §4 safety-constraint and §5 verification-plan sections cited `:cppfrontend:featuregenParity` and "the 17-instantiation ALL unit" as if they were current gates. Both were removed in the Phase-E flip, and the module is `krapper_parse` now. The doc's OWN later "Retired gate names" note already documents the equivalent gate (regenerate featuregen's `build/krapped-cpp/` tree + diff against baseline). Made the older sections consistent with that correction. The retired names are retained ONLY in the note that narrates them as removed (history preserved, not scrubbed).

## Investigated and deliberately left
- **`docs/clang-runbook.md` `featuregenParity`/`goldenCompare`** — the single mention (line 92) already says these "were removed in #92". Correct historical narrative, not stale-as-current. Nothing to change.
- **`goldenCompare` (verdict: already DEAD, correctly documented; surrounding code LIVE — left untouched).** The `goldenCompare()` function and its `--golden-compare` CLI mode were already deleted in #92 (it compared the old libclang-C reducer vs the cpp front-end; the reducer is gone). What remains under `krapper_parse/src/nativeMain/kotlin/GoldenCompare.kt` is `writeFile`/`readFile` posix IO helpers that are actively used across `KrapperParse.kt` (golden-emit / forcing-fixture / parity-emit modes), and the `goldenEmit` build task is a live wired gate (`dependsOn` feeding handoffGenerate). The file/task comments accurately narrate the removal. The filename `GoldenCompare.kt` is now a misnomer, but renaming a live module file to "clean up naming" would risk live code and lose the historical breadcrumb — per the conservative rule, left as-is (suspected-cosmetic-only follow-up at most).
- **`libclang` in docs (`ARCHITECTURE.md`, `README.md`, `campaigns/self-hosting.md`, `features.md`, `releasing.md`, `clang-runbook.md`, the design doc)** — all reviewed; every mention is either past-tense narrative of the removal ("used to depend on", "Replaces the old C `libclang` reducer", "migration off `libclang`") or refers to `libclang-cpp`/`libLLVM`, the LLVM C++ library that `krapper_parse` genuinely still links against (a current true fact, distinct from the removed C `libclang` reducer). None describe the deleted reducer as present. Left untouched — not scrubbing history.
- **`testlib` / `:slice`** — no references to the deleted MODULES exist anywhere (docs or build scripts). All surviving `testlib` hits are TEST FIXTURE names (`TestLib_OtherClass`, `testlibOtherclass*` in krapper_gen tests); `:slice` appears nowhere. Fixture names left alone per instruction. (Unrelated `clang_slice.h`/`libClangSlice` is the live krapper_parse C++ shim, not the deleted `:slice` module.)

## Scope
**Docs-only.** Single file changed (`docs/design/broad-forcing-resolve.md`, +15/-13). No `.kt`/`.kts` touched, so no build gate required; confirmed the doc reads correctly and consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)