### PR TITLE
feat(plugin): resolve the consumer's LLVM include path for cpp-parse (#124, #128 R4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ kplusplus {
 
     cppStandard = "c++17"             // default c++14
 
+    // Point the front-end at a non-default-path LLVM-22 install, if your `llvm-config`
+    // isn't on PATH (auto-discovered otherwise; also settable via -PllvmConfig).
+    // llvmConfig = "/usr/lib/llvm-22/bin/llvm-config"
+
     // Force template specializations you use (C++ instantiates templates at
     // compile time, so each concrete type you call needs to be requested).
     instantiate("std::vector<int>")
@@ -38,6 +42,12 @@ kplusplus {
 ```
 
 Build, and the generated Kotlin bindings are on the classpath — call your C++ API directly.
+
+New to K++, or consuming the **published** plugin from an external project? Start with the
+step-by-step [docs/getting-started.md](docs/getting-started.md) — the full external-consumer flow
+(declare the plugin from `mavenCentral()`/the Plugin Portal, the LLVM-22 prerequisite + how to
+point K++ at a non-default-path install via `llvmConfig` / `-PllvmConfig`, minimal config, build +
+run).
 
 Runnable samples live under [`samples/`](samples). Start with
 [`samples/minimal`](samples/minimal) — a tiny hand-written C++ geometry library bound and run

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -507,14 +507,6 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
     }
 
     /**
-     * Pick a C++ compiler for krapper_gen's wrapper-library step. krapper_gen
-     * generates C++ code that references some libstdc++ internals (matching
-     * what v8's own headers expose); newer host gcc / clang reject those.
-     * The konan-bundled toolchain (gcc 8.3 / glibcxx 7) accepts them. Try
-     * the konan toolchain first if present; otherwise fall back to clang++.
-     * Override via `kplusplus { compiler = "..." }`.
-     */
-    /**
      * Resolve the consumer's LLVM/Clang include dir(s) to thread into the cpp-parse as `-I`
      * (#124, #128 R4). The cpp front-end's bundled Clang finds Clang's OWN builtin headers via
      * its resource-dir (`clang++ -print-resource-dir`, resolved inside krapper_parse) and system
@@ -602,6 +594,14 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
             .map { File(it, name) }.firstOrNull { it.canExecute() }
     }
 
+    /**
+     * Pick a C++ compiler for krapper_gen's wrapper-library step. krapper_gen
+     * generates C++ code that references some libstdc++ internals (matching
+     * what v8's own headers expose); newer host gcc / clang reject those.
+     * The konan-bundled toolchain (gcc 8.3 / glibcxx 7) accepts them. Try
+     * the konan toolchain first if present; otherwise fall back to clang++.
+     * Override via `kplusplus { compiler = "..." }`.
+     */
     private fun resolveDefaultCompiler(): String {
         val konanRoot = System.getProperty("user.home") + "/.konan/dependencies"
         val konanDir = File(konanRoot)

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -130,6 +130,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 it.inputs.property("cppStandard", e.cppStandard ?: "")
                 it.inputs.property("noRtti", e.noRtti)
                 it.inputs.property("rootPackage", e.rootPackage ?: "")
+                it.inputs.property("llvmConfig", e.llvmConfig ?: "")
                 it.inputs.property("only", e.only.sorted())
                 it.inputs.property("onlyFile", e.onlyFile ?: "")
                 it.inputs.property("fixups", e.fixups.toJsonArray())
@@ -350,7 +351,14 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val modelsDir = File(krappedDir, "cpp-models").apply { mkdirs() }
         // The include dirs ride the trailing args as -I tokens; krapper_parse partitions them
         // from the type specs (which never start with -I) — see --parity-emit / parityEmit.
-        val includeFlags = includeDirs.map { "-I$it" }
+        // Prepend the consumer's LLVM include dir (#124, #128 R4): a from-published consumer
+        // whose LLVM-22 headers are NOT on the default include path (e.g. apt.llvm.org under
+        // /usr/lib/llvm-22/include) would otherwise fail to resolve <clang/AST/...>-style
+        // headers, because krapper_parse's bundled Clang only searches its resource-dir +
+        // the driver's default paths. Discovered via `llvm-config --includedir` (or the
+        // kplusplus { llvmConfig = ... } / -PllvmConfig override), mirroring settings.gradle.kts.
+        val llvmIncludeDirs = resolveLlvmIncludeDirs(target, ext)
+        val includeFlags = (llvmIncludeDirs + includeDirs).map { "-I$it" }
         fun emit(specs: List<String>): String {
             val proc = ProcessBuilder(
                 listOf(cppBinary.absolutePath, "--parity-emit", modelsDir.absolutePath, headerPath, std) +
@@ -506,6 +514,94 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
      * the konan toolchain first if present; otherwise fall back to clang++.
      * Override via `kplusplus { compiler = "..." }`.
      */
+    /**
+     * Resolve the consumer's LLVM/Clang include dir(s) to thread into the cpp-parse as `-I`
+     * (#124, #128 R4). The cpp front-end's bundled Clang finds Clang's OWN builtin headers via
+     * its resource-dir (`clang++ -print-resource-dir`, resolved inside krapper_parse) and system
+     * C++ headers via the driver's default GCC detection, but a library's OWN headers under a
+     * NON-default-path LLVM install (e.g. apt.llvm.org's /usr/lib/llvm-22/include, where
+     * <clang/AST/...> lives) are found ONLY if explicitly on the include path. In-tree this box
+     * has system LLVM-22 on the default path so no -I was needed; a from-published consumer on a
+     * versioned install has neither the settings.gradle.kts probe nor that default path — this
+     * closes that gap.
+     *
+     * Discovery order, mirroring settings.gradle.kts:
+     *   1. the `kplusplus { llvmConfig = ... }` DSL override;
+     *   2. the `-PllvmConfig=<path>` project property (the SAME opt-in settings.gradle.kts uses);
+     *   3. `llvm-config` on PATH.
+     * When an override is set but unusable, fail fast with an actionable message. When NOTHING is
+     * configured and `llvm-config` is not on PATH, return empty (the header may still be on the
+     * default path, as in-tree) rather than hard-failing — if it is not, krapper_parse's own
+     * parse error surfaces. Idempotent + additive: absent config on a default-path box adds no -I.
+     */
+    private fun resolveLlvmIncludeDirs(target: Project, ext: KPlusPlusExtension?): List<String> {
+        val llvmConfigOverride = ext?.llvmConfig?.takeIf { it.isNotBlank() }
+            ?: (target.findProperty("llvmConfig") as? String)?.takeIf { it.isNotBlank() }
+        val llvmConfigExec = resolveExecutable(llvmConfigOverride ?: "llvm-config")
+        if (llvmConfigExec == null) {
+            if (llvmConfigOverride != null) {
+                throw GradleException(
+                    "kplusplus: the configured llvm-config '$llvmConfigOverride' " +
+                        "(kplusplus { llvmConfig = ... } or -PllvmConfig=) is not an executable " +
+                        "file. Point it at your LLVM-22 install's llvm-config, e.g. " +
+                        "/usr/lib/llvm-22/bin/llvm-config."
+                )
+            }
+            // Nothing configured + none on PATH: don't hard-fail — the header may still be on
+            // the default include path (the in-tree case). Surface the override hint at info.
+            target.logger.info(
+                "kplusplus: no llvm-config on PATH and none configured; the cpp front-end will " +
+                    "rely on the default include path for library headers. If parsing fails to " +
+                    "find your LLVM/library headers, set kplusplus { llvmConfig = " +
+                    "\"/path/to/llvm-config\" } or pass -PllvmConfig=<path>."
+            )
+            return emptyList()
+        }
+        val includeDir = probeExec(llvmConfigExec, "--includedir")
+        if (includeDir.isNullOrBlank() || !File(includeDir).isDirectory) {
+            throw GradleException(
+                "kplusplus: `${llvmConfigExec.absolutePath} --includedir` returned " +
+                    "'${includeDir.orEmpty()}', which is not a directory. Is this a valid LLVM " +
+                    "install? Override with kplusplus { llvmConfig = \"...\" } or -PllvmConfig=."
+            )
+        }
+        // Additive-only guard (protects the in-tree path): a system LLVM install reports its
+        // includedir as a DEFAULT system path (e.g. /usr/include). Clang already searches those,
+        // so injecting them as an explicit `-I` adds nothing AND would reorder search precedence
+        // (user `-I` before system) — exactly the in-tree case we must not alter. Only thread the
+        // dir when it is a NON-default path (the versioned-install case #124 is about, e.g.
+        // /usr/lib/llvm-22/include).
+        val canonical = File(includeDir).canonicalPath
+        if (canonical in DEFAULT_SYSTEM_INCLUDE_DIRS) return emptyList()
+        return listOf(includeDir)
+    }
+
+    /** First line of `<exec> <arg>` stdout, trimmed; null on non-zero exit or no output. */
+    private fun probeExec(exec: File, arg: String): String? {
+        return try {
+            val proc = ProcessBuilder(exec.absolutePath, arg)
+                .redirectErrorStream(true).start()
+            val out = proc.inputStream.readBytes().toString(Charsets.UTF_8).trim()
+            if (proc.waitFor() != 0) null else out.ifEmpty { null }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Look up an executable: an absolute/relative path is taken verbatim (must be executable);
+     * a bare name is searched on PATH. Mirrors settings.gradle.kts's resolveExecutable so the
+     * consumer-side discovery matches the in-tree toolchain probe. Null when nothing is found.
+     */
+    private fun resolveExecutable(name: String): File? {
+        val direct = File(name)
+        if (direct.path.contains(File.separatorChar)) {
+            return direct.takeIf { it.canExecute() }
+        }
+        return System.getenv("PATH").orEmpty().split(File.pathSeparatorChar)
+            .map { File(it, name) }.firstOrNull { it.canExecute() }
+    }
+
     private fun resolveDefaultCompiler(): String {
         val konanRoot = System.getProperty("user.home") + "/.konan/dependencies"
         val konanDir = File(konanRoot)
@@ -935,5 +1031,12 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         // under when a module sets no kplusplus { cppStandard = ... }. Matches krapper_gen's
         // own default and the former featuregen-hardcoded cpp path.
         const val DEFAULT_CPP_STANDARD = "c++14"
+
+        // Default system include dirs a system LLVM reports as its --includedir. When
+        // llvm-config --includedir returns one of these, threading it as an explicit `-I`
+        // is a no-op that would only reorder Clang's search precedence, so it is skipped
+        // (keeps the in-tree, system-LLVM cpp path byte-for-byte unchanged). See
+        // resolveLlvmIncludeDirs.
+        val DEFAULT_SYSTEM_INCLUDE_DIRS = setOf("/usr/include", "/usr/local/include")
     }
 }

--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension.kt
@@ -92,6 +92,21 @@ open class KPlusPlusExtension {
      */
     var referencePolicy: String? = null
 
+    /**
+     * Path to the consumer's `llvm-config` (#124, #128 R4). The cpp front-end
+     * (`kpp.frontend.<module>=cpp`) parses your headers with a bundled Clang. Clang's
+     * OWN builtin headers (stddef.h etc.) are located by krapper_parse via
+     * `clang++ -print-resource-dir` on `PATH`; but a library's headers under a
+     * NON-default-path LLVM install (e.g. apt.llvm.org under `/usr/lib/llvm-22/include`,
+     * where `<clang/AST/...>` lives) are only found if explicitly on the include path.
+     * When left null the plugin auto-discovers via `llvm-config` on `PATH` (mirroring
+     * the root `settings.gradle.kts` probe) and honors `-PllvmConfig=<path>`; set this
+     * to point at a specific install's `llvm-config`, and the plugin runs
+     * `<llvmConfig> --includedir` and threads that dir into the parse as a `-I`. Takes
+     * precedence over the `-PllvmConfig` property.
+     */
+    var llvmConfig: String? = null
+
     internal val only: MutableList<String> = mutableListOf()
     internal var onlyFile: String? = null
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,114 @@
+# Getting started with K++
+
+This walks a **real external consumer** from an empty Kotlin/Native project to running Kotlin
+that calls a C++ library — using the **published** K++ plugin (no `includeBuild`, no cloning the
+K++ repo). If you want to read a finished version of exactly this, see
+[`samples/minimal`](../samples/minimal).
+
+## Prerequisites
+
+- **JDK 21** to run the Gradle build.
+- **An LLVM/Clang 22 toolchain.** K++'s front-end is self-hosted on Clang: it parses your headers
+  with a bundled Clang. `clang++` must be on `PATH` (it locates Clang's builtin headers and also
+  compiles the generated C++ wrapper). If your LLVM-22 install is *not* on the default path (e.g.
+  an apt.llvm.org install under `/usr/lib/llvm-22`), see [Pointing K++ at your LLVM](#pointing-k-at-your-llvm)
+  below.
+- A C++ library to bind (headers + a `.a`/`.so`), or just hand-write a small one as the sample does.
+
+You do **not** need to build K++ from source, and you do **not** pass `-PenableClang` in your
+consumer build — that flag only gates modules *inside* the K++ repository. The `krapper_gen` /
+`krapper_parse` tool binaries ride bundled inside the published plugin jar; the plugin extracts and
+runs them itself.
+
+## 1. Declare the plugin
+
+`settings.gradle.kts` — the plugin resolves from the Gradle Plugin Portal / Maven Central:
+
+```kotlin
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+```
+
+`build.gradle.kts`:
+
+```kotlin
+plugins {
+    kotlin("multiplatform") version "2.4.0"
+    id("com.monkopedia.kplusplus.compiler") version "0.3.3"
+}
+
+repositories {
+    mavenCentral()
+}
+```
+
+## 2. Configure the binding
+
+Add a `kplusplus { }` block pointing at the header(s) and library you want to bind:
+
+```kotlin
+kplusplus {
+    header("cpp/geometry.h")            // the header(s) to bind
+    library("build/cpplib/libgeometry.a") // the native library to link
+    cppStandard = "c++17"               // default is c++14
+    // headerDirectory("cpp/include")   // extra -I roots for your headers, if any
+    // instantiate("std::vector<int>")  // force template specializations you call
+}
+```
+
+Wire the native binary so it links against the system libstdc++ (the front-end parses against it),
+build the `.a`, and add a `main` that calls the generated API. The complete, runnable version of
+all of this is [`samples/minimal/build.gradle.kts`](../samples/minimal/build.gradle.kts) — copy it
+as your starting point.
+
+## 3. Build and run
+
+```
+./gradlew runReleaseExecutableKlinker
+```
+
+The first build is slow (it downloads the plugin + bundled tools, generates the bindings, then
+compiles and links the generated C++ wrapper); later runs are incremental.
+
+## Pointing K++ at your LLVM
+
+The cpp front-end finds Clang's own builtin headers (`stddef.h` etc.) via `clang++` on `PATH`.
+Your **library's** headers under a versioned LLVM install (e.g. `<clang/AST/...>` under
+`/usr/lib/llvm-22/include`) are on the default include search path only for a *system* install. If
+your LLVM-22 is a side-by-side / apt.llvm.org install, the plugin needs to know where its headers
+are.
+
+By default the plugin auto-discovers this by running `llvm-config --includedir` on `PATH` (the same
+probe the K++ repo's own build uses) and threads that directory into the parse. If `llvm-config`
+is not on `PATH`, or points at the wrong install, override it — in order of precedence:
+
+1. The DSL, in your `kplusplus { }` block:
+
+   ```kotlin
+   kplusplus {
+       // ...
+       llvmConfig = "/usr/lib/llvm-22/bin/llvm-config"
+   }
+   ```
+
+2. Or the project property, on the command line / in `gradle.properties`:
+
+   ```
+   ./gradlew runReleaseExecutableKlinker -PllvmConfig=/usr/lib/llvm-22/bin/llvm-config
+   ```
+
+When a configured `llvm-config` is not an executable, or does not report a valid include directory,
+the build fails immediately with a message telling you exactly what to set — rather than surfacing a
+cryptic `file not found` deep in the parse. When `llvm-config` reports a default system path (e.g.
+`/usr/include`), nothing extra is added: Clang already searches it.
+
+## See also
+
+- [`samples/minimal`](../samples/minimal) — the smallest end-to-end binding, a working copy of this guide.
+- [`samples/v8`](../samples/v8) — the heavyweight demo (binds and runs V8).
+- [README](../README.md) — the `kplusplus { }` DSL reference and `fixup { }` escape hatch.
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) — how the self-hosted front-end and generator fit together.


### PR DESCRIPTION
## The gap (#124 / #128 R4)

`krapper_parse`'s `--parity-emit` builds its Clang parse args as `-std=X`, `-resource-dir=$(clang++ -print-resource-dir)`, plus the `-I` flags the plugin passes from `kplusplus { headerDirectory(...) }`. So:

- **Clang's own builtin headers** (`stddef.h` etc.) — found via `clang++ -print-resource-dir` on `PATH`. **Robust** (already handled).
- **A library's own headers** under a **non-default-path** LLVM install (e.g. apt.llvm.org's `/usr/lib/llvm-22/include`, where `<clang/AST/...>` lives) — found **only if explicitly on the include path**. In-tree this box happens to have system LLVM-22 on the default path, so no `-I` was ever needed; `:krapper_parse` (ex-`:cppfrontend`) declares no `headerDirectory`. A from-published consumer on a versioned install has neither the `settings.gradle.kts` toolchain probe nor that default path → the parse silently drops the include.

So the gap is category (b), the consumer's/self target headers — **not** the builtin headers.

### "blocked" verdict

The `blocked` label was **pure coordination**, not a technical blocker: triage folded #124 into #128 R4 to avoid a duplicate/conflicting dispatch. R4 is exactly this work, so it is unblocked now. No Jason-level decision required; it was "unbuilt", not externally blocked.

## Design

- **Auto-discover** the LLVM include dir via `llvm-config --includedir` on `PATH` (mirrors the root `settings.gradle.kts` probe) and thread it into `krapper_parse` as a `-I`, reusing the existing `includeFlags` partition (no parallel path).
- **Override chain**: new `kplusplus { llvmConfig = "..." }` DSL knob → the existing `-PllvmConfig=<path>` project property → `llvm-config` on `PATH`.
- **Actionable failure**: a configured `llvm-config` that isn't executable, or that reports a non-directory `--includedir`, fails the build immediately with a message telling the consumer exactly what to set — instead of a cryptic `file not found` deep in the parse.
- **Additive-only guard**: when `--includedir` reports a default system path (`/usr/include`, `/usr/local/include`), nothing is added — Clang already searches those, and injecting them as an explicit `-I` would only reorder search precedence. This keeps the **in-tree system-LLVM cpp path byte-for-byte unchanged** (featuregen/cppfixture declare no `headerDirectory` and rely on the default path).

## What I verified

- `:kplusplus-compiler-gradle:compileKotlin` green; module has no ktlint task / no unit tests (NO-SOURCE).
- **The #124 gap reproduced + fixed through the actual published 0.3.3 `krapper_parse` binary.** A consumer header `#include <mylib/widget.h>` where `widget.h` lives only under a non-default dir:
  - **without `-I`** (repros #124): `fatal error: 'mylib/widget.h' file not found`, and the emitted base model is truncated (captures only the outer `Gadget`, drops `mylib::Widget`).
  - **with `-I<non-default>`** (what the plugin now threads): clean parse, model captures **both** `Gadget` and `Widget`.
- **LLVM-not-on-default-path case**: a fake versioned `llvm-config` reporting `<dir>/include` → the resolver threads `-I<dir>/include`. The real system `llvm-config --includedir` here is `/usr/include` → resolver returns **empty** (guarded) → in-tree path unaltered.
- In-tree additivity confirmed structurally: featuregen/cppfixture declare no `headerDirectory`, and the guard drops the `/usr/include` result, so their `includeFlags` are identical to before.

## Docs

`docs/getting-started.md` — the real external-consumer flow (published `0.3.3` plugin from `mavenCentral()`/Plugin Portal, LLVM-22 prerequisite, the `llvmConfig`/`-PllvmConfig` override, minimal `kplusplus { }` config, build + run), plus a README quickstart link and the `llvmConfig` knob in the DSL snippet.

## Files touched

- `compiler/gradle/.../KPlusPlusCompilerGradlePlugin.kt` — `resolveLlvmIncludeDirs` + `probeExec`/`resolveExecutable` helpers; thread the discovered dir into `runKrapperParseSync`'s `includeFlags`; up-to-date input for `llvmConfig`.
- `compiler/gradle/.../KPlusPlusExtension.kt` — `var llvmConfig`.
- `docs/getting-started.md` (new), `README.md`.

Refs #124, #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
