### PR TITLE
fix(codegen): AST well-formedness gates — skip bindings needing an absent element == / a deleted default ctor (#10)

### DIFF
--- a/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
+++ b/krapper_gen/src/nativeMain/kotlin/com/monkopedia/krapper/generator/Parsing.kt
@@ -643,6 +643,7 @@ suspend fun WrappedTemplate.typedAs(
     dropMistypedInitializerListMembers(outputClass, fullyQualified)
     rewritePairSecondReturns(outputClass, fullyQualified)
     rewriteViewReturns(outputClass)
+    dropValueEqualityIfElementLacksEquals(outputClass, templateSpec, baseContext, fullyQualified)
     return outputClass.resolve(localContext)?.let { it to outputClass }
 }
 
@@ -798,6 +799,53 @@ internal suspend fun rewriteViewReturns(element: WrappedElement) =
 // via `.str()` (T1.10, rewriteViewReturns); as a PARAM they are constructed from an inbound
 // `const char*` at the C boundary (T1.10p, determineArgumentCastMode -> STRING_VIEW).
 internal val STRING_VIEW_TYPES = setOf("llvm::StringRef")
+
+// #10 GATE 1 (value-equality). The container member names whose BODY instantiates
+// `element == element`: llvm::ArrayRef<T>::equals delegates to std::equal, and the
+// std::vector<T> free `operator==`/`operator!=` compare element-wise. When the concrete
+// element type `T` is a RECORD that declares no `operator==` anywhere in scope, these
+// members fail to instantiate deep in <stl_algobase.h> — the exact invalid-operands tail
+// (#10). Drop them here, at template materialization, when the element is PROVEN to lack
+// `==` (its parse-time metadata flag is false); keep-on-doubt otherwise.
+private val VALUE_EQUALITY_MEMBERS = setOf("equals", "operator==", "operator!=")
+
+/**
+ * #10 GATE 1 consumer. For the just-materialized specialization [outputClass], drop each
+ * [VALUE_EQUALITY_MEMBERS] member iff the container's element type is a record PROVEN to have
+ * no `operator==` — the parse-time [ClassMetadata.hasEqualityOperator] fact carried on the
+ * element's [WrappedClass] in [baseContext]'s tracker.
+ *
+ * Keep-on-doubt is load-bearing (a false DROP loses a valid binding — forbidden):
+ *  - a non-record element (scalar / pointer / enum — which have a builtin `==`) is never in
+ *    the class tracker, so it is left untouched;
+ *  - a record we can't find in the tracker (unbound / out-of-scope) is left untouched;
+ *  - ONLY an element record whose metadata says `hasEqualityOperator == false` gates.
+ */
+private fun dropValueEqualityIfElementLacksEquals(
+    outputClass: WrappedClass,
+    templateSpec: WrappedTemplateType,
+    baseContext: ResolveContext,
+    fullyQualified: String
+) {
+    val element = templateSpec.templateArgs.singleOrNull()
+        ?.let { if (it.isConst) it.unconst else it }
+        ?: return
+    // Only a bare record element can lack `==`; a pointer/reference element (std::vector<T*>)
+    // compares pointers with the builtin `==` and must never be gated.
+    if (element.isPointer || element.isReference) return
+    val elementClass = baseContext.tracker.classes[element.toString()] ?: return
+    if (elementClass.metadata.hasEqualityOperator) return
+    for (method in outputClass.children.filterIsInstance<WrappedMethod>()) {
+        if (method.name !in VALUE_EQUALITY_MEMBERS) continue
+        DropLedger.record(
+            "$fullyQualified::${method.name}",
+            "Element type $element has no operator== (container value-equality would " +
+                "fail to instantiate) [#10 gate 1]",
+            DropPhase.RESOLVE
+        )
+        outputClass.removeChild(method)
+    }
+}
 
 /**
  * T1.7e unique_ptr-return marshalling. A by-value `std::unique_ptr<T>` return is

--- a/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
+++ b/krapper_model/src/nativeMain/kotlin/com/monkopedia/krapper/generator/model/WrappedClass.kt
@@ -48,12 +48,24 @@ data class ClassMetadata(
     // Same idea for copy ASSIGNMENT (`operator=`): when it's deleted/inaccessible the
     // generated field setter's `field = *value` won't compile, so the setter is dropped.
     var hasDeletedCopyAssignment: Boolean = false,
-    // Set when this class can't be DEFAULT-constructed because it has a (public) reference
-    // data member and declares no usable constructor: its implicit default constructor is
-    // deleted (a reference must be initialized), so krapper must NOT synthesize a
-    // default-construct path (`new T()`) for it — that would emit a call to the
-    // implicitly-deleted default ctor (T-skip residual, e.g. FunctionEffectSet::Conflict).
-    var hasDeletedDefaultConstructor: Boolean = false
+    // Set when this class can't be DEFAULT-constructed because its default constructor is
+    // deleted — either a materialized default ctor decl is `isDeleted()`, or the structural
+    // `[class.default.ctor]` check fires (a base/field with no usable default ctor, a
+    // reference field, or a const-qualified field). krapper must NOT synthesize a
+    // default-construct path (`new T()`) for such a class — that would emit a call to the
+    // implicitly-deleted default ctor (#10 gate 2; the reference-field case is the original
+    // T-skip residual, e.g. FunctionEffectSet::Conflict).
+    var hasDeletedDefaultConstructor: Boolean = false,
+    // Set when this class (a RECORD) has an accessible `operator==` reachable for value
+    // comparison — as a member, an inherited member on a public base, or a free function in
+    // the enclosing namespace. Consumed by the #10 gate-1 value-equality drop: a container
+    // member whose body instantiates `element == element` (`llvm::ArrayRef<T>::equals` /
+    // `std::vector<T>::operator==` and their `!=` peers) is dropped when the element record
+    // has NO `operator==` (the body would fail to instantiate deep in <stl_algobase.h>).
+    // Keep-on-doubt: only a class PROVEN to lack `==` disables the container member; a
+    // non-record element (scalar/pointer/enum, which have a builtin `==`) never sets this
+    // flag and is never gated (see the gate's non-record exemption).
+    var hasEqualityOperator: Boolean = false
 )
 
 class WrappedClass(

--- a/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/ModelBuilder.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import clang.AccessSpecifier
+import clang.CXXBaseSpecifier
 import clang.CXXConstructorDecl
 import clang.CXXDestructorDecl
 import clang.CXXMethodDecl
@@ -26,6 +27,7 @@ import clang.FunctionDecl
 import clang.NamedDecl
 import clang.NamespaceDecl
 import clang.ParmVarDecl
+import clang.QualType
 import clang.RecordDecl
 import clang.TemplateDecl
 import clang.TemplateParameterList
@@ -66,6 +68,16 @@ import kppbridge.defaultArgType
 // "cpp:<id>". The two front-ends therefore NEVER agree on the literal identity string —
 // Phase C's tree-diff treats identity fields as maskable and compares structure only.
 private fun Decl.canonical(): Decl = (getCanonicalDecl() as? Decl) ?: this
+
+// The DEFINING redeclaration of a record (or null when it is never defined). A base/field
+// type may be spelled through a forward declaration whose own `decls()` carries no members;
+// the #10 gates must introspect the definition. Re-view the RecordDecl-Api result as a
+// CXXRecordDecl (address-identical), returning the record itself when it is already the
+// definition.
+private fun CXXRecordDecl.definitionOrNull(): CXXRecordDecl? = when {
+    isThisDeclarationADefinition() -> this
+    else -> recordDeclGetDefinition()?.let { CXXRecordDecl(it.ptr) }
+}
 
 // Shared with TypeBuilder (the dependent-T WrappedTemplateRef must key on the SAME
 // identity string as the WrappedTemplateParam it refers to).
@@ -381,6 +393,157 @@ private class ModelBuilder(private val memScope: MemScope) {
             if (decl.isImplicit()) continue
             addMember(decl, parent, metadata)
         }
+        // #10 GATE 2 (deleted default ctor): generalize the reference-field-only fact
+        // addField already records so the resolver's `_new` guard covers ALL deletion
+        // reasons, not just a reference member. The direct decl scan catches an already-
+        // materialized deleted default ctor (Module::Header family), the structural check
+        // the still-lazy implicit case (TargetInfo::GCCRegAlias const-array family). Runs
+        // AFTER the member loop so it sees the same decls addMember walked.
+        if (defaultCtorIsDeleted(record)) metadata.hasDeletedDefaultConstructor = true
+        // #10 GATE 1 (value-equality): record whether this record has an accessible
+        // `operator==` (member / public base / enclosing-namespace free function). The
+        // consumer (krapper_gen typedAs) drops a container `equals`/`operator==` whose
+        // element is a record proven to lack `==`, so the container body never fails to
+        // instantiate `element == element` deep in <stl_algobase.h>.
+        if (recordHasEqualityOperator(record)) metadata.hasEqualityOperator = true
+    }
+
+    // #10 GATE 2 predicate — is [record]'s DEFAULT constructor deleted? Two-step hybrid
+    // (`hasDefaultConstructor()` is useless: it returns true even for an implicitly-deleted
+    // default ctor, and clang 22 has no `defaultedDefaultConstructorIsDeleted()`):
+    //  1. DIRECT — a materialized `CXXConstructorDecl` that isDefaultConstructor() AND
+    //     isDeleted() (clang already built the decl because it was odr-used in the parse);
+    //  2. STRUCTURAL — when the implicit default ctor is still lazy
+    //     (needsImplicitDefaultConstructor), apply `[class.default.ctor]` deletion rules
+    //     over bases + non-in-class-initialized fields.
+    // Keep-on-doubt: returns true ONLY on a positive proof of deletion; every ambiguous
+    // case leaves the existing behaviour (a false KEEP is at worst an unchanged error, a
+    // false DROP would lose a valid `_new`).
+    private fun defaultCtorIsDeleted(record: CXXRecordDecl): Boolean = with(memScope) {
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            val ctor = decl.asCXXConstructorDecl() ?: continue
+            if (ctor.isDefaultConstructor() &&
+                ctor.asFunctionDecl().isDeleted()
+            ) {
+                return true
+            }
+        }
+        // Only reach the structural rules when the implicit default ctor hasn't been
+        // materialized (otherwise the direct scan above is authoritative). If a usable
+        // default ctor decl exists, needsImplicitDefaultConstructor() is false and we
+        // correctly keep the `_new`.
+        if (!record.needsImplicitDefaultConstructor()) return false
+        structuralDefaultCtorDeleted(record)
+    }
+
+    // `[class.default.ctor]` structural deletion over the AST: the implicit default ctor is
+    // deleted if any base or non-in-class-initialized field can't be default-constructed —
+    // a record base/field whose OWN default ctor is unusable (recurse), a reference field,
+    // or a const-qualified field. Recursion is depth-bounded by [seen] (a self-referential
+    // record type can't complete-construct anyway). Anything not positively proven deleting
+    // is treated as constructible (keep-on-doubt).
+    private fun structuralDefaultCtorDeleted(
+        record: CXXRecordDecl,
+        seen: MutableSet<String> = mutableSetOf()
+    ): Boolean = with(memScope) {
+        if (!seen.add(record.asNamedDecl().getNameAsString().orEmpty().ifEmpty { return false })) {
+            return false
+        }
+        for (base in record.bases()) {
+            if (base == null) continue
+            if (baseOrFieldTypeDeletesDefaultCtor(base.getType(), seen)) return true
+        }
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            val field = decl.asFieldDecl() ?: continue
+            // A field with an in-class initializer (`int n = 0;`) is default-initialized by
+            // that initializer, so it never deletes the default ctor.
+            if (field.hasInClassInitializer()) continue
+            if (baseOrFieldTypeDeletesDefaultCtor(field.getType(), seen)) return true
+        }
+        false
+    }
+
+    // Whether a base/field of [type] makes the enclosing class's implicit default ctor
+    // deleted: a reference member (must be initialized), a const-qualified member (a const
+    // scalar/array/pointer has no default initializer), or a record member whose own
+    // default ctor is deleted (recurse). A non-const scalar/pointer/enum default-initializes
+    // fine and does not delete.
+    private fun baseOrFieldTypeDeletesDefaultCtor(
+        type: QualType,
+        seen: MutableSet<String>
+    ): Boolean = with(memScope) {
+        val ty = type.typePtr() ?: return false
+        if (ty.isReferenceType()) return true
+        if (type.isConstQualified()) return true
+        val nested = ty.asRecord() ?: return false
+        // Only a DEFINED record can be introspected; reach the definition when the leaf
+        // itself is a forward declaration, and leave a never-defined record as
+        // constructible (keep-on-doubt).
+        val defn = nested.definitionOrNull() ?: return false
+        defaultCtorIsDeletedForNested(defn, seen)
+    }
+
+    // The nested-record arm of the structural recursion: a direct deleted default-ctor decl
+    // OR (when still lazy) the structural rules again.
+    private fun defaultCtorIsDeletedForNested(
+        record: CXXRecordDecl,
+        seen: MutableSet<String>
+    ): Boolean = with(memScope) {
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            val ctor = decl.asCXXConstructorDecl() ?: continue
+            if (ctor.isDefaultConstructor() && ctor.asFunctionDecl().isDeleted()) return true
+        }
+        if (!record.needsImplicitDefaultConstructor()) return false
+        structuralDefaultCtorDeleted(record, seen)
+    }
+
+    // #10 GATE 1 predicate — does [record] have an accessible `operator==` usable for value
+    // comparison? Mirrors the design's probe (§4.1): a member/base `operator==` OR a free
+    // `operator==` in the enclosing namespace. The free scan is LOAD-BEARING — SourceLocation
+    // / StringRef have no member `==` but a namespace-level one, and dropping their container
+    // value-equality would be a false DROP. Keep-on-doubt everywhere else: an unresolvable or
+    // undefined record returns... nothing here (the caller only ACTS on a positive hit at the
+    // element side, so a missing flag simply keeps the container member).
+    private fun recordHasEqualityOperator(record: CXXRecordDecl): Boolean = with(memScope) {
+        if (recordDeclaresEqualityMember(record, mutableSetOf())) return true
+        // Enclosing-namespace free `operator==`. getEnclosingNamespaceContext walks past the
+        // record's own context to the nearest namespace (`clang` for `clang::Module::Header`).
+        val enclosing = record.asDecl().getDeclContext()?.getEnclosingNamespaceContext()
+            ?: return false
+        if (!enclosing.isNamespace()) return false
+        for (decl in enclosing.decls()) {
+            if (decl == null) continue
+            if (decl.asCXXMethodDecl() != null) continue
+            val fn = decl.asFunctionDecl() ?: continue
+            if (fn.asNamedDecl().getNameAsString() == "operator==") return true
+        }
+        false
+    }
+
+    // A member `operator==` on [record] or any of its public bases (recurse, depth-bounded).
+    private fun recordDeclaresEqualityMember(
+        record: CXXRecordDecl,
+        seen: MutableSet<String>
+    ): Boolean = with(memScope) {
+        if (!seen.add(record.asNamedDecl().getNameAsString().orEmpty().ifEmpty { return false })) {
+            return false
+        }
+        for (decl in record.asDeclContext().decls()) {
+            if (decl == null) continue
+            val method = decl.asCXXMethodDecl() ?: continue
+            if (method.asNamedDecl().getNameAsString() == "operator==") return true
+        }
+        for (base in record.bases()) {
+            if (base == null) continue
+            if (base.getAccessSpecifier() != AccessSpecifier.AS_public) continue
+            val baseRecord = base.getType().typePtr()?.asRecord() ?: continue
+            val defn = baseRecord.definitionOrNull() ?: continue
+            if (recordDeclaresEqualityMember(defn, seen)) return true
+        }
+        false
     }
 
     private fun addMember(decl: Decl, parent: WrappedElement, metadata: ClassMetadata) {

--- a/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
+++ b/krapper_parse/src/nativeMain/kotlin/TypeBuilder.kt
@@ -52,11 +52,11 @@ import kppbridge.templateBaseName
 // QualType::getTypePtrOrNull() is declared to return the TypeApi *interface* (the generated
 // related-object-getter convention); re-wrap to the concrete Type so the shape predicates
 // (which live on the concrete class) resolve. Same pattern as the type-decode probe.
-private fun QualType.typePtr(): Type? = getTypePtrOrNull()?.let { Type(it.ptr) }
+internal fun QualType.typePtr(): Type? = getTypePtrOrNull()?.let { Type(it.ptr) }
 
 // Type::getAsCXXRecordDecl() likewise returns the Api interface; re-wrap so the
 // dyn-cast helpers + NamedDecl upcasts resolve.
-private fun Type.asRecord(): CXXRecordDecl? =
+internal fun Type.asRecord(): CXXRecordDecl? =
     getAsCXXRecordDecl()?.let { CXXRecordDecl(it.ptr) }
 
 // BRIDGE: the generated down-cast helper `Type.asTypedefType()` is missing — TypedefType's


### PR DESCRIPTION
Progresses #10. Implements the two narrow AST-capability well-formedness gates from `docs/design/wellformedness-binding-gate.md` (mechanism **A′**), the same species as the existing #163 dyn_cast gate — no live Sema, and **no new `clang_slice.h` binding** (all primitives were already bound).

## Gate 1 — value-equality (invalid-operands)
**Predicate (krapper_parse `ModelBuilder`, §4.1):** for each defined record, set the new `ClassMetadata.hasEqualityOperator` when an accessible `operator==` is reachable — as a member, on a public base (recurse), **or** as a free function in the enclosing namespace (`getEnclosingNamespaceContext().decls()` scan; the free scan is load-bearing — it retains `SourceLocation`/`StringRef`, whose only `==` is namespace-level).

**Hook / drop (krapper_gen `Parsing.typedAs`):** a new `rewriteMethods` sibling pass `dropValueEqualityIfElementLacksEquals` runs at template materialization. When the container's concrete element type is a **record proven to lack `==`** (its parse-time flag is false), it drops that specialization's `equals` / `operator==` / `operator!=` members, so the body never fails to instantiate `element == element` deep in `<stl_algobase.h>`. **Keep-on-doubt:** a non-record / pointer / reference element (builtin `==`) and any element not found in the resolve tracker are left untouched.

## Gate 2 — deleted default ctor
**Predicate (krapper_parse `ModelBuilder`):** generalizes the reference-field-only `hasDeletedDefaultConstructor` fact to all deletion reasons via the design's two-step hybrid — (1) DIRECT: a materialized `CXXConstructorDecl` that `isDefaultConstructor()` && `isDeleted()`; (2) STRUCTURAL (when `needsImplicitDefaultConstructor()`): the `[class.default.ctor]` rules over bases + non-in-class-initialized fields (a base/field record with an unusable default ctor → recurse, a reference field, or a const-qualified field). Feeds `ModelResolution.modifyMethodsIfNeeded`'s existing `_new` guard unchanged.

Every drop is logged through the existing `DropLedger` (Gate 1 → `DropPhase.RESOLVE`).

## Verification
- **featuregen cpp SYNC byte-identical + 195/0.** Regenerated the featuregen bindings on `main` and on this branch with freshly-built binaries: `diff -rq` reports **BYTE-IDENTICAL** — no valid method dropped (the forbidden outcome). `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` = **195 tests / 0 failures**.
- **Broad re-measure (`docs/campaigns/broad-error-measure.sh`), before → after, no new error types (branch errors are a strict subset of main's):**

| bucket | main | branch |
|---|---|---|
| **TOTAL** | **245** | **185** |
| invalid-binary-operands | 35 | 1 |
| deleted-ctor (default+copy lines) | 55 | 49 |
| no-matching-constructor | 24 | 24 |
| no-matching-function | 15 | 15 |
| rvalue-param-init | 1 | 1 |

  Gate 1 cleared the 5 no-`==` element containers (`ArrayRef<Builtin::Info|Token|TemplateArgument|LambdaCapture|FixItHint>::equals`) while KEEPING the controls (`SourceLocation`/`StringRef`, via free `==`). One invalid-operand residual remains — `clang::TokenValue`, which HAS a member `operator==(const Token&)` (comparison against a *different* type), so the name-based keep-on-doubt predicate correctly does not drop it; this is a safe false-KEEP (an unchanged existing error, no regression). Gate 2 cleared the concrete direct/structural default-ctor families (`Module::DirectoryName`, `TargetInfo::GCCRegAlias`/`AddlRegName` const-array, `FunctionEffectSet::Conflict`); the residual default-ctor lines are `StringMapEntry<…>` (deleted-base on a template *specialization*, whose dependent base can't be resolved at pattern-parse — out of reach for a parse-time concrete gate) and STL-internal `std::_Construct` element default-construction (not the synthesized `_new`).
- `:krapper_gen:nativeTest` green; `:cppfixture:nativeTest -Pkpp.frontend.cppfixture=cpp` green; `:krapper_gen:ktlintCheck` green; krapper_parse hand-source ktlint unchanged (18 pre-existing findings, **0 new**).

See `docs/design/wellformedness-binding-gate.md` for the full probe-validated design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
