### PR TITLE
fix(build): bridge the in-tree krapper_parse build for featuregen/cppfixture so IDE sync works without -PenableClang

### DIFF
--- a/cppfixture/build.gradle.kts
+++ b/cppfixture/build.gradle.kts
@@ -56,3 +56,21 @@ kplusplus {
     // so this module is "cpp-ready" today (unlike v8/clang-slice consumers).
     header("include/point2d.h")
 }
+
+// TRANSITIONAL BRIDGE (remove once the consumed plugin is 0.3.4+): this module applies the
+// PUBLISHED kplusplus plugin pinned in settings.gradle.kts (currently 0.3.3), whose
+// kplusplusSync still gates the ":krapper_parse:linkReleaseExecutableKlinker" dependsOn on the
+// -PenableClang flag — a flag PR #173 REMOVED. So under the committed default
+// -Pkpp.frontend.cppfixture=cpp, without that flag the in-tree parser is never auto-built and
+// kplusplusSync fails ("krapper_parse binary was not found at …") — which breaks IntelliJ sync
+// (the IDE model-fetch doesn't pre-build the parser the way a manual :krapper_parse:link would).
+// The in-tree plugin (compiler/gradle/.../KPlusPlusCompilerGradlePlugin.kt) already wires this
+// unconditionally post-#173; this bridge restores that wiring against the CONSUMED 0.3.3 plugin.
+// tasks.matching{}.configureEach is used (not tasks.named) so it resolves cleanly even while the
+// IDE is modeling the task graph and regardless of plugin-apply ordering. Delete when 0.3.4
+// (with the require-LLVM plugin that always-wires) is the pinned version.
+if (providers.gradleProperty("kpp.frontend.cppfixture").orNull == "cpp") {
+    tasks.matching { it.name == "kplusplusSync" }.configureEach {
+        dependsOn(":krapper_parse:linkReleaseExecutableKlinker")
+    }
+}

--- a/featuregen/build.gradle.kts
+++ b/featuregen/build.gradle.kts
@@ -65,6 +65,25 @@ kplusplus {
 // kplusplusSync (krapper_parse parse -> ModelIo -> krapper_gen), auto-wiring
 // :krapper_parse:linkReleaseExecutableKlinker. What remains module-specific (below) is purely
 // the RUN link, not the generation:
+//
+// TRANSITIONAL BRIDGE (remove once the consumed plugin is 0.3.4+): this module applies the
+// PUBLISHED kplusplus plugin pinned in settings.gradle.kts (currently 0.3.3), whose
+// kplusplusSync still gates the ":krapper_parse:linkReleaseExecutableKlinker" dependsOn on the
+// -PenableClang flag — a flag PR #173 REMOVED. So under the committed default
+// -Pkpp.frontend.featuregen=cpp, without that flag the in-tree parser is never auto-built and
+// kplusplusSync fails ("krapper_parse binary was not found at …") — which breaks IntelliJ sync
+// (the IDE model-fetch doesn't pre-build the parser the way a manual :krapper_parse:link would).
+// The in-tree plugin (compiler/gradle/.../KPlusPlusCompilerGradlePlugin.kt) already wires this
+// unconditionally post-#173; this bridge restores that wiring against the CONSUMED 0.3.3 plugin.
+// tasks.matching{}.configureEach is used (not tasks.named) so it resolves cleanly even while the
+// IDE is modeling the task graph and regardless of plugin-apply ordering. Delete when 0.3.4
+// (with the require-LLVM plugin that always-wires) is the pinned version.
+if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
+    tasks.matching { it.name == "kplusplusSync" }.configureEach {
+        dependsOn(":krapper_parse:linkReleaseExecutableKlinker")
+    }
+}
+
 if (providers.gradleProperty("kpp.frontend.featuregen").orNull == "cpp") {
     // MAKE THE TESTS LINK + RUN. The cpp front-end parses featuregen's surface against the
     // SYSTEM libstdc++ (gcc-16 here), so the


### PR DESCRIPTION
## Problem
IntelliJ sync fails on `main`: `:featuregen:kplusplusSync` and `:cppfixture:kplusplusSync` abort with:

```
-Pkpp.frontend.<m>=cpp but the krapper_parse binary was not found at
krapper_parse/build/bin/klinker/krapper_parseRelease/krapper_parse … build with -PenableClang …
```

## Root cause
`:featuregen` and `:cppfixture` apply the **PUBLISHED** kplusplus plugin pinned at **0.3.3** in `settings.gradle.kts`. That consumed 0.3.3 plugin's `kplusplusSync` still gates the `:krapper_parse:linkReleaseExecutableKlinker` `dependsOn` on the `-PenableClang` flag — the flag **PR #173 removed**. Under the committed default `-Pkpp.frontend.<m>=cpp`, without that flag the in-tree parser is never auto-built, so the sync fails.

`:krapper_parse`'s own sync works because it uses the *bundled* published tool; but `:featuregen`/`:cppfixture` need the **in-tree** parser link output. #173's own verification manually linked `:krapper_parse` first, which **masked** this; the IDE model-fetch does not pre-build it, so IntelliJ sync breaks.

## Fix — transitional in-tree bridge
In `featuregen/build.gradle.kts` and `cppfixture/build.gradle.kts`, under the module's cpp frontend, add an explicit `dependsOn(":krapper_parse:linkReleaseExecutableKlinker")` to `kplusplusSync` — independent of the consumed plugin's `-PenableClang` gating. Uses `tasks.matching { … }.configureEach` (not `tasks.named`) so it resolves cleanly while the IDE is modeling the task graph and regardless of plugin-apply ordering.

The in-tree plugin already wires this unconditionally post-#173; this bridge restores that behavior against the CONSUMED 0.3.3 plugin. **Transitional — remove once 0.3.4 (the require-LLVM plugin that always-wires) is the pinned version.**

Does NOT re-introduce `-PenableClang`; does NOT touch the seed machinery or krapper_parse's bundled-tool self-host.

**Scope:** `clangwalk` is `=seed` (no parser) and `krapper_parse` self-hosts on the bundled tool, so neither needs the bridge.

## Verification (fresh: `rm -rf krapper_parse/build/bin`, NO `-PenableClang`, NO manual parser prebuild)
- **FAILS on `origin/main`:** `./gradlew :featuregen:kplusplusSync :cppfixture:kplusplusSync` → `krapper_parse binary was not found … build with -PenableClang` (BUILD FAILED).
- **PASSES on this branch:** same command → the bridge auto-builds `:krapper_parse:linkReleaseExecutableKlinker`; featuregen 126 files + cppfixture 2 files (BUILD SUCCESSFUL in 3m38s).
- **PASSES on this branch (closest IDE proxy):** `./gradlew :featuregen:prepareKotlinIdeaImport :cppfixture:prepareKotlinIdeaImport` → BUILD SUCCESSFUL in 2m47s.
- Byte-identical generated bindings vs `origin/main` (a `dependsOn` change cannot affect codegen).
- Gates green: `:krapper_gen:nativeTest`, `:featuregen:nativeTest -Pkpp.frontend.featuregen=cpp` (195/0), `:cppfixture:nativeTest -Pkpp.frontend.cppfixture=cpp` (2/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)