### PR TITLE
chore: build-file tidy — clear ktlint-script debt + deprecations, tidy dead config

### DIFF
--- a/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
+++ b/compiler/gradle/src/main/kotlin/com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin.kt
@@ -951,7 +951,7 @@ class KPlusPlusCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 return@afterEvaluate
             }
             compilation.cinterops.create("kplusplus") { interop ->
-                interop.defFile = krappedDef
+                interop.definitionFile.set(krappedDef)
             }
             // The cinterop task reads the generated .def; make it regenerate via
             // kplusplusSync first so it can't process a stale def (issue #16).

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -24,7 +25,7 @@ val signingConfigured =
 mavenPublishing {
     publishToMavenCentral(automaticRelease = true)
     if (signingConfigured) signAllPublications()
-    configure(KotlinJvm(javadocJar = JavadocJar.Empty(), sourcesJar = true))
+    configure(KotlinJvm(javadocJar = JavadocJar.Empty(), sourcesJar = SourcesJar.Sources()))
     pom {
         name.set("kplusplus compiler (FIR plugin)")
         description.set(

--- a/featuregen/build.gradle.kts
+++ b/featuregen/build.gradle.kts
@@ -47,11 +47,11 @@ kplusplus {
     // Seed the user template `Box<T>` instantiations: their Kotlin facade is itself
     // generated, so the compiler can't request them via SYNC_REQUIRED (see the
     // instantiate() KDoc). One per featuregen Box test.
-    instantiate("Box<int>")              // UT-box: primitive arg
-    instantiate("Box<Point>")            // UT-box-point: user-type arg -> Box__Point
-    instantiate("Box<Box<int>>")         // UT-box-nested: nested -> Box<Box__Int>()
-    instantiate("Pair2<int, double>")    // UT-pair2: 2-type-param user template -> Pair2__Int__Double
-    instantiate("std::unique_ptr<int>")  // SP-unique: get/release/operator-> via pointer typedef
+    instantiate("Box<int>") // UT-box: primitive arg
+    instantiate("Box<Point>") // UT-box-point: user-type arg -> Box__Point
+    instantiate("Box<Box<int>>") // UT-box-nested: nested -> Box<Box__Int>()
+    instantiate("Pair2<int, double>") // UT-pair2: 2-type-param user template -> Pair2__Int__Double
+    instantiate("std::unique_ptr<int>") // SP-unique: get/release/operator-> via pointer typedef
     // RG-range (T1.3): RangeHolder::items() is materialized into std::vector<Thing*>.
     // Like the Box facade, this vector instantiation is generated on demand by the
     // range rewrite (not via a Kotlin call site), so it can't be discovered through
@@ -87,17 +87,24 @@ if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
     // hardcoded. This is ENTIRELY under the property guard: the default
     // `./gradlew :featuregen:nativeTest` never enters this block, so the standard test
     // link path is untouched.
-    val systemStdcxxSo: File = run {
-        val proc = ProcessBuilder("clang++", "-print-file-name=libstdc++.so")
-            .redirectErrorStream(true).start()
-        val out = proc.inputStream.readBytes().toString(Charsets.UTF_8).trim()
-        proc.waitFor()
-        File(out).canonicalFile.takeIf { it.isFile }
-            ?: error(
-                "#78: could not resolve the system libstdc++.so from " +
-                    "`clang++ -print-file-name=libstdc++.so` (got: '$out')"
-            )
-    }
+    val systemStdcxxSo: File =
+        run {
+            val proc =
+                ProcessBuilder("clang++", "-print-file-name=libstdc++.so")
+                    .redirectErrorStream(true)
+                    .start()
+            val out =
+                proc.inputStream
+                    .readBytes()
+                    .toString(Charsets.UTF_8)
+                    .trim()
+            proc.waitFor()
+            File(out).canonicalFile.takeIf { it.isFile }
+                ?: error(
+                    "#78: could not resolve the system libstdc++.so from " +
+                        "`clang++ -print-file-name=libstdc++.so` (got: '$out')",
+                )
+        }
     val systemStdcxxLibDir = systemStdcxxSo.parentFile.absolutePath
     kotlin {
         linuxX64("native") {
@@ -117,7 +124,7 @@ if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
                 "-rpath",
                 systemStdcxxLibDir,
                 "-rpath-link",
-                systemStdcxxLibDir
+                systemStdcxxLibDir,
             )
         }
     }

--- a/krapper_parse/build.gradle.kts
+++ b/krapper_parse/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
                     "-lLLVM-${rootProject.extra.properties["llvmMajor"] ?: "22"}",
                     "-lstdc++",
                     "-lm",
-                    "-lpthread"
+                    "-lpthread",
                 )
                 runTask()
             }
@@ -205,7 +205,7 @@ kplusplus {
         // preference + dependent-specialization decode (see clang_slice.h).
         "kppbridge::numTemplateArgs",
         "kppbridge::templateArgAsType",
-        "kppbridge::templateBaseName"
+        "kppbridge::templateBaseName",
     )
     // FIXUPS (documented generator gaps, #44 brick 5): krapper's operator generation
     // emits invalid Kotlin for four of llvm::APSInt's C++ operators —
@@ -249,17 +249,27 @@ kplusplus {
 // goldenEmit makes the cpp front-end parse the fixture and write the bytes (fixture.h) +
 // the full-fidelity ModelIo handoff JSON (model.json) that handoffGenerate consumes. The
 // standing cpp regression lock is handoffGenerate (cpp e2e, below) + :featuregen:nativeTest.
-val goldenDir = layout.buildDirectory.dir("golden").get().asFile
-val krapperParseBinary = layout.buildDirectory
-    .file("bin/klinker/krapper_parseRelease/krapper_parse").get().asFile
-val krapperGenKexe = rootProject.layout.projectDirectory
-    .file("krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe").asFile
+val goldenDir =
+    layout.buildDirectory
+        .dir("golden")
+        .get()
+        .asFile
+val krapperParseBinary =
+    layout.buildDirectory
+        .file("bin/klinker/krapper_parseRelease/krapper_parse")
+        .get()
+        .asFile
+val krapperGenKexe =
+    rootProject.layout.projectDirectory
+        .file("krapper_gen/build/bin/native/releaseExecutable/krapper_gen.kexe")
+        .asFile
 
-val goldenEmit = tasks.register<Exec>("goldenEmit") {
-    dependsOn("linkReleaseExecutableKlinker")
-    doFirst { goldenDir.mkdirs() }
-    commandLine(krapperParseBinary.absolutePath, "--golden-emit", goldenDir.absolutePath)
-}
+val goldenEmit =
+    tasks.register<Exec>("goldenEmit") {
+        dependsOn("linkReleaseExecutableKlinker")
+        doFirst { goldenDir.mkdirs() }
+        commandLine(krapperParseBinary.absolutePath, "--golden-emit", goldenDir.absolutePath)
+    }
 
 // ---- #101: NONCOPYABLE special-member determinism guard ----
 // Runs the krapper_parse binary's `--noncopyable-determinism` mode, which parses a
@@ -283,7 +293,11 @@ tasks.register<Exec>("noncopyableDeterminismCheck") {
 //                      clang++ -c; a non-zero exit fails the task), proving the handed-off
 //                      model carries everything the real pipeline consumes.
 // --instantiate is scoped out on this path; the fixture needs no instantiations.
-val handoffDir = layout.buildDirectory.dir("handoff").get().asFile
+val handoffDir =
+    layout.buildDirectory
+        .dir("handoff")
+        .get()
+        .asFile
 
 tasks.register<Exec>("handoffGenerate") {
     dependsOn(goldenEmit, ":krapper_gen:linkReleaseExecutableNative")
@@ -299,7 +313,7 @@ tasks.register<Exec>("handoffGenerate") {
         File(goldenDir, "model.json").absolutePath,
         "-o",
         handoffDir.absolutePath,
-        "fixture"
+        "fixture",
     )
     doLast {
         // The run already failed on any resolve/codegen/compile error; assert the
@@ -307,8 +321,11 @@ tasks.register<Exec>("handoffGenerate") {
         val expected = listOf("fixture.h", "fixture.cc", "fixture.def", "libfixture.a")
         val missing = expected.filter { !File(handoffDir, it).exists() }
         check(missing.isEmpty()) { "handoffGenerate: missing generated artifact(s): $missing" }
-        val kotlinFiles = File(handoffDir, "src").walkTopDown()
-            .filter { it.isFile && it.extension == "kt" }.toList()
+        val kotlinFiles =
+            File(handoffDir, "src")
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .toList()
         check(kotlinFiles.isNotEmpty()) { "handoffGenerate: no Kotlin bindings generated" }
         println("handoffGenerate: generated " + (expected + kotlinFiles.map { it.name }))
     }
@@ -326,30 +343,36 @@ tasks.register<Exec>("handoffGenerate") {
 //                         task), then functionally asserts the recovered range accessor
 //                         (Bag::items()) and the vector specialization's core surface
 //                         materialized.
-val handoffInstDir = layout.buildDirectory.dir("handoff_inst").get().asFile
+val handoffInstDir =
+    layout.buildDirectory
+        .dir("handoff_inst")
+        .get()
+        .asFile
 
-val handoffInstEmit = tasks.register<Exec>("handoffInstEmit") {
-    dependsOn("linkReleaseExecutableKlinker")
-    doFirst { handoffInstDir.mkdirs() }
-    commandLine(krapperParseBinary.absolutePath, "--handoff-emit", handoffInstDir.absolutePath)
-}
+val handoffInstEmit =
+    tasks.register<Exec>("handoffInstEmit") {
+        dependsOn("linkReleaseExecutableKlinker")
+        doFirst { handoffInstDir.mkdirs() }
+        commandLine(krapperParseBinary.absolutePath, "--handoff-emit", handoffInstDir.absolutePath)
+    }
 
 // The CLI tail: fixture, standard, allowlist scope and instantiation for the cpp run.
-fun instGenerateArgs(outDir: File) = listOf(
-    "-h",
-    File(handoffInstDir, "bag.h").absolutePath,
-    "--std",
-    "c++17",
-    "--only",
-    "Bag",
-    "--only",
-    "Item",
-    "--instantiate",
-    "std::vector<Item*>",
-    "-o",
-    outDir.absolutePath,
-    "bag"
-)
+fun instGenerateArgs(outDir: File) =
+    listOf(
+        "-h",
+        File(handoffInstDir, "bag.h").absolutePath,
+        "--std",
+        "c++17",
+        "--only",
+        "Bag",
+        "--only",
+        "Item",
+        "--instantiate",
+        "std::vector<Item*>",
+        "-o",
+        outDir.absolutePath,
+        "bag",
+    )
 
 tasks.register<Exec>("handoffInstGenerate") {
     dependsOn(handoffInstEmit, ":krapper_gen:linkReleaseExecutableNative")
@@ -362,8 +385,8 @@ tasks.register<Exec>("handoffInstGenerate") {
             File(handoffInstDir, "bag_model.json").absolutePath,
             "--forcingModel",
             "std::vector<Item*>=" +
-                File(handoffInstDir, "KrapperForce_std_vector_ItemPtr.json").absolutePath
-        ) + instGenerateArgs(outDir)
+                File(handoffInstDir, "KrapperForce_std_vector_ItemPtr.json").absolutePath,
+        ) + instGenerateArgs(outDir),
     )
     doLast {
         // Functional gate. The wrapper already COMPILED (writeTo's CppCompiler step fails the
@@ -374,23 +397,24 @@ tasks.register<Exec>("handoffInstGenerate") {
             "handoffInstGenerate: Bag::items() was not recovered by pass-3 forcing"
         }
         val vector = File(outDir, "src/std_Vector__Item_P.kt").readText()
-        val expectedSurface = listOf(
-            "fun size(): size_t",
-            "fun push_back(",
-            "fun at(",
-            "operator fun get(",
-            "fun front(): Item?",
-            "fun back(): Item?",
-            "fun empty(): Boolean",
-            "fun clear(): Unit"
-        )
+        val expectedSurface =
+            listOf(
+                "fun size(): size_t",
+                "fun push_back(",
+                "fun at(",
+                "operator fun get(",
+                "fun front(): Item?",
+                "fun back(): Item?",
+                "fun empty(): Boolean",
+                "fun clear(): Unit",
+            )
         val missing = expectedSurface.filter { !vector.contains(it) }
         check(missing.isEmpty()) {
             "handoffInstGenerate: vector specialization is missing core surface: $missing"
         }
         println(
             "handoffInstGenerate: cpp instantiation-forcing run compiled + materialized " +
-                "the specialization and recovered items()"
+                "the specialization and recovered items()",
         )
     }
 }

--- a/samples/minimal/gradle.properties
+++ b/samples/minimal/gradle.properties
@@ -1,5 +1,9 @@
-kotlin.native.cacheKind.linuxX64=none
 org.gradle.jvmargs=-Xmx4096m
+# The single custom native target is named "native" (see build.gradle.kts), which clashes
+# with the source sets the default hierarchy template creates — Kotlin warns and skips the
+# template. This sample doesn't use the template's shared intermediate source sets, so
+# disable it explicitly to clear the warning (mirrors the root gradle.properties).
+kotlin.mpp.applyDefaultHierarchyTemplate=false
 # Generate the geometry bindings through the cpp front-end. As a from-published consumer
 # the krapper_parse tool binary is resolved by coordinate from mavenLocal (or the bundled
 # plugin jar) —

--- a/samples/v8/gradle.properties
+++ b/samples/v8/gradle.properties
@@ -1,5 +1,9 @@
-kotlin.native.cacheKind.linuxX64=none
 org.gradle.jvmargs=-Xmx4096m
+# The single custom native target is named "native" (see build.gradle.kts), which clashes
+# with the source sets the default hierarchy template creates — Kotlin warns and skips the
+# template. This sample doesn't use the template's shared intermediate source sets, so
+# disable it explicitly to clear the warning (mirrors the root gradle.properties).
+kotlin.mpp.applyDefaultHierarchyTemplate=false
 # Generate the v8 bindings through the cpp front-end. Requires an LLVM 22 toolchain on the
 # box (this sample includeBuilds the main kplusplus build, whose settings-eval fails fast if
 # LLVM is absent).


### PR DESCRIPTION
General build-file **tidy-in-place** — the last of the 3-PR config-cleanup chain (after #173 require-LLVM, #174 flip-era comment sweep). Convention-plugin / `buildSrc` consolidation is explicitly **deferred**; this PR only cleans up in place.

## Group A — safe/mechanical (done)

**A.1 — ktlint `.kts` script debt (the point of this PR).** `:krapper_parse:ktlintKotlinScriptCheck` and `:featuregen:ktlintKotlinScriptCheck` both had pre-existing style violations (missing trailing commas, multiline-expression wrapping, comment-alignment whitespace, a >100-char line). Ran `ktlintKotlinScriptFormat` on both; both script checks are now green. Pure style — no task input/output/commandLine/value changed.

**A.2 — trivial deprecations.**
- `KPlusPlusCompilerGradlePlugin.kt`: `interop.defFile = krappedDef` (non-lazy, `'var defFile: File' is deprecated`) → `interop.definitionFile.set(krappedDef)` (the lazy `RegularFileProperty`). Confirmed the warning was present on main and is gone on the branch.
- `compiler/plugin/build.gradle.kts`: `KotlinJvm(..., sourcesJar = true)` (deprecated boolean overload) → `SourcesJar.Sources()`, matching the sibling `compiler/gradle` module's `GradlePlugin(..., sourcesJar = SourcesJar.Sources())`.

**A.3 — dead config.** Removed the dead `kotlin.native.cacheKind.linuxX64=none` property from both sample `gradle.properties` (see B.4 — it was a no-op / actively deprecated). No other genuine dead/duplicated intra-file config found worth touching (the hardcoded `version`/Kotlin literals are a known cross-file pattern; de-duping them is the deferred consolidation, not this PR).

## Group B — behavior-adjacent (verified)

**B.4 — `kotlin.native.cacheKind.linuxX64=none` (samples/v8 + samples/minimal).** This property was **removed in Kotlin 2.3.20**; both samples run 2.4.0. On `minimal` it emitted an explicit `Deprecated Gradle Property Used` warning; on `v8` it was a silently-ignored no-op. **I deliberately did NOT migrate it to the `disableNativeCache` DSL** (the mirror of `krapper_gen`): that DSL's `DisableCacheInKotlinVersion.2_4_0` constant is *itself* deprecated (it would add a **new** warning), and enabling it would *change behavior* — actually disabling a cache the samples have been building fine without since they moved to 2.4.0. Per the "no new warnings / byte-identical" rule, the correct tidy is to **delete the dead line**, which I did.

**B.6 — Kotlin Hierarchy Template clash (samples/v8 + samples/minimal).** Both samples name their single custom native target `"native"`, which clashes with the default hierarchy template's source sets (Kotlin warned + skipped the template). Applied the tool's own suggested fix — added `kotlin.mpp.applyDefaultHierarchyTemplate=false` to each sample's `gradle.properties` (mirrors the root `gradle.properties`, which already has it; the samples are separate composite/standalone build roots so they need their own). Verified the warning is cleared and both samples still configure.

## Deliberately LEFT

**B.5 — `macosX64(...)` target deprecation** (krapper_gen, krapper_model, samples/v8, samples/minimal). Tier-demotion warning ("Target will be removed in a future release"), not a removal — the target still works. It appears as one branch of a host-OS `when` expression in each module; there is no clean drop-in replacement, and a scoped `@Suppress` on a `when`-branch inside the `kotlin { }` DSL isn't clean and would only hide a genuine future-removal signal. Left as-is per the task's guidance.

**Root `android.set(true)` in the ktlint config** — this is a non-Android project, but flipping it would change ktlint's ruleset (behavior-adjacent, could surface new violations). Out of scope for a tidy; left.

## Byte-identical proof

A build-config tidy must not change codegen. Regenerated the featuregen cpp output (`:featuregen:kplusplusSync -Pkpp.frontend.featuregen=cpp`) on **clean `main`** vs **this branch**, each in its own worktree (both LLVM 22 / clang 22). After normalizing only the worktree-path prefix in the `.def` (`/tmp/kpp-buildtidy` vs `/tmp/kpp-main-verify` — an absolute-path environment artifact, not codegen), a recursive `diff -r` over all 165 generated source/header/def files reports **IDENTICAL: no content differences**.

## Green gates (JDK 21, LLVM 22)

- `:krapper_gen:nativeTest` — BUILD SUCCESSFUL
- `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` — BUILD SUCCESSFUL (cpp path, since cpp-module build files were touched)
- `:krapper_parse:ktlintKotlinScriptCheck`, `:featuregen:ktlintKotlinScriptCheck`, `:krapper_gen:ktlintKotlinScriptCheck` — green
- `-p compiler :kplusplus-compiler-gradle:compileKotlin` + `:kplusplus-compiler-plugin:compileKotlin` — SUCCESSFUL, `defFile` deprecation warning gone
- `./gradlew projects` — configures
- samples/v8 + samples/minimal `./gradlew help --offline` — configure; hierarchy + cacheKind warnings gone, no new warning gained

## Note

Pre-existing ktlint violations in `krapper_parse/src/nativeMain/kotlin/*.kt` (hand-written source, e.g. `KrapperParse.kt:373` >100 chars) exist on `main` and are **out of scope** for this build-file/`.kts` tidy — I confirmed those files are byte-identical to main and did not touch them (running `ktlintFormat` over them would edit hand-written logic files, beyond a config tidy). Flagging so a follow-up can clear the source-set debt separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
