### PR TITLE
fix(codegen): spell fully-defaulted template specializations with their canonical args (broad-surface CTAD cluster, #10)

### DIFF
--- a/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
@@ -281,6 +281,39 @@ fun buildWrappedType(type: QualType): WrappedType {
             ?.takeIf { it.isNotEmpty() } ?: return UNRESOLVABLE
         // #123: an inaccessible nested record can't be named from the wrapper — drop it.
         if (!record.asDecl().isAccessibleTagType()) return UNRESOLVABLE
+        // FULLY-DEFAULTED template specialization (#10): a use written with an EMPTY
+        // argument list (`BumpPtrAllocatorImpl<>`, or `TimePoint<>` = the alias
+        // `time_point<system_clock, D>` whose sole non-defaulted arg is itself defaulted)
+        // carries ZERO *written* args, so the sugared-TST branch above (guarded on the
+        // written count) never fires and the type reaches this record leaf. Spelling it as
+        // the bare template NAME (`llvm::BumpPtrAllocatorImpl`) is not a valid type — C++
+        // rejects the naked template-name ("requires template arguments; argument deduction
+        // not allowed here") wherever the binding names it by value (a field getter's
+        // `reinterpret_cast<T*>`, a return placement-`new T(...)`). The CANONICAL record IS
+        // a ClassTemplateSpecializationDecl carrying the FULL, resolved argument list, so
+        // recover it here and emit a real `WrappedTemplateType` (`BumpPtrAllocatorImpl<...>`).
+        // Only fully-defaulted specializations reach this point — any with ≥1 written arg
+        // took the sugared branch — so the `vector<Item*>` written-arg preference is intact.
+        val canonArgCount = numTemplateArgs(canonical)
+        if (canonArgCount > 0) {
+            val args = (0u until canonArgCount.toUInt()).map { i ->
+                val arg = templateArgAsType(canonical, i)
+                if (arg.typePtr() == null) UNRESOLVABLE else buildWrappedType(arg)
+            }
+            // A `void` TYPE argument marks a TRANSPARENT / incomplete-friendly specialization
+            // (`std::less<void>` & the other `<void>` transparent comparators): the member
+            // signatures then take dependent params that resolve to a bare `void` BY VALUE
+            // (`operator()(const void, const void)`), which is ill-formed C++ ("'void' must be
+            // the first and only parameter"). Such a type never legitimately binds by value, so
+            // KEEP the prior bare-name leaf here — on which the resolver never materialized a
+            // usable binding anyway (the naked name is inert, not named by value) — rather than
+            // expanding it into a specialization whose newly-resolved members emit `void`
+            // value params. `time_point`/`BumpPtrAllocatorImpl` carry no `void` arg and expand.
+            if (args.none { it.isVoid }) {
+                return WrappedTemplateType(WrappedTypeReference(qualified), args)
+                    .maybeConst(isConst)
+            }
+        }
         return WrappedTypeReference(qualified).maybeConst(isConst)
     }
     if (canonTy != null && canonTy.isEnumeralType()) {


### PR DESCRIPTION
## Cluster chosen & why
The broad-surface tail's largest **systematic** cluster: **use of a class template without its arguments (CTAD not allowed here)** — 25 errors that manifest in three grep buckets that are the SAME underlying failure:
- `requires template arguments; argument deduction not allowed here` (25)
- `cannot form pointer to deduced class template specialization type` (25)

Split by type: **13 `llvm::BumpPtrAllocatorImpl` + 12 `std::chrono::time_point`** — one shared root cause. (The other big buckets — `deleted-ctor` 15 default + 16 copy + 24 explicit-deleted, `invalid-binary-operands` 35 — are each several distinct bespoke roots, not one systematic pattern.)

## Error pattern
```
error: use of class template 'std::chrono::time_point' requires template arguments; argument deduction not allowed here
    std::chrono::time_point* ret_value_cast = reinterpret_cast<std::chrono::time_point*>(ret_value);
    ::new (ret_value_cast) std::chrono::time_point(thiz_cast->getLastAccessedTime());
```
The type is spelled as the **bare template name** — no `<...>`.

## Root cause
`TimePoint<>` (alias for `time_point<system_clock, D>`, `D` defaulted) and `BumpPtrAllocator = BumpPtrAllocatorImpl<>` (all params defaulted) are written with an **empty** argument list, so `numTemplateArgs(type)` reads the sugared TemplateSpecializationType's ZERO *written* args. `TypeBuilder`'s template branch is guarded on that count (`> 0`), so it never fires; the type falls through to the **record leaf**, which spells `qualifiedName(record)` = the naked template name. C++ rejects a naked template-name wherever the binding names the type by value (a field getter's `reinterpret_cast<T*>`, a return placement-`new T(...)`).

## Fix
`krapper_parse/.../TypeBuilder.kt`, record-leaf branch: when the canonical record IS a `ClassTemplateSpecializationDecl` carrying args (`numTemplateArgs(canonical) > 0`), recover the FULL resolved argument list and emit a real `WrappedTemplateType` instead of the bare ref. Only fully-defaulted specializations reach this leaf (any with ≥1 written arg took the sugared branch), so the `vector<Item*>` written-arg preference is untouched.

**Guard:** a specialization carrying a bare `void` TYPE arg (`std::less<void>` & the other transparent comparators) is NOT expanded — its members then take dependent params that resolve to `void` BY VALUE (`operator()(const void, const void)`, ill-formed), so we keep the prior inert bare-name leaf. `time_point`/`BumpPtrAllocatorImpl` carry no `void` arg and expand.

## Broad before/after (`docs/campaigns/broad-error-measure.sh`, clean-main-fresh → branch)
| bucket | before | after |
|---|---|---|
| **TOTAL** | **295** | **245 (-50)** |
| requires-template-args / deduction-not-allowed | 25 | 0 |
| cannot-form-pointer-to-deduced | 25 | 0 |

Zero new error signatures; **no other bucket regressed** (verified by `comm`/`diff` of per-signature counts vs a freshly-parsed clean-main baseline — the only deltas are the three removals above).

## Behavior-preservation
The clangwalk self-hosted slice (`--only` allowlist + IGNORE_MISSING) regenerates **BYTE-IDENTICAL**: same-env clean-main-exe vs branch-exe over freshly re-parsed `base_model.json`, `.cc` + `.h` + `src/*.kt` + all 3 forcing headers unchanged (the expanded types live only in the broad transitive surface, never in the scoped slice). `:krapper_gen:nativeTest`, `:krapper_gen:ktlintCheck`, `:krapper_parse` source ktlint, and `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp --rerun-tasks` all green.

## Remaining next targets
The tail is now increasingly bespoke: `deleted-ctor` (synthesized default `_new` for classes whose implicit default ctor is deleted — diverse per-type reasons, clang exposes no single `defaultedDefaultConstructorIsDeleted` bit in this version; the copy/explicit-deleted halves are move-only-by-value passes) and `invalid-binary-operands` (35 — STL `==` on element types lacking `operator==`, each a distinct type).

Progresses #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
