### PR TITLE
feat(build): add binary-compatibility-validator (apiCheck) to the published plugin (#178)

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -7,11 +7,32 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.vannik.publish) apply false
     alias(libs.plugins.gradle.plugin.publish) apply false
+    // JetBrains binary-compatibility-validator: an ABI gate on the consumer-facing public
+    // surface of the two Central-published JVM modules (the Gradle plugin + its DSL, and the
+    // FIR kotlinc-plugin jar). Applied at the included-build root; it wires an `apiCheck` task
+    // (run as part of `check`) that diffs the current public API against the committed `.api`
+    // dumps. Regenerate the baseline with `apiDump` when the public API changes intentionally.
+    alias(libs.plugins.binary.compatibility.validator)
 }
 
 allprojects {
     group = "com.monkopedia.kplusplus"
     version = "0.3.3"
+}
+
+// Scope the ABI gate to the PUBLISHED modules only. The compiler build's published set is the
+// Gradle plugin (`:kplusplus-compiler-gradle`) and the FIR jar (`:kplusplus-compiler-plugin`)
+// — see docs/releasing.md. Everything else is not published, so it has no consumer ABI:
+//   * the included-build root project (no code, no artifact);
+//   * `:kplusplus-compiler-plugin-native` — an internal K/N compiler variant that shares the
+//     plugin's sources but is never published as a coordinate.
+apiValidation {
+    ignoredProjects.addAll(
+        listOf(
+            rootProject.name,
+            "kplusplus-compiler-plugin-native"
+        )
+    )
 }
 
 // Aggregate publish for the two consumer-facing JVM artifacts that live in this

--- a/compiler/gradle/api/kplusplus-compiler-gradle.api
+++ b/compiler/gradle/api/kplusplus-compiler-gradle.api
@@ -1,0 +1,47 @@
+public final class com/monkopedia/kplusplus/compiler/gradle/FixupSpec {
+	public fun <init> ()V
+	public final fun addUniquePtrGet ()V
+	public final fun removeMethod (Ljava/lang/String;)V
+	public final fun scriptOriginOptionsFix ()V
+	public final fun stripConstFromReturnType (Ljava/lang/String;)V
+}
+
+public final class com/monkopedia/kplusplus/compiler/gradle/KPlusPlusCompilerGradlePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
+	public static final field DEFAULT_CPP_STANDARD Ljava/lang/String;
+	public static final field MIN_KOTLIN_VERSION Ljava/lang/String;
+	public static final field PLUGIN_GROUP Ljava/lang/String;
+	public static final field PLUGIN_ID Ljava/lang/String;
+	public static final field PLUGIN_NAME Ljava/lang/String;
+	public static final field PLUGIN_VERSION Ljava/lang/String;
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
+	public fun getCompilerPluginId ()Ljava/lang/String;
+	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public class com/monkopedia/kplusplus/compiler/gradle/KPlusPlusExtension {
+	public fun <init> ()V
+	public final fun fixup (Lorg/gradle/api/Action;)V
+	public final fun getCompiler ()Ljava/lang/String;
+	public final fun getCppStandard ()Ljava/lang/String;
+	public final fun getLlvmConfig ()Ljava/lang/String;
+	public final fun getNoRtti ()Z
+	public final fun getReferencePolicy ()Ljava/lang/String;
+	public final fun getRootPackage ()Ljava/lang/String;
+	public final fun header (Ljava/lang/String;)V
+	public final fun headerDirectory (Ljava/lang/String;)V
+	public final fun instantiate (Ljava/lang/String;)V
+	public final fun library (Ljava/lang/String;)V
+	public final fun only ([Ljava/lang/String;)V
+	public final fun onlyFile (Ljava/lang/String;)V
+	public final fun setCompiler (Ljava/lang/String;)V
+	public final fun setCppStandard (Ljava/lang/String;)V
+	public final fun setLlvmConfig (Ljava/lang/String;)V
+	public final fun setNoRtti (Z)V
+	public final fun setReferencePolicy (Ljava/lang/String;)V
+	public final fun setRootPackage (Ljava/lang/String;)V
+}
+

--- a/compiler/plugin/api/kplusplus-compiler-plugin.api
+++ b/compiler/plugin/api/kplusplus-compiler-plugin.api
@@ -1,0 +1,52 @@
+public final class com/monkopedia/kplusplus/compiler/CppVectorIrExtension : org/jetbrains/kotlin/backend/common/extensions/IrGenerationExtension {
+	public fun <init> ()V
+	public fun generate (Lorg/jetbrains/kotlin/ir/declarations/IrModuleFragment;Lorg/jetbrains/kotlin/backend/common/extensions/IrPluginContext;)V
+}
+
+public final class com/monkopedia/kplusplus/compiler/FirKPlusPlusRegistrar : org/jetbrains/kotlin/fir/extensions/FirExtensionRegistrar {
+	public fun <init> ()V
+}
+
+public final class com/monkopedia/kplusplus/compiler/KPlusPlusCommandLineProcessor : org/jetbrains/kotlin/compiler/plugin/CommandLineProcessor {
+	public static final field Companion Lcom/monkopedia/kplusplus/compiler/KPlusPlusCommandLineProcessor$Companion;
+	public static final field PLUGIN_ID Ljava/lang/String;
+	public fun <init> ()V
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getPluginOptions ()Ljava/util/Collection;
+	public fun processOption (Lorg/jetbrains/kotlin/compiler/plugin/AbstractCliOption;Ljava/lang/String;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+}
+
+public final class com/monkopedia/kplusplus/compiler/KPlusPlusCommandLineProcessor$Companion {
+	public final fun getREQUEST_MANIFEST_PATH_KEY ()Lorg/jetbrains/kotlin/config/CompilerConfigurationKey;
+	public final fun getREQUEST_MANIFEST_PATH_OPTION ()Lorg/jetbrains/kotlin/compiler/plugin/CliOption;
+	public final fun getROOT_PACKAGE_KEY ()Lorg/jetbrains/kotlin/config/CompilerConfigurationKey;
+	public final fun getROOT_PACKAGE_OPTION ()Lorg/jetbrains/kotlin/compiler/plugin/CliOption;
+}
+
+public final class com/monkopedia/kplusplus/compiler/KPlusPlusComponentRegistrar : org/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar {
+	public fun <init> ()V
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getSupportsK2 ()Z
+	public fun registerExtensions (Lorg/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar$ExtensionStorage;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+}
+
+public final class com/monkopedia/kplusplus/compiler/fir/CppVectorCallRefinement : org/jetbrains/kotlin/fir/extensions/FirFunctionCallRefinementExtension {
+	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;)V
+	public fun anchorElement (Lorg/jetbrains/kotlin/fir/symbols/impl/FirRegularClassSymbol;)Lorg/jetbrains/kotlin/KtSourceElement;
+	public fun intercept (Lorg/jetbrains/kotlin/fir/resolve/calls/candidate/CallInfo;Lorg/jetbrains/kotlin/fir/symbols/impl/FirNamedFunctionSymbol;)Lorg/jetbrains/kotlin/fir/extensions/FirFunctionCallRefinementExtension$CallReturnType;
+	public fun ownsSymbol (Lorg/jetbrains/kotlin/fir/symbols/impl/FirRegularClassSymbol;)Z
+	public fun restoreSymbol (Lorg/jetbrains/kotlin/fir/expressions/FirFunctionCall;Lorg/jetbrains/kotlin/name/Name;)Lorg/jetbrains/kotlin/fir/symbols/impl/FirRegularClassSymbol;
+	public fun transform (Lorg/jetbrains/kotlin/fir/expressions/FirFunctionCall;Lorg/jetbrains/kotlin/fir/symbols/impl/FirNamedFunctionSymbol;)Lorg/jetbrains/kotlin/fir/expressions/FirFunctionCall;
+}
+
+public final class com/monkopedia/kplusplus/compiler/fir/KPlusPlusDiagnostics : org/jetbrains/kotlin/diagnostics/KtDiagnosticsContainer {
+	public static final field INSTANCE Lcom/monkopedia/kplusplus/compiler/fir/KPlusPlusDiagnostics;
+	public fun getRendererFactory ()Lorg/jetbrains/kotlin/diagnostics/rendering/BaseDiagnosticRendererFactory;
+	public final fun getSYNC_REQUIRED ()Lorg/jetbrains/kotlin/diagnostics/KtDiagnosticFactory1;
+}
+
+public final class com/monkopedia/kplusplus/compiler/fir/KPlusPlusFirCheckersComponent : org/jetbrains/kotlin/fir/analysis/extensions/FirAdditionalCheckersExtension {
+	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;)V
+	public fun getExpressionCheckers ()Lorg/jetbrains/kotlin/fir/analysis/checkers/expression/ExpressionCheckers;
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ ktlint-cli = "1.8.0"
 klinker = "0.2.0"
 gradle-plugin-publish = "2.1.0"
 vannik = "0.37.0"
+binary-compatibility-validator = "0.18.0"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -31,3 +32,4 @@ ksrpc = { id = "com.monkopedia.ksrpc.plugin", version.ref = "ksrpc" }
 klinker = { id = "com.monkopedia.klinker.plugin", version.ref = "klinker" }
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }
 vannik-publish = { id = "com.vanniktech.maven.publish", version.ref = "vannik" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }


### PR DESCRIPTION
## What

Adds JetBrains **binary-compatibility-validator** (`org.jetbrains.kotlinx.binary-compatibility-validator` **0.18.0**, latest stable) as an ABI gate on the consumer-facing public surface of the Central-published plugin.

## Modules that got apiCheck

Applied at the `compiler` included-build root and scoped (via `apiValidation { ignoredProjects }`) to the **two Central-published JVM modules** (per `docs/releasing.md`):

- `:kplusplus-compiler-gradle` — the Gradle plugin jar + its `kplusplus { } / fixup { }` DSL (`KPlusPlusExtension`, `FixupSpec`, `KPlusPlusCompilerGradlePlugin`).
- `:kplusplus-compiler-plugin` — the FIR kotlinc-plugin jar.

Ignored (not published, no consumer ABI): the included-build root project and `:kplusplus-compiler-plugin-native` (an internal K/N compiler variant that shares the plugin's sources but is never published as a coordinate).

## Baseline (the ABI ledger)

Committed the initial `apiDump` output:
- `compiler/gradle/api/kplusplus-compiler-gradle.api`
- `compiler/plugin/api/kplusplus-compiler-plugin.api`

These are the real current public surface (not empty/stale). `build/api/*.api` stays gitignored.

## Wiring

`apiCheck` is a dependency of `check` on both published modules (the validator's default) and runs against the committed baseline.

## Verification

- `apiDump` then `apiCheck` = **clean/PASSES**; the task EXISTS and RUNS (not skipped).
- **Gate bites:** added a throwaway public `fun temporaryAbiGateProbe()` to `KPlusPlusExtension` → `apiCheck` **FAILED** with a precise diff (`+ public final fun temporaryAbiGateProbe ()Ljava/lang/String;`), then **reverted** — apiCheck green again. Proves it's a real gate, not a no-op.
- Compiler modules compile (`:kplusplus-compiler-gradle`, `:kplusplus-compiler-plugin`, `:kplusplus-compiler-plugin-native`) and the root build configures (`./gradlew projects`).

The diff is exactly: the catalog entry + the plugin application/scoping + the two committed `.api` files. No change to the plugin's actual logic.

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)