### PR TITLE
reduce(krapper_gen): drive operator-symbol mappers from one source-of-truth table (#17 item 7)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/KotlinWriter.kt
@@ -1777,28 +1777,12 @@ class KotlinWriter(private val pkg: String, policy: CodeGenerationPolicy = Throw
         else -> method
     }
 
-    // NB: this is the KOTLIN-name operator-symbol table. There are sibling tables on the C
-    // side (NameHandler.cleanupName, NameHandler.cleanupOperatorName) — keep them in mind if
-    // adding a symbol here; they intentionally differ (Kotlin vs C identifier rules).
-    private fun String.kotlinMethodName() = replace("<", "_lt")
-        .replace(">", "_gt")
-        .replace("\"\"", "_qts")
-        .replace("\"", "_qt")
-        .replace("()", "_call") // operator() → a plain `_call` method (not idiomatic invoke yet)
-        .replace("==", "_cmp")
-        .replace("=", "_eq")
-        .replace("+", "_plus")
-        .replace("-", "_minus")
-        .replace("/", "_div")
-        .replace("*", "_star")
-        .replace("%", "_mod")
-        .replace("!", "_not")
-        // Bitwise/logic operators from free functions (e.g. std::operator& from <memory>),
-        // which fall through the member-operator path to a plainly-named function.
-        .replace("&", "_and")
-        .replace("|", "_or")
-        .replace("^", "_xor")
-        .replace("~", "_inv")
+    // The Kotlin-name operator-symbol rewrite. The symbol set + ordering come from the
+    // shared [OPERATOR_SYMBOLS] table (via [kotlinToken]); the C-side renderer
+    // (NameHandler.cleanupOperatorName) reads the SAME table's C column, so the two
+    // intentionally-different renderings cannot drift apart. NameHandler.cleanupName is a
+    // separate general sanitizer (see the note on OPERATOR_SYMBOLS).
+    private fun String.kotlinMethodName() = replaceKotlinOperatorTokens()
         // A C++ method whose name IS a Kotlin hard keyword (`in`/`is`/`when`/`object`/…)
         // has no operator symbols to replace, so it reaches here unchanged and would emit
         // `fun in(...)` (won't parse). Back-tick-escape it (mirrors the param/field path).

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/NameHandler.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/NameHandler.kt
@@ -128,8 +128,9 @@ class NameHandler {
 // name path). Every C++ operator symbol is mapped to a DISTINCT, alphabetic,
 // valid C-identifier token so that (a) no invalid character leaks into the C
 // name and (b) two different operators never collide / truncate to the same
-// token. Multi-character symbols are replaced before their single-character
-// components so e.g. `<<=` does not get eaten by the `<`/`=` rules first.
+// token. The symbol set + longest-first ordering come from the shared
+// [OPERATOR_SYMBOLS] table (via [cOperatorToken]) so this and the Kotlin-side
+// renderer cannot drift apart.
 //
 // This is intentionally a SEPARATE pass from `cleanupName()` (which is also
 // applied to type spellings like `type-parameter-0-0`): mapping `-`/`+`/`/`
@@ -140,39 +141,7 @@ internal fun String.cleanupOperatorName(): String {
     // Only operator method names carry these symbols; bail early otherwise so
     // the common (non-operator) case stays cheap and untouched.
     if (!startsWith("operator")) return this
-    var result = this
-    // (symbol -> token), ordered longest-first so multi-char compounds win.
-    val replacements = listOf(
-        "<<=" to "_shleq",
-        ">>=" to "_shreq",
-        "<<" to "_shl",
-        ">>" to "_shr",
-        "<=" to "_le",
-        ">=" to "_ge",
-        "!=" to "_ne",
-        "->" to "_arrow",
-        "+=" to "_pluseq",
-        "-=" to "_minuseq",
-        "*=" to "_timeseq",
-        "/=" to "_diveq",
-        "%=" to "_modeq",
-        "&=" to "_andeq",
-        "|=" to "_oreq",
-        "^=" to "_xoreq",
-        "++" to "_inc",
-        "--" to "_dec",
-        "+" to "_plus",
-        "-" to "_minus",
-        "/" to "_div",
-        "%" to "_mod",
-        "<" to "_lt",
-        ">" to "_gt",
-        "," to "_comma"
-    )
-    for ((symbol, token) in replacements) {
-        result = result.replace(symbol, token)
-    }
-    return result
+    return replaceCOperatorTokens()
 }
 
 internal fun String.cleanupName(): String = replace("::", "_")

--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/OperatorSymbolTable.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/codegen/OperatorSymbolTable.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.krapper.generator.codegen
+
+/**
+ * Single source of truth for the C++ operator-symbol set and the DISTINCT token
+ * each renderer substitutes for it. Two renderers read this table:
+ *
+ *  - [String.kotlinMethodName] (KotlinWriter) reads [kotlinToken] — the token that
+ *    makes the operator name a valid **Kotlin** identifier fragment.
+ *  - [String.cleanupOperatorName] (NameHandler) reads [cOperatorToken] — the token
+ *    that makes it a valid, non-colliding **C** identifier fragment.
+ *
+ * The Kotlin and C tokens intentionally DIFFER (different identifier rules and
+ * historical spellings, e.g. `*` -> `_star` in Kotlin but `_Times`-style names come
+ * from the [Operator] enum on the C side); a `null` column means that renderer does
+ * not rewrite that symbol at all. Keeping the symbol set + ordering in one list means
+ * adding or changing an operator happens in ONE place and the two renderers cannot
+ * silently drift apart.
+ *
+ * ORDER IS LOAD-BEARING: entries are applied top-to-bottom by a plain
+ * [String.replace] fold, so every multi-character compound MUST precede any single
+ * character it contains (e.g. `<<=` before `<<` before `<`, `""` before `"`, `==`
+ * before `=`). The list below is sorted longest-first with those pairings preserved,
+ * which reproduces each renderer's original per-chain ordering exactly (proven
+ * byte-identical by fuzzing the folded table against the original chains).
+ *
+ * NB: [String.cleanupName] is deliberately NOT driven from this table. It is a
+ * GENERAL C-identifier sanitizer (it also rewrites non-operator spellings like `::`,
+ * ` `, `@`, type-parameter names) whose ordering has its own semantics — notably it
+ * deletes `>` to empty, which can fuse a following `=` into a new `==`. Folding it in
+ * here would force an awkward interleave of operator and non-operator rows for no
+ * maintainability gain, so it keeps its own chain.
+ */
+internal data class OperatorSymbol(
+    /** The C++ operator symbol to match. */
+    val symbol: String,
+    /** Replacement producing a valid Kotlin identifier fragment, or null to skip. */
+    val kotlinToken: String?,
+    /** Replacement producing a valid C identifier fragment, or null to skip. */
+    val cOperatorToken: String?
+)
+
+internal val OPERATOR_SYMBOLS = listOf(
+    OperatorSymbol("<<=", kotlinToken = null, cOperatorToken = "_shleq"),
+    OperatorSymbol(">>=", kotlinToken = null, cOperatorToken = "_shreq"),
+    OperatorSymbol("<<", kotlinToken = null, cOperatorToken = "_shl"),
+    OperatorSymbol(">>", kotlinToken = null, cOperatorToken = "_shr"),
+    OperatorSymbol("<=", kotlinToken = null, cOperatorToken = "_le"),
+    OperatorSymbol(">=", kotlinToken = null, cOperatorToken = "_ge"),
+    OperatorSymbol("!=", kotlinToken = null, cOperatorToken = "_ne"),
+    OperatorSymbol("->", kotlinToken = null, cOperatorToken = "_arrow"),
+    OperatorSymbol("+=", kotlinToken = null, cOperatorToken = "_pluseq"),
+    OperatorSymbol("-=", kotlinToken = null, cOperatorToken = "_minuseq"),
+    OperatorSymbol("*=", kotlinToken = null, cOperatorToken = "_timeseq"),
+    OperatorSymbol("/=", kotlinToken = null, cOperatorToken = "_diveq"),
+    OperatorSymbol("%=", kotlinToken = null, cOperatorToken = "_modeq"),
+    OperatorSymbol("&=", kotlinToken = null, cOperatorToken = "_andeq"),
+    OperatorSymbol("|=", kotlinToken = null, cOperatorToken = "_oreq"),
+    OperatorSymbol("^=", kotlinToken = null, cOperatorToken = "_xoreq"),
+    OperatorSymbol("++", kotlinToken = null, cOperatorToken = "_inc"),
+    OperatorSymbol("--", kotlinToken = null, cOperatorToken = "_dec"),
+    OperatorSymbol("\"\"", kotlinToken = "_qts", cOperatorToken = null),
+    OperatorSymbol("==", kotlinToken = "_cmp", cOperatorToken = null),
+    OperatorSymbol("()", kotlinToken = "_call", cOperatorToken = null),
+    OperatorSymbol("\"", kotlinToken = "_qt", cOperatorToken = null),
+    OperatorSymbol("=", kotlinToken = "_eq", cOperatorToken = null),
+    OperatorSymbol("+", kotlinToken = "_plus", cOperatorToken = "_plus"),
+    OperatorSymbol("-", kotlinToken = "_minus", cOperatorToken = "_minus"),
+    OperatorSymbol("/", kotlinToken = "_div", cOperatorToken = "_div"),
+    OperatorSymbol("*", kotlinToken = "_star", cOperatorToken = null),
+    OperatorSymbol("%", kotlinToken = "_mod", cOperatorToken = "_mod"),
+    OperatorSymbol("<", kotlinToken = "_lt", cOperatorToken = "_lt"),
+    OperatorSymbol(">", kotlinToken = "_gt", cOperatorToken = "_gt"),
+    OperatorSymbol("!", kotlinToken = "_not", cOperatorToken = null),
+    OperatorSymbol("&", kotlinToken = "_and", cOperatorToken = null),
+    OperatorSymbol("|", kotlinToken = "_or", cOperatorToken = null),
+    OperatorSymbol("^", kotlinToken = "_xor", cOperatorToken = null),
+    OperatorSymbol("~", kotlinToken = "_inv", cOperatorToken = null),
+    OperatorSymbol(",", kotlinToken = null, cOperatorToken = "_comma")
+)
+
+/** Fold the selected token column of [OPERATOR_SYMBOLS] over [this], in table order. */
+private inline fun String.replaceOperatorSymbols(token: (OperatorSymbol) -> String?): String {
+    var result = this
+    for (entry in OPERATOR_SYMBOLS) {
+        val replacement = token(entry) ?: continue
+        result = result.replace(entry.symbol, replacement)
+    }
+    return result
+}
+
+/** Rewrite C++ operator symbols to their Kotlin-identifier tokens (see [OPERATOR_SYMBOLS]). */
+internal fun String.replaceKotlinOperatorTokens(): String = replaceOperatorSymbols {
+    it.kotlinToken
+}
+
+/** Rewrite C++ operator symbols to their C-identifier tokens (see [OPERATOR_SYMBOLS]). */
+internal fun String.replaceCOperatorTokens(): String = replaceOperatorSymbols { it.cOperatorToken }


### PR DESCRIPTION
## What

Drive the shared operator-symbol SET + ordering from ONE source-of-truth table instead of three separately-hardcoded `.replace()` chains. This is a maintainability unification (source-of-truth), NOT a merge — the Kotlin and C token renderings stay distinct.

## The mappers

Three parallel operator-symbol mappers were identified:

1. `KotlinWriter.kotlinMethodName()` — Kotlin-identifier tokens (`*` → `_star`, `==` → `_cmp`, …).
2. `NameHandler.cleanupOperatorName()` — C-identifier tokens (`<<=` → `_shleq`, `->` → `_arrow`, …).
3. `NameHandler.cleanupName()` — a GENERAL C-identifier sanitizer.

**Only mappers 1 and 2 are unified** behind the new table. Mapper 3 is deliberately left as its own chain and is documented as such: `cleanupName` is not really an operator mapper — it also rewrites non-operator spellings (`::`, ` `, `@`, type-parameter names) and its ordering has load-bearing semantics that don't fit an operator table (it deletes `>` to empty, which can fuse a following `=` into a new `==`). Folding it in would force an awkward interleave of operator/non-operator rows for no gain. Reported rather than forced.

## Table design

New `OperatorSymbolTable.kt`:
- `OperatorSymbol(symbol, kotlinToken, cOperatorToken)` — one row per C++ operator symbol, with a nullable token column per renderer (`null` = that renderer does not rewrite the symbol).
- `OPERATOR_SYMBOLS` — the single ordered list (longest-symbol-first, required pairings preserved), so adding/changing an operator happens in ONE place and the two renderers cannot drift.
- `String.replaceKotlinOperatorTokens()` / `String.replaceCOperatorTokens()` fold the respective column over the input in table order.

`kotlinMethodName()` keeps its trailing `.escapeKotlinKeyword()`; `cleanupOperatorName()` keeps its `startsWith("operator")` guard.

## Byte-identical proof (method + result)

1. **Fuzz of the pure renderers:** replicated the original three chains and the folded table, then fuzzed 400,000 random operator-symbol strings (every symbol + identifier chars) through both. **0 mismatches** for `kotlinMethodName` and `cleanupOperatorName`. (This fuzz is also what surfaced that `cleanupName`'s ordering is genuinely different, so it was excluded.)
2. **End-to-end regeneration diff (same-env):** ran the in-tree cpp front-end (`:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp -PenableClang`, which builds in-tree krapper_gen/krapper_parse and generates+compiles the full featuregen STL surface incl. operator-named methods) on this branch, snapshotted `featuregen/build/krapped-cpp`, then reverted the three files to `origin/main`, rebuilt, and regenerated over the identical parse models. **`diff -rq` of the two output trees: IDENTICAL** — every `.cc`, `.h`, and `src/*.kt` byte-identical (parse models identical too).

Operator names are unchanged.

## Gates

- Byte-identical generated output: PASS (both proofs above).
- `:krapper_gen:nativeTest`: green (no test expectation changed).
- `:krapper_gen:ktlintCheck`: green.
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp -PenableClang`: green (full build + generate + compile + run).

## Net line delta

`3 files changed, 122 insertions(+), 57 deletions(-)`. The two mappers shrink by ~57 lines; the new table adds ~112 (mostly the table rows + the source-of-truth doc comment). Real (non-comment) code is roughly flat as intended — the win is maintainability, not size.

Refs #17 (item 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
